### PR TITLE
Add routing and split out home from feed

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -9,28 +9,8 @@ import {
 } from '@elastic/eui';
 import { useEffect, useMemo, useState } from 'react';
 import '@elastic/eui/dist/eui_theme_light.css';
+import type { WireData } from './sharedTypes';
 import { WireCardList } from './WiresCards';
-
-export type WireData = {
-	id: number;
-	externalId: string;
-	ingestedAt: string;
-	content: Partial<{
-		uri: string;
-		usn: string;
-		version: string;
-		firstVersion: string; // date
-		versionCreated: string; // date
-		dateTimeSent: string; //date
-		headline: string;
-		subhead: string;
-		byline: string;
-		keywords: string;
-		usage: string;
-		location: string;
-		body_text: string;
-	}>;
-};
 
 type PageStage = { loading: true } | { error: string } | WireData[];
 

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -14,10 +14,12 @@ import { querify } from './querify';
 import type { WireData } from './sharedTypes';
 import { WireCardList } from './WiresCards';
 
-type PageStage = { loading: true } | { error: string } | WireData[];
+type SearchState = { loading: true } | { error: string } | WireData[];
 
 export function App() {
-	const [pageState, setPageState] = useState<PageStage>({ loading: true });
+	const [searchState, setSearchState] = useState<SearchState>({
+		loading: true,
+	});
 
 	const [query, setQuery] = useState<string>('');
 
@@ -27,9 +29,9 @@ export function App() {
 		const quer = querify(query);
 		fetch('/api/search' + quer)
 			.then((res) => res.json())
-			.then((j) => setPageState(j as WireData[]))
+			.then((j) => setSearchState(j as WireData[]))
 			.catch((e) =>
-				setPageState({
+				setSearchState({
 					error:
 						e instanceof Error
 							? e.message
@@ -54,18 +56,18 @@ export function App() {
 					</EuiHeaderSectionItem>
 				</EuiHeader>
 				<EuiPageTemplate.Section>
-					{'error' in pageState && (
+					{'error' in searchState && (
 						<EuiPageTemplate.EmptyPrompt>
-							<p>Sorry, failed to load because of {pageState.error}</p>
+							<p>Sorry, failed to load because of {searchState.error}</p>
 						</EuiPageTemplate.EmptyPrompt>
 					)}
-					{'loading' in pageState && (
+					{'loading' in searchState && (
 						<EuiPageTemplate.EmptyPrompt
 							icon={<EuiLoadingLogo logo="clock" size="xl" />}
 							title={<h2>Loading Wires</h2>}
 						/>
 					)}
-					{Array.isArray(pageState) && <WireCardList wires={pageState} />}
+					{Array.isArray(searchState) && <WireCardList wires={searchState} />}
 				</EuiPageTemplate.Section>
 			</EuiPageTemplate>
 		</EuiProvider>

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -9,32 +9,12 @@ import {
 } from '@elastic/eui';
 import { useEffect, useMemo, useState } from 'react';
 import '@elastic/eui/dist/eui_theme_light.css';
+import { debounce } from './debounce';
+import { querify } from './querify';
 import type { WireData } from './sharedTypes';
 import { WireCardList } from './WiresCards';
 
 type PageStage = { loading: true } | { error: string } | WireData[];
-
-const querify = (query: string): string => {
-	if (query.trim().length <= 0) return '';
-	const params = new URLSearchParams();
-	params.set('q', query.trim());
-	return '?' + params.toString();
-};
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- suitably generic function
-const debounce = <F extends (...args: any[]) => void>(
-	f: F,
-	delay: number,
-): ((...args: Parameters<F>) => void) => {
-	let waiting: ReturnType<typeof setTimeout> | undefined;
-
-	return (...args: Parameters<F>) => {
-		if (waiting !== undefined) {
-			clearTimeout(waiting);
-		}
-		waiting = setTimeout(() => f(...args), delay);
-	};
-};
 
 export function App() {
 	const [pageState, setPageState] = useState<PageStage>({ loading: true });

--- a/newswires/client/src/Feed.tsx
+++ b/newswires/client/src/Feed.tsx
@@ -1,0 +1,47 @@
+import { EuiLoadingLogo, EuiPageTemplate } from '@elastic/eui';
+import { useEffect, useState } from 'react';
+import { querify } from './querify';
+import type { WireData } from './sharedTypes';
+import { WireCardList } from './WiresCards';
+
+type SearchState = { loading: true } | { error: string } | WireData[];
+
+export const Feed = ({ searchQuery }: { searchQuery: string }) => {
+	const [searchState, setSearchState] = useState<SearchState>({
+		loading: true,
+	});
+
+	useEffect(() => {
+		const quer = querify(searchQuery);
+		fetch('/api/search' + quer)
+			.then((res) => res.json())
+			.then((j) => setSearchState(j as WireData[]))
+			.catch((e) =>
+				setSearchState({
+					error:
+						e instanceof Error
+							? e.message
+							: typeof e === 'string'
+								? e
+								: 'unknown error',
+				}),
+			);
+	}, [searchQuery]);
+
+	return (
+		<EuiPageTemplate.Section>
+			{'error' in searchState && (
+				<EuiPageTemplate.EmptyPrompt>
+					<p>Sorry, failed to load because of {searchState.error}</p>
+				</EuiPageTemplate.EmptyPrompt>
+			)}
+			{'loading' in searchState && (
+				<EuiPageTemplate.EmptyPrompt
+					icon={<EuiLoadingLogo logo="clock" size="xl" />}
+					title={<h2>Loading Wires</h2>}
+				/>
+			)}
+			{Array.isArray(searchState) && <WireCardList wires={searchState} />}
+		</EuiPageTemplate.Section>
+	);
+};

--- a/newswires/client/src/SearchBox.tsx
+++ b/newswires/client/src/SearchBox.tsx
@@ -1,6 +1,7 @@
 import type { QueryType } from '@elastic/eui';
 import { EuiCallOut, EuiSearchBar } from '@elastic/eui';
-import { Fragment, useState } from 'react';
+import { Fragment, useMemo, useState } from 'react';
+import { debounce } from './debounce';
 
 export function SearchBox({
 	initialQuery,
@@ -14,6 +15,8 @@ export function SearchBox({
 	const [query, setQuery] = useState<QueryType>(initialQuery);
 	const [error, setError] = useState<null | Error>(null);
 
+	const debouncedUpdate = useMemo(() => debounce(update, 750), [update]);
+
 	return (
 		<Fragment>
 			<EuiSearchBar
@@ -24,7 +27,11 @@ export function SearchBox({
 					} else {
 						setError(null);
 						setQuery(query);
-						update(query.text);
+						if (incremental) {
+							debouncedUpdate(query.text);
+						} else {
+							update(query.text);
+						}
 					}
 				}}
 				box={{ incremental }}

--- a/newswires/client/src/SearchBox.tsx
+++ b/newswires/client/src/SearchBox.tsx
@@ -1,0 +1,42 @@
+import type { QueryType } from '@elastic/eui';
+import { EuiCallOut, EuiSearchBar } from '@elastic/eui';
+import { Fragment, useState } from 'react';
+
+export function SearchBox({
+	initialQuery,
+	update,
+	incremental = false,
+}: {
+	initialQuery: string;
+	update: (newQuery: string) => void;
+	incremental?: boolean;
+}) {
+	const [query, setQuery] = useState<QueryType>(initialQuery);
+	const [error, setError] = useState<null | Error>(null);
+
+	return (
+		<Fragment>
+			<EuiSearchBar
+				query={query}
+				onChange={({ query, error }) => {
+					if (error) {
+						setError(error);
+					} else {
+						setError(null);
+						setQuery(query);
+						update(query.text);
+					}
+				}}
+				box={{ incremental }}
+				aria-label="search wires"
+			/>
+			{error && (
+				<EuiCallOut
+					iconType="faceSad"
+					color="danger"
+					title={`Invalid search: ${error.message}`}
+				/>
+			)}
+		</Fragment>
+	);
+}

--- a/newswires/client/src/WiresCards.tsx
+++ b/newswires/client/src/WiresCards.tsx
@@ -17,7 +17,7 @@ import {
 import { css } from '@emotion/react';
 import { useMemo, useState } from 'react';
 import sanitizeHtml from 'sanitize-html';
-import type { WireData } from './App';
+import type { WireData } from './sharedTypes';
 
 export const WireCardList = ({ wires }: { wires: WireData[] }) => {
 	const [isFlyoutVisible, setIsFlyoutVisible] = useState(false);

--- a/newswires/client/src/debounce.ts
+++ b/newswires/client/src/debounce.ts
@@ -1,0 +1,14 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- suitably generic function
+export const debounce = <F extends (...args: any[]) => void>(
+	f: F,
+	delay: number,
+): ((...args: Parameters<F>) => void) => {
+	let waiting: ReturnType<typeof setTimeout> | undefined;
+
+	return (...args: Parameters<F>) => {
+		if (waiting !== undefined) {
+			clearTimeout(waiting);
+		}
+		waiting = setTimeout(() => f(...args), delay);
+	};
+};

--- a/newswires/client/src/main.tsx
+++ b/newswires/client/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App.tsx';
 import './icons';
+import { HistoryContextProvider } from './urlState.tsx';
 
 createRoot(document.getElementById('root')!).render(
 	<StrictMode>
-		<App />
+		<HistoryContextProvider>
+			<App />
+		</HistoryContextProvider>
 	</StrictMode>,
 );

--- a/newswires/client/src/querify.ts
+++ b/newswires/client/src/querify.ts
@@ -1,0 +1,6 @@
+export const querify = (query: string): string => {
+	if (query.trim().length <= 0) return '';
+	const params = new URLSearchParams();
+	params.set('q', query.trim());
+	return '?' + params.toString();
+};

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -1,0 +1,20 @@
+export type WireData = {
+	id: number;
+	externalId: string;
+	ingestedAt: string;
+	content: Partial<{
+		uri: string;
+		usn: string;
+		version: string;
+		firstVersion: string; // date
+		versionCreated: string; // date
+		dateTimeSent: string; //date
+		headline: string;
+		subhead: string;
+		byline: string;
+		keywords: string;
+		usage: string;
+		location: string;
+		body_text: string;
+	}>;
+};

--- a/newswires/client/src/urlState.tsx
+++ b/newswires/client/src/urlState.tsx
@@ -1,0 +1,163 @@
+import type { Context, MouseEventHandler, PropsWithChildren } from 'react';
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useEffect,
+	useState,
+} from 'react';
+
+export const paths = ['', 'feed'] as const;
+export type HistoryState = Readonly<{
+	location: (typeof paths)[number];
+	params?: Partial<Record<string, string>>;
+}>;
+
+const defaultState = Object.freeze({
+	location: '' as const,
+	params: {},
+});
+
+const isHistoryState = (s: unknown): s is HistoryState => {
+	if (typeof s !== 'object') return false;
+	if (s === null) return false;
+
+	if (!('location' in s) || typeof s.location !== 'string') return false;
+	const location = s.location as (typeof paths)[number];
+	if (!paths.includes(location)) return false;
+
+	if ('params' in s) {
+		if (typeof s.params !== 'object' || s.params === null) return false;
+		for (const [k, v] of Object.entries(s.params)) {
+			if (typeof k !== 'string' || typeof v !== 'string') return false;
+		}
+	}
+
+	return true;
+};
+
+const readUrl = (locationString?: string): HistoryState => {
+	const location = locationString
+		? new URL(locationString, window.location.href)
+		: window.location;
+	const page = location.pathname.slice(1);
+	if (page === 'feed') {
+		const urlSearchParams = new URLSearchParams(location.search);
+		const queryString = urlSearchParams.get('q');
+		const params: Record<string, string> = {};
+		if (typeof queryString === 'string') {
+			params['q'] = queryString;
+		}
+		return { location: page, params };
+	} else {
+		return defaultState;
+	}
+};
+
+const paramsToQuerystring = (p: HistoryState['params']): string => {
+	const params = Object.fromEntries(
+		Object.entries(p ?? {}).reduce<Array<[string, string]>>((acc, [k, v]) => {
+			if (typeof v === 'string') {
+				return [...acc, [k, v]];
+			} else {
+				return acc;
+			}
+		}, []),
+	);
+	const querystring = new URLSearchParams(params).toString();
+	return querystring;
+};
+
+const location = (state: HistoryState): string => {
+	const querystring = paramsToQuerystring(state.params);
+	return `/${state.location}${
+		querystring.length !== 0 ? '?' : ''
+	}${querystring}`;
+};
+
+type HistoryContextShape = {
+	currentState: HistoryState;
+	pushState: (state: HistoryState) => void;
+	replaceState: (state: HistoryState) => void;
+};
+const HistoryContext: Context<HistoryContextShape | null> =
+	createContext<HistoryContextShape | null>(null);
+
+export const HistoryContextProvider = ({ children }: PropsWithChildren) => {
+	const [currentState, setState] = useState<HistoryState>(readUrl());
+
+	const pushState = useCallback(
+		(state: HistoryState) => {
+			history.pushState(state, '', location(state));
+			setState(state);
+		},
+		[setState],
+	);
+
+	const replaceState = useCallback(
+		(state: HistoryState) => {
+			history.replaceState(state, '', location(state));
+			setState(state);
+		},
+		[setState],
+	);
+
+	const popStateCallback = useCallback(
+		(e: PopStateEvent) => {
+			if (isHistoryState(e.state)) {
+				setState(e.state);
+			} else {
+				setState(defaultState);
+			}
+		},
+		[setState],
+	);
+
+	useEffect(() => {
+		if (window.history.state === null) {
+			window.history.replaceState(currentState, '', location(currentState));
+		}
+	}, [currentState]);
+
+	useEffect(() => {
+		window.addEventListener('popstate', popStateCallback);
+		return () => window.removeEventListener('popstate', popStateCallback);
+	}, [popStateCallback]);
+
+	return (
+		<HistoryContext.Provider value={{ currentState, pushState, replaceState }}>
+			{children}
+		</HistoryContext.Provider>
+	);
+};
+
+export const useHistory = () => {
+	const historyContext = useContext(HistoryContext);
+	if (historyContext === null) {
+		throw new Error('useHistory must be used within a HistoryContextProvider');
+	}
+	return historyContext;
+};
+
+export const Link = ({
+	children,
+	href,
+}: PropsWithChildren<{ href: string }>) => {
+	const { pushState } = useHistory();
+
+	const onClick: MouseEventHandler<HTMLAnchorElement> = useCallback(
+		(e) => {
+			if (!(e.getModifierState('Meta') || e.getModifierState('Control'))) {
+				e.preventDefault();
+				pushState(readUrl(href));
+			}
+		},
+		[href, pushState],
+	);
+
+	return (
+		<a href={href} onClick={onClick}>
+			{children}
+		</a>
+	);
+};

--- a/newswires/conf/routes
+++ b/newswires/conf/routes
@@ -5,6 +5,7 @@
 
 # An example controller showing a sample home page
 GET     /                           controllers.ViteController.index()
+GET     /feed                           controllers.ViteController.index()
 GET     /api/                       controllers.HomeController.index()
 GET     /api/search                 controllers.QueryController.query(q: Option[String])
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?


### Preliminary Refactors

- [Extract WireData to sharedTypes file](https://github.com/guardian/newswires/pull/17/commits/b32800dfe159adda28e9f2085c9380eb11b31457)
- [Extract util functions](https://github.com/guardian/newswires/pull/17/commits/a5ac142b5e4a1b83269c446f3904cc0998f81686)
- [Rename PageStage/State to SearchState](https://github.com/guardian/newswires/pull/17/commits/cbcac43a8652ea1f7acbe348b2ffb38a8521fd16)


### Main feature

- [Add routing for home & feed pages](https://github.com/guardian/newswires/pull/17/commits/6190bc235818042c97fcfcc9d7a0df6ccb9b1717)
  - Copies over the pattern from `state.tsx` [in the crosswordv2 app](https://github.com/guardian/crosswordv2/pull/293).
- [Add debouncing back in for incremental search](https://github.com/guardian/newswires/pull/17/commits/d506a8ca91c8515cccfdef6ae74e4c1e8db71eb4)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] visiting `/` shows the new landing page
- [x] visiting `/feed` shows all wire results
- [x] visiting `/feed?q=ipsum` loads filtered wire results
- [x] searching from landing page (press enter to search) navigates to `/feed?q=[your search terms]`
- [x] search from the Feed page nav bar is debounced, and search terms are written to the URL search params

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

### Landing page

<img width="1307" alt="image" src="https://github.com/user-attachments/assets/a97a2ada-9b20-4a98-87e4-afbc3070f95b">

### Search terms are bound to the URL

<img width="1313" alt="image" src="https://github.com/user-attachments/assets/b0c8db17-f74f-4814-93cc-0769ae38f879">


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
