### PR TITLE
start codifying db schema with migrations

### DIFF
--- a/db/.gitignore
+++ b/db/.gitignore
@@ -1,0 +1,1 @@
+.scala-build

--- a/db/.scalafmt.conf
+++ b/db/.scalafmt.conf
@@ -1,0 +1,2 @@
+version = "3.7.15"
+runner.dialect = scala3

--- a/db/README.md
+++ b/db/README.md
@@ -2,10 +2,20 @@
 
 This directory contains database configuration, including and especially the database migrations.
 
-Run the migrations with [flyway](https://documentation.red-gate.com/flyway/flyway-cli-and-api/welcome-to-flyway), which can be installed with Homebrew.
+Run the migrations with a scala-cli script, `flyway.sc`, which wraps the [flyway](https://documentation.red-gate.com/flyway/flyway-cli-and-api/welcome-to-flyway)
+API. Install scala-cli with Homebrew:
 
-This directory includes config for connecting to the local database, and is run as part of the start script.
+```sh
+brew install Virtuslab/scala-cli/scala-cli
+```
 
-`flyway migrate`
+Then you can inspect the state of the database, and run any pending migrations, by running the script directly.
 
-Instructions for connecting to our pre-production and production databases are contained elsewhere.
+```sh
+./flyway.sc info local      # to see which migrations have been applied
+./flyway.sc migrate local   # to run all pending migrations
+```
+
+Change the `local` in the above commands for `code` or `prod` to run against the remote databases. Remember you'll need to have set up a tunnel to connect to those databases using [ssm-scala](https://github.com/guardian/ssm-scala).
+
+The local migrations are run as part of the start script.

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,11 @@
+# db
+
+This directory contains database configuration, including and especially the database migrations.
+
+Run the migrations with [flyway](https://documentation.red-gate.com/flyway/flyway-cli-and-api/welcome-to-flyway), which can be installed with Homebrew.
+
+This directory includes config for connecting to the local database, and is run as part of the start script.
+
+`flyway migrate`
+
+Instructions for connecting to our pre-production and production databases are contained elsewhere.

--- a/db/flyway.sc
+++ b/db/flyway.sc
@@ -1,0 +1,174 @@
+#!/usr/bin/env -S scala-cli shebang -S 3.3
+
+//> using dep com.lihaoyi::ujson:3.3.1
+//> using dep org.flywaydb:flyway-core:10.18.0
+//> using dep org.flywaydb:flyway-database-postgresql:10.18.0
+//> using dep org.postgresql:postgresql:42.7.4
+//> using dep software.amazon.awssdk:rds:2.28.6
+//> using dep software.amazon.awssdk:secretsmanager:2.28.6
+import software.amazon.awssdk.services.rds.model.GenerateAuthenticationTokenRequest
+import software.amazon.awssdk.services.rds.RdsClient
+
+import org.flywaydb.core.Flyway
+import scala.io.StdIn.readLine
+import scala.jdk.CollectionConverters._
+import scala.util.Try
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient
+import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest
+
+type Row = List[String]
+type Table = List[Row]
+
+def infoCmd(env: String, flyway: Flyway): Unit = {
+
+  val table: Table = (flyway
+    .info()
+    .all()
+    .toList
+    .map(info =>
+      List(
+        info.getVersion().getVersion(),
+        info.getDescription(),
+        Try(info.getInstalledOn().toString()).getOrElse(""),
+        Try(info.getState().toString()).getOrElse("")
+      )
+    ))
+
+  tabulate(List("version", "description", "installed on", "state"), table)
+
+  def tabulate(headers: Row, t: Table) = {
+    val widths = (headers +: t).transpose.map(_.map(_.length).max)
+    val totalWidth = widths.sum + widths.size * 3 - 1
+
+    def pad(cols: List[String]) =
+      cols.zipWithIndex.map(pair => pair._1.padTo(widths(pair._2), ' '))
+
+    println("+" + "-" * totalWidth + "+")
+
+    println(pad(headers).mkString("| ", " | ", " |"))
+
+    println("+" + "-" * totalWidth + "+")
+
+    for (row <- t) {
+      println(pad(row).mkString("| ", " | ", " |"))
+    }
+
+    println("+" + "-" * totalWidth + "+")
+  }
+}
+
+def migrateCmd(env: String, flyway: Flyway): Unit = {
+
+  println()
+  println("Validating migration schema...")
+  println()
+
+  val pendingMigrations = flyway.info().pending()
+  println()
+
+  if (pendingMigrations.isEmpty) {
+    println("No migrations needed, exiting...")
+  } else {
+    println("Validation succeeded")
+    println(
+      s"Ready to run ${pendingMigrations.length} migrations on the $env environment database!"
+    )
+    print(s"Are you sure these migrations are ready to run? (y/N) ")
+
+    val decision = readLine()
+
+    if (decision.trim().toLowerCase().startsWith("y")) {
+      flyway.migrate()
+      println("All migrations run, exiting successfully")
+    } else {
+      println("No migrations run, exiting as requested")
+      sys.exit(2)
+    }
+  }
+}
+
+def localFlyway: Flyway = buildFlyway("postgres")
+
+def buildFlyway(password: String) =
+  Flyway
+    .configure()
+    .dataSource(
+      "jdbc:postgresql://localhost:5432/newswires",
+      "postgres",
+      password
+    )
+    .locations("filesystem:migrations")
+    .load()
+
+def codeFlyway: Flyway = {
+  val credentials =
+    DefaultCredentialsProvider.builder().profileName("editorial-feeds").build()
+  val secretsManager =
+    SecretsManagerClient
+      .builder()
+      .credentialsProvider(credentials)
+      .region(Region.EU_WEST_1)
+      .build()
+
+  val matchingSecret = secretsManager
+    .listSecrets()
+    .secretList()
+    .asScala
+    .find(secret => {
+      val tags = secret.tags().asScala
+      secret.name().contains("NewswiresDBNewswiresSecret") && tags.exists(tag =>
+        tag.key == "App" && tag.value == "newswires"
+      ) && tags.exists(tag => tag.key == "Stage" && tag.value == "CODE")
+    })
+    .getOrElse {
+      println("No secret matching the expected name or tags!")
+      sys.exit(1)
+    }
+
+  val getSecretRequest = GetSecretValueRequest
+    .builder()
+    .secretId(matchingSecret.arn())
+    .build()
+
+  val response = secretsManager.getSecretValue(getSecretRequest)
+
+  val secretData = ujson.read(response.secretString())
+
+  val rds = RdsClient.builder()
+  .credentialsProvider(credentials)
+  .region(Region.EU_WEST_1)
+  .build()
+
+  val generateTokenRequest =  GenerateAuthenticationTokenRequest.builder()
+    .credentialsProvider(credentials)
+    .username("postgres")
+    .port(5432)
+    .hostname(secretData("host").str)
+    .build()
+
+  val token = rds.utilities().generateAuthenticationToken(generateTokenRequest)
+
+  buildFlyway(token)
+}
+
+val command = args.lift(0) match {
+  case Some("info")    => infoCmd
+  case Some("migrate") => migrateCmd
+  case o =>
+    val msg = o.fold("No command specified!")(cmd => s"Unknown command $cmd!")
+    println(s"$msg Try again with one of `info`, `migrate`")
+    sys.exit(1)
+}
+
+val (env, flyway) = args.lift(1).map(_.toLowerCase()) match {
+  case Some("local") => ("local", localFlyway)
+  case Some("code") => ("code", codeFlyway)
+  case o =>
+    val msg = o.fold("No environment specified!")(env => s"Unknown env $env!")
+    println(s"$msg Try again with one of `local`, `code` or `prod`")
+    sys.exit(1)
+}
+
+command(env, flyway)

--- a/db/flyway.sc
+++ b/db/flyway.sc
@@ -6,6 +6,7 @@
 //> using dep org.postgresql:postgresql:42.7.4
 //> using dep software.amazon.awssdk:rds:2.28.6
 //> using dep software.amazon.awssdk:secretsmanager:2.28.6
+import java.nio.file.Path
 import software.amazon.awssdk.services.rds.model.GenerateAuthenticationTokenRequest
 import software.amazon.awssdk.services.rds.RdsClient
 
@@ -91,6 +92,8 @@ def migrateCmd(env: String, flyway: Flyway): Unit = {
 
 def localFlyway: Flyway = buildFlyway("postgres")
 
+val location = Path.of(scriptPath).getParent().resolve("migrations").toString()
+
 def buildFlyway(password: String) =
   Flyway
     .configure()
@@ -99,7 +102,7 @@ def buildFlyway(password: String) =
       "postgres",
       password
     )
-    .locations("filesystem:migrations")
+    .locations(s"filesystem:$location")
     .load()
 
 def codeFlyway: Flyway = {

--- a/db/flyway.toml
+++ b/db/flyway.toml
@@ -1,0 +1,7 @@
+[flyway]
+locations = ["filesystem:migrations"]
+
+[environments.default]
+url = "jdbc:postgresql://localhost:5432/newswires"
+user = "postgres"
+password = "postgres"

--- a/db/flyway.toml
+++ b/db/flyway.toml
@@ -1,7 +1,0 @@
-[flyway]
-locations = ["filesystem:migrations"]
-
-[environments.default]
-url = "jdbc:postgresql://localhost:5432/newswires"
-user = "postgres"
-password = "postgres"

--- a/db/migrations/V1__Create_wires_table.sql
+++ b/db/migrations/V1__Create_wires_table.sql
@@ -1,0 +1,10 @@
+
+CREATE TABLE IF NOT EXISTS fingerpost_wire_entry (
+    id BIGSERIAL PRIMARY KEY,
+    external_id TEXT,
+    ingested_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
+    content JSONB NOT NULL
+);
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+

--- a/db/migrations/V2__trigram_indices.sql
+++ b/db/migrations/V2__trigram_indices.sql
@@ -1,0 +1,18 @@
+-- Adding indexes to support the initial, pg_trgm based search filters.
+-- These should almost certainly only be temporary, and be replaced with
+-- indexes for tsvector based searches soon...
+
+CREATE INDEX headline_trgm_index ON fingerpost_wire_entry
+  USING GIN ((content->>'headline') gin_trgm_ops);
+
+CREATE INDEX subhead_trgm_index ON fingerpost_wire_entry
+  USING GIN ((content->>'subhead') gin_trgm_ops);
+
+CREATE INDEX keywords_trgm_index ON fingerpost_wire_entry
+  USING GIN ((content->>'keywords') gin_trgm_ops);
+
+CREATE INDEX byline_trgm_index ON fingerpost_wire_entry
+  USING GIN ((content->>'byline') gin_trgm_ops);
+
+CREATE INDEX body_text_trgm_index ON fingerpost_wire_entry
+  USING GIN ((content->>'body_text') gin_trgm_ops);

--- a/ingestion-lambda/localRun.ts
+++ b/ingestion-lambda/localRun.ts
@@ -6,9 +6,7 @@ const lorem = new LoremIpsum({});
 
 const loremHtml = new LoremIpsum({}, 'html');
 
-void (async () => {
-	recursivelyScheduleEvent();
-})();
+recursivelyScheduleEvent();
 
 function recursivelyScheduleEvent() {
 	setTimeout(

--- a/ingestion-lambda/localRun.ts
+++ b/ingestion-lambda/localRun.ts
@@ -1,22 +1,12 @@
 import type { SQSEvent, SQSRecord } from 'aws-lambda';
 import { LoremIpsum } from 'lorem-ipsum';
-import { tableName } from './src/database';
 import { main } from './src/handler';
-import { createDbConnection } from './src/rds';
 
 const lorem = new LoremIpsum({});
 
 const loremHtml = new LoremIpsum({}, 'html');
 
 void (async () => {
-	const sql = await createDbConnection();
-	await sql`CREATE TABLE IF NOT EXISTS ${sql(tableName)} (
-	    id BIGSERIAL PRIMARY KEY,
-	    external_id TEXT,
-	    ingested_at TIMESTAMP WITH TIME ZONE DEFAULT CURRENT_TIMESTAMP,
-	    content JSONB NOT NULL
-	)`;
-
 	recursivelyScheduleEvent();
 })();
 

--- a/scripts/start
+++ b/scripts/start
@@ -149,7 +149,8 @@ main() {
     else
       echo "Using the local stack. Starting Docker, Ingestion Lambda and Play App."
       # run all three, and terminate together when the user presses `ctrl+c`: https://stackoverflow.com/a/52033580
-      (trap 'kill 0' SIGINT; startDockerContainers && startIngestionLambda & startPlayApp & wait)
+      startDockerContainers
+      (trap 'kill 0' SIGINT; startIngestionLambda & startPlayApp & wait)
     fi
 
 }

--- a/scripts/start
+++ b/scripts/start
@@ -88,9 +88,8 @@ startDockerContainers() {
   fi
   docker compose up -d --wait
   echo "Applying database migrations if necessary..."
-  pushd "$ROOT_DIR/db"
-  flyway migrate
-  popd
+
+  yes | ./db/flyway.sc migrate local
 }
 
 startIngestionLambda() {
@@ -152,7 +151,6 @@ main() {
       startDockerContainers
       (trap 'kill 0' SIGINT; startIngestionLambda & startPlayApp & wait)
     fi
-
 }
 
 main

--- a/scripts/start
+++ b/scripts/start
@@ -65,6 +65,7 @@ checkRequirements() {
   # other
   checkRequirement nginx
   checkRequirement aws
+  checkRequirement flyway
 }
 
 tunnelToAwsDb() {
@@ -85,7 +86,11 @@ startDockerContainers() {
     # shellcheck disable=SC2046
     kill $(echo "${EXISTING_TUNNELS}" | awk '{print $2}')
   fi
-  docker compose up -d
+  docker compose up -d --wait
+  echo "Applying database migrations if necessary..."
+  pushd "$ROOT_DIR/db"
+  flyway migrate
+  popd
 }
 
 startIngestionLambda() {


### PR DESCRIPTION
start a directory of DB migrations, so the schema is version controlled and can be iterated on and applied to different environments safely.

I've struggled and generally been dissatisfied with play evolutions in previous projects, as it's generally designed to work with runtime dependency injection rather than our preferred usage of compile-time/explicit injection, so I'm going back to flyway; somewhat annoying that it's a new dependency, but it can be run and applied independently of the main app, and is much easier to configure, which I find a positive, and generally doesn't try to lead you down the minefield of building "down" migrations