### PR TITLE
set updatereplace and deletionpolicies of Retain

### DIFF
--- a/cdk/lib/__snapshots__/wires-feeds.test.ts.snap
+++ b/cdk/lib/__snapshots__/wires-feeds.test.ts.snap
@@ -2110,7 +2110,7 @@ dpkg -i /wires-feeds/newswires.deb",
       "UpdateReplacePolicy": "Delete",
     },
     "fingerpostqueueF09A4E0A": {
-      "DeletionPolicy": "Delete",
+      "DeletionPolicy": "RetainExceptOnCreate",
       "Properties": {
         "MessageRetentionPeriod": 1209600,
         "RedrivePolicy": {
@@ -2147,7 +2147,7 @@ dpkg -i /wires-feeds/newswires.deb",
         "VisibilityTimeout": 300,
       },
       "Type": "AWS::SQS::Queue",
-      "UpdateReplacePolicy": "Delete",
+      "UpdateReplacePolicy": "Retain",
     },
     "fingerpostqueuePolicy8A8FE8AE": {
       "Properties": {
@@ -2222,6 +2222,7 @@ dpkg -i /wires-feeds/newswires.deb",
       "Type": "AWS::SNS::Subscription",
     },
     "fingerposttopic0A8134FC": {
+      "DeletionPolicy": "RetainExceptOnCreate",
       "Properties": {
         "Tags": [
           {
@@ -2247,6 +2248,7 @@ dpkg -i /wires-feeds/newswires.deb",
         ],
       },
       "Type": "AWS::SNS::Topic",
+      "UpdateReplacePolicy": "Retain",
     },
     "fingerposttopicPolicy93AB9BE9": {
       "Properties": {
@@ -2291,7 +2293,7 @@ dpkg -i /wires-feeds/newswires.deb",
       "Type": "AWS::SNS::TopicPolicy",
     },
     "sourcequeue87B8A558": {
-      "DeletionPolicy": "Delete",
+      "DeletionPolicy": "RetainExceptOnCreate",
       "Properties": {
         "MessageRetentionPeriod": 1209600,
         "RedrivePolicy": {
@@ -2328,7 +2330,7 @@ dpkg -i /wires-feeds/newswires.deb",
         "VisibilityTimeout": 300,
       },
       "Type": "AWS::SQS::Queue",
-      "UpdateReplacePolicy": "Delete",
+      "UpdateReplacePolicy": "Retain",
     },
     "sourcequeueDeadLetterQueueTEST4E4374EA": {
       "DeletionPolicy": "Delete",
@@ -2433,6 +2435,7 @@ dpkg -i /wires-feeds/newswires.deb",
       "Type": "AWS::SNS::Subscription",
     },
     "sourcetopic7C3DC892": {
+      "DeletionPolicy": "RetainExceptOnCreate",
       "Properties": {
         "Tags": [
           {
@@ -2458,6 +2461,7 @@ dpkg -i /wires-feeds/newswires.deb",
         ],
       },
       "Type": "AWS::SNS::Topic",
+      "UpdateReplacePolicy": "Retain",
     },
     "sourcetopicPolicy693F1C42": {
       "Properties": {

--- a/cdk/lib/wires-feeds.ts
+++ b/cdk/lib/wires-feeds.ts
@@ -8,7 +8,7 @@ import {
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 import type { App } from 'aws-cdk-lib';
-import { Duration } from 'aws-cdk-lib';
+import { Duration, RemovalPolicy } from 'aws-cdk-lib';
 import { InstanceClass, InstanceSize, InstanceType } from 'aws-cdk-lib/aws-ec2';
 import { ArnPrincipal, User } from 'aws-cdk-lib/aws-iam';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
@@ -61,6 +61,7 @@ export class WiresFeeds extends GuStack {
 			const topic = new Topic(scope, `${topicType}-topic`, {
 				enforceSSL: true,
 			});
+			topic.applyRemovalPolicy(RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE);
 			topic.grantPublish(new ArnPrincipal(user.userArn));
 
 			const queueName = `${topicType}-queue`;
@@ -83,6 +84,7 @@ export class WiresFeeds extends GuStack {
 					queue: deadLetterQueue,
 					maxReceiveCount: 3,
 				},
+				removalPolicy: RemovalPolicy.RETAIN_ON_UPDATE_OR_DELETE,
 			});
 
 			topic.addSubscription(


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Sets UpdateReplacePolicy and DeletionPolicy on the topics and queues, to make sure they're not deleted by a cloudformation mistake