### PR TITLE
Pin postgres version in local and RDS

### DIFF
--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -1288,6 +1288,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
         "DeletionProtection": true,
         "EnableIAMDatabaseAuthentication": true,
         "Engine": "postgres",
+        "EngineVersion": "16.4",
         "MasterUserPassword": {
           "Fn::Join": [
             "",

--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -1,6 +1,12 @@
-import { GuStackProps } from '@guardian/cdk/lib/constructs/core';
-import { GuCname } from '@guardian/cdk/lib/constructs/dns';
+import type { Alarms } from '@guardian/cdk';
+import { GuPlayApp } from '@guardian/cdk';
+import { AccessScope } from '@guardian/cdk/lib/constants';
+import type { NoMonitoring } from '@guardian/cdk/lib/constructs/cloudwatch';
 import { GuParameter, GuStack } from '@guardian/cdk/lib/constructs/core';
+import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuCname } from '@guardian/cdk/lib/constructs/dns';
+import { GuVpc, SubnetType } from '@guardian/cdk/lib/constructs/ec2';
+import { GuGetS3ObjectsPolicy } from '@guardian/cdk/lib/constructs/iam';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 import type { App } from 'aws-cdk-lib';
@@ -13,14 +19,13 @@ import {
 } from 'aws-cdk-lib/aws-ec2';
 import { Runtime } from 'aws-cdk-lib/aws-lambda';
 import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
+import {
+	DatabaseInstanceEngine,
+	PostgresEngineVersion,
+} from 'aws-cdk-lib/aws-rds';
 import { Topic } from 'aws-cdk-lib/aws-sns';
-import { Queue } from 'aws-cdk-lib/aws-sqs';
+import type { Queue } from 'aws-cdk-lib/aws-sqs';
 import { GuDatabase } from './constructs/database';
-import { Alarms, GuPlayApp } from '@guardian/cdk';
-import { NoMonitoring } from '@guardian/cdk/lib/constructs/cloudwatch';
-import { AccessScope } from '@guardian/cdk/lib/constants';
-import { GuGetS3ObjectsPolicy } from '@guardian/cdk/lib/constructs/iam';
-import { GuVpc, SubnetType } from '@guardian/cdk/lib/constructs/ec2';
 
 export type NewswiresProps = GuStackProps & {
 	fingerpostQueue: Queue;
@@ -57,6 +62,9 @@ export class Newswires extends GuStack {
 			vpcSubnets: {
 				subnets: privateSubnets,
 			},
+			engine: DatabaseInstanceEngine.postgres({
+				version: PostgresEngineVersion.of('16.4', '16'),
+			}),
 		});
 
 		const feedsBucket = new GuS3Bucket(this, `feeds-bucket-${this.stage}`, {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - '/tmp/localstack:/var/lib/localstack'
       - ./localstack:/etc/localstack/init/ready.d
   db:
-    image: postgres:14
+    image: postgres:16.4
     container_name: newswires-db
     ports:
       - 5432:5432


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
