### PR TITLE
Add start script and local db config

### DIFF
--- a/newswires/app/AppComponents.scala
+++ b/newswires/app/AppComponents.scala
@@ -46,8 +46,11 @@ class AppComponents(context: Context)
     .build()
 
   if (context.environment.mode == Mode.Dev) {
-    // TODO run against a local DB?
-    Database.configureRemoteDevDb(ssmClient)
+    if (sys.env.contains("USE_CODE_DB")) {
+      Database.configureRemoteDevDb(ssmClient)
+    } else {
+      Database.configureLocalDevDB()
+    }
   } else if (context.environment.mode == Mode.Prod) {
     Database.configureDeployedDb(configuration)
   }

--- a/newswires/app/conf/Database.scala
+++ b/newswires/app/conf/Database.scala
@@ -110,4 +110,25 @@ object Database extends Logging {
 
     ConnectionPool.singleton(new DataSourceConnectionPool(ds))
   }
+
+  def configureLocalDevDB(): Unit = {
+    logger.info("building DB config for connecting to CODE DB from local")
+
+    val username = "postgres"
+    val port = "5432"
+    val address = "localhost"
+    val databaseName = "newswires"
+
+    val ds = new AwsWrapperDataSource()
+    ds.setJdbcProtocol("jdbc:postgresql:")
+    ds.setServerName(address)
+    ds.setDatabase(databaseName)
+    ds.setServerPort(port)
+    ds.setTargetDataSourceClassName("org.postgresql.ds.PGSimpleDataSource")
+    ds.setPassword("postgres")
+    ds.setUser(username)
+
+    ConnectionPool.singleton(new DataSourceConnectionPool(ds))
+  }
+
 }

--- a/newswires/app/conf/Database.scala
+++ b/newswires/app/conf/Database.scala
@@ -112,7 +112,7 @@ object Database extends Logging {
   }
 
   def configureLocalDevDB(): Unit = {
-    logger.info("building DB config for connecting to CODE DB from local")
+    logger.info("building DB config for connecting to local DB")
 
     val username = "postgres"
     val port = "5432"

--- a/scripts/start
+++ b/scripts/start
@@ -18,7 +18,6 @@ ROOT_DIR=${DIR}/..
 # copied over from the Grid. Not 100% sure of the rationale, but perhaps: https://stackoverflow.com/questions/56520354/getting-an-amazonkinesisexception-status-code-502-when-using-localstack-from-ja
 export AWS_CBOR_DISABLE=true
 
-LOCAL_AUTH=false
 for arg in "$@"; do
   if [ "$arg" == "--debug" ]; then
     IS_DEBUG=true
@@ -35,10 +34,6 @@ isInstalled() {
 }
 
 hasCredentials() {
-  if [[ $LOCAL_AUTH == true ]]; then
-    return
-  fi
-
   STATUS=$(aws sts get-caller-identity --profile ${AWS_PROFILE} 2>&1 || true)
   if [[ ${STATUS} =~ (ExpiredToken) ]]; then
     echo -e "${red}Credentials for the ${AWS_PROFILE} profile are expired. Please fetch new credentials and run this again.${plain}"
@@ -79,8 +74,6 @@ tunnelToAwsDb() {
     if [[ -n $EXISTING_TUNNELS ]]; then
       echo "RE-USING EXISTING TUNNEL TO CODE POSTGRES (on port ${POSTGRES_PORT})"
     else
-      # todo: Grid script uses the following options, do we need any of these?
-      #  TUNNEL_OPTS="-o ExitOnForwardFailure=yes -o ServerAliveInterval=10 -o ServerAliveCountMax=2"
       ssm ssh -t ${APP_NAME},CODE -p ${AWS_PROFILE} -x --newest --rds-tunnel 5432:${APP_NAME},CODE
       echo "TUNNEL ESTABLISHED TO CODE POSTGRES (on port ${POSTGRES_PORT})"
     fi

--- a/scripts/start
+++ b/scripts/start
@@ -145,7 +145,7 @@ main() {
     hasCredentials
     checkRequirements
     checkNodeVersion
-    if [ $USE_CODE == true ]; then
+    if [ "$USE_CODE" == "true" ]; then
         echo "Using CODE. Starting play app with tunnel to AWS DB."
         tunnelToAwsDb && USE_CODE_DB=true startPlayApp
     else

--- a/scripts/start
+++ b/scripts/start
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+
+set -e
+
+green='\x1B[0;32m'
+red='\x1B[0;31m'
+plain='\x1B[0m' # No Color
+
+AWS_PROFILE='editorial-feeds'
+POSTGRES_PORT='5432'
+APP_NAME='newswires'
+EXISTING_TUNNELS=$(ps -ef | grep ssh | grep ${POSTGRES_PORT} | grep -v grep || true)
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ROOT_DIR=${DIR}/..
+
+
+# copied over from the Grid. Not 100% sure of the rationale, but perhaps: https://stackoverflow.com/questions/56520354/getting-an-amazonkinesisexception-status-code-502-when-using-localstack-from-ja
+export AWS_CBOR_DISABLE=true
+
+LOCAL_AUTH=false
+for arg in "$@"; do
+  if [ "$arg" == "--debug" ]; then
+    IS_DEBUG=true
+    shift
+  fi
+  if [ "$arg" == "--use-CODE" ]; then
+    USE_CODE=true
+    shift
+  fi
+done
+
+isInstalled() {
+  hash "$1" 2>/dev/null
+}
+
+hasCredentials() {
+  if [[ $LOCAL_AUTH == true ]]; then
+    return
+  fi
+
+  STATUS=$(aws sts get-caller-identity --profile ${AWS_PROFILE} 2>&1 || true)
+  if [[ ${STATUS} =~ (ExpiredToken) ]]; then
+    echo -e "${red}Credentials for the ${AWS_PROFILE} profile are expired. Please fetch new credentials and run this again.${plain}"
+    exit 1
+  elif [[ ${STATUS} =~ ("could not be found") ]]; then
+    echo -e "${red}Credentials for the ${AWS_PROFILE} profile are missing. Please ensure you have the right credentials.${plain}"
+    exit 1
+  fi
+}
+
+checkRequirement() {
+  if ! isInstalled "$1"; then
+    echo -e "${red}[MISSING DEPENDENCY] $1 not found. Please install $1${plain}"
+    exit 1
+  fi
+}
+
+checkRequirements() {
+  # server side
+  checkRequirement java
+  checkRequirement sbt
+
+  # client side
+  checkRequirement npm
+
+  # used for postgres and AWS localstack
+  checkRequirement docker
+
+  # other
+  checkRequirement nginx
+  checkRequirement aws
+}
+
+tunnelToAwsDb() {
+    if (docker stats --no-stream &> /dev/null); then
+      docker compose down
+    fi
+    if [[ -n $EXISTING_TUNNELS ]]; then
+      echo "RE-USING EXISTING TUNNEL TO CODE POSTGRES (on port ${POSTGRES_PORT})"
+    else
+      # todo: Grid script uses the following options, do we need any of these?
+      #  TUNNEL_OPTS="-o ExitOnForwardFailure=yes -o ServerAliveInterval=10 -o ServerAliveCountMax=2"
+      ssm ssh -t ${APP_NAME},CODE -p ${AWS_PROFILE} -x --newest --rds-tunnel 5432:${APP_NAME},CODE
+      echo "TUNNEL ESTABLISHED TO CODE POSTGRES (on port ${POSTGRES_PORT})"
+    fi
+}
+
+startDockerContainers() {
+  if [[ $EXISTING_TUNNELS ]]; then
+    echo "KILLING EXISTING TUNNEL TO CODE POSTGRES (on port ${POSTGRES_PORT})"
+    # shellcheck disable=SC2046
+    kill $(echo "${EXISTING_TUNNELS}" | awk '{print $2}')
+  fi
+  docker compose up -d
+}
+
+startIngestionLambda() {
+  pushd "$ROOT_DIR/ingestion-lambda"
+  npm install
+  npm run dev
+  popd
+}
+
+startPlayApp() {
+  # pushd to find build.sbt and allow this script to be executed from any location (but ideally from the project root)
+  echo "========================================================="
+  echo "= Press cmd-C then cmd-D to stop"
+  echo "========================================================="
+  pushd "$ROOT_DIR/${APP_NAME}"
+  if [ "$IS_DEBUG" == true ] ; then
+    SBT_OPTS="-jvm-debug 5005"
+  fi
+  if [[ $USE_CODE == true ]]; then
+    sbt "${SBT_OPTS} run"
+  else
+    sbt "${SBT_OPTS} run"
+  fi
+  popd
+}
+
+checkNodeVersion() {
+  runningNodeVersion=$(node -v)
+  requiredNodeVersion=$(cat "$ROOT_DIR/.nvmrc")
+
+  if [ "$runningNodeVersion" != "$requiredNodeVersion" ]; then
+    echo -e "${red}Using wrong version of Node. Required ${requiredNodeVersion}. Running ${runningNodeVersion}.${plain}"
+    exit 1
+  fi
+}
+
+checkForJavaHome() {
+  echo "Checking JAVA_HOME"
+  if [[ -z "$JAVA_HOME" ]]; then
+    echo "  JAVA_HOME not set, please set it before continuing"
+    echo "  This can be done by adding \"export JAVA_HOME=\$(/usr/libexec/java_home)\" to ~/.profile"
+    exit 1
+  else
+    echo "  JAVA_HOME is set to $JAVA_HOME"
+  fi
+}
+
+main() {
+    checkForJavaHome
+    hasCredentials
+    checkRequirements
+    checkNodeVersion
+    if [ $USE_CODE == true ]; then
+        echo "Using CODE. Starting play app with tunnel to AWS DB."
+        tunnelToAwsDb && USE_CODE_DB=true startPlayApp
+    else
+      echo "Using the local stack. Starting Docker, Ingestion Lambda and Play App."
+      # run all three, and terminate together when the user presses `ctrl+c`: https://stackoverflow.com/a/52033580
+      (trap 'kill 0' SIGINT; startDockerContainers && startIngestionLambda & startPlayApp & wait)
+    fi
+
+}
+
+main


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Add a config function for connecting to the local postgres db
- Add a start script (modelled after [the Grid's `start.sh`](https://github.com/guardian/grid/blob/main/dev/script/start.sh) which:
  - Checks for necessary dependencies
  - By default will spin up the Docker containers, run the `ingestion-lambda` in 'dev' mode, and start the Play app.
  - If passed the `--use-CODE` flag, it will establish a tunnel to the CODE db, if there isn't one already, and start the Play app.


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
