### PR TITLE
Add 'no results' component to feed

### DIFF
--- a/newswires/client/src/Feed.tsx
+++ b/newswires/client/src/Feed.tsx
@@ -1,4 +1,4 @@
-import { EuiLoadingLogo, EuiPageTemplate } from '@elastic/eui';
+import { EuiEmptyPrompt, EuiLoadingLogo, EuiPageTemplate } from '@elastic/eui';
 import { useEffect, useState } from 'react';
 import { querify } from './querify';
 import type { WireData } from './sharedTypes';
@@ -41,7 +41,18 @@ export const Feed = ({ searchQuery }: { searchQuery: string }) => {
 					title={<h2>Loading Wires</h2>}
 				/>
 			)}
-			{Array.isArray(searchState) && <WireCardList wires={searchState} />}
+			{Array.isArray(searchState) && searchState.length === 0 && (
+				<EuiEmptyPrompt
+					body={<p>Try a different search term</p>}
+					color="subdued"
+					layout="horizontal"
+					title={<h2>No results match your search criteria</h2>}
+					titleSize="s"
+				/>
+			)}
+			{Array.isArray(searchState) && searchState.length > 0 && (
+				<WireCardList wires={searchState} />
+			)}
 		</EuiPageTemplate.Section>
 	);
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Render an 'empty prompt' letting the user know that there are no results matching their query, if the API returns and empty array. (And don't render the wires card list unless there _are_ some results.)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="1311" alt="image" src="https://github.com/user-attachments/assets/fd9cf456-6512-43a9-ac7f-80de520aa395">


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
