### PR TITLE
new `/api/keywords` endpoint

### DIFF
--- a/ingestion-lambda/localRun.ts
+++ b/ingestion-lambda/localRun.ts
@@ -41,6 +41,11 @@ function createDummyFeedEntry() {
 
 	const externalId = `APBIZWIR/${usn}/${dateTimeSent}/0`;
 
+	const keywords = new Array(Math.floor(Math.random() * 5) + 2) // 2-7 keywords
+		.fill(0)
+		.map(() => lorem.generateWords(Math.floor(Math.random() * 3) + 1)) // 1-3 words per keyword
+		.join('+'); // not sure why keywords are separated by + (rather than it being a json array), but that's what the example does
+
 	return {
 		externalId: externalId,
 		body: {
@@ -64,7 +69,7 @@ function createDummyFeedEntry() {
 				code: '',
 			},
 			mediaCatCodes: 'f',
-			keywords: 'Electric vehicles+Sports+Parasports',
+			keywords,
 			organisation: {
 				symbols: '',
 			},

--- a/ingestion-lambda/localRun.ts
+++ b/ingestion-lambda/localRun.ts
@@ -43,8 +43,7 @@ function createDummyFeedEntry() {
 
 	const keywords = new Array(Math.floor(Math.random() * 5) + 2) // 2-7 keywords
 		.fill(0)
-		.map(() => lorem.generateWords(Math.floor(Math.random() * 3) + 1)) // 1-3 words per keyword
-		.join('+'); // not sure why keywords are separated by + (rather than it being a json array), but that's what the example does
+		.map(() => lorem.generateWords(Math.floor(Math.random() * 3) + 1)); // 1-3 words per keyword
 
 	return {
 		externalId: externalId,

--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -27,8 +27,11 @@ class QueryController(
     Ok(Json.toJson(results))
   }
 
-  def keywords: Action[AnyContent] = AuthAction {
-    val results = FingerpostWireEntry.getKeywords()
+  def keywords(
+      maybeInLastHours: Option[Int],
+      maybeLimit: Option[Int]
+  ): Action[AnyContent] = AuthAction {
+    val results = FingerpostWireEntry.getKeywords(maybeInLastHours, maybeLimit)
     Ok(Json.toJson(results))
   }
 

--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -27,4 +27,9 @@ class QueryController(
     Ok(Json.toJson(results))
   }
 
+  def keywords: Action[AnyContent] = AuthAction {
+    val results = FingerpostWireEntry.getKeywords()
+    Ok(Json.toJson(results))
+  }
+
 }

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -93,4 +93,20 @@ object FingerpostWireEntry extends SQLSyntaxSupport[FingerpostWireEntry] {
         .apply()
 
   }
+
+  def getKeywords()  = DB readOnly {
+    implicit session =>
+      sql"""| SELECT distinct keyword, count(*)
+            | FROM (
+            |     SELECT unnest(string_to_array(content ->> 'keywords', '+')) as keyword
+            |     FROM fingerpost_wire_entry
+            | ) as all_keywords
+            | GROUP BY keyword
+            | """.stripMargin
+        .map(rs => rs.string("keyword") -> rs.int("count"))
+        .list()
+        .apply()
+        .toMap // TODO would a list be better?
+  }
+
 }

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -99,7 +99,6 @@ object FingerpostWireEntry extends SQLSyntaxSupport[FingerpostWireEntry] {
         .fold(sqls"")(inLastHours =>
           sqls"WHERE ingested_at > now() - ($inLastHours::text || ' hours')::interval"
         )
-      println(innerWhereClause)
       val limitClause = maybeLimit
         .map(limit => sqls"LIMIT $limit")
         .orElse(maybeInLastHours.map(_ => sqls"LIMIT 10"))

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -1,6 +1,5 @@
 package db
 
-import org.postgresql.util.PSQLException
 import play.api.libs.json.{Json, OFormat}
 import scalikejdbc._
 
@@ -16,7 +15,7 @@ case class FingerpostWire(
     headline: Option[String],
     subhead: Option[String],
     byline: Option[String],
-    keywords: Option[String],
+    keywords: Option[List[String]],
     usage: Option[String],
     location: Option[String],
     body_text: Option[String]
@@ -107,7 +106,7 @@ object FingerpostWireEntry extends SQLSyntaxSupport[FingerpostWireEntry] {
         .getOrElse(sqls"")
       sql"""| SELECT distinct keyword, count(*)
             | FROM (
-            |     SELECT unnest(string_to_array(content ->> 'keywords', '+')) as keyword
+            |     SELECT jsonb_array_elements(content -> 'keywords') as keyword
             |     FROM fingerpost_wire_entry
             |     $innerWhereClause
             | ) as all_keywords

--- a/newswires/client/src/WiresCards.tsx
+++ b/newswires/client/src/WiresCards.tsx
@@ -59,7 +59,7 @@ export const WireCardList = ({ wires }: { wires: WireData[] }) => {
 				title: 'Keywords',
 				description: (
 					<EuiFlexGroup wrap responsive={false} gutterSize="xs">
-						{keywords?.split('+').map((keyword) => (
+						{keywords?.map((keyword) => (
 							<EuiFlexItem key={keyword} grow={false}>
 								<EuiBadge color="primary">{keyword}</EuiBadge>
 							</EuiFlexItem>

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -12,7 +12,7 @@ export type WireData = {
 		headline: string;
 		subhead: string;
 		byline: string;
-		keywords: string;
+		keywords: string[];
 		usage: string;
 		location: string;
 		body_text: string;

--- a/newswires/conf/routes
+++ b/newswires/conf/routes
@@ -8,7 +8,7 @@ GET     /                           controllers.ViteController.index()
 GET     /feed                           controllers.ViteController.index()
 GET     /api/                       controllers.HomeController.index()
 GET     /api/search                 controllers.QueryController.query(q: Option[String])
-GET     /api/keywords               controllers.QueryController.keywords
+GET     /api/keywords               controllers.QueryController.keywords(inLastHours: Option[Int], limit:Option[Int])
 
 GET     /oauthCallback              controllers.AuthController.oauthCallback()
 

--- a/newswires/conf/routes
+++ b/newswires/conf/routes
@@ -8,6 +8,7 @@ GET     /                           controllers.ViteController.index()
 GET     /feed                           controllers.ViteController.index()
 GET     /api/                       controllers.HomeController.index()
 GET     /api/search                 controllers.QueryController.query(q: Option[String])
+GET     /api/keywords               controllers.QueryController.keywords
 
 GET     /oauthCallback              controllers.AuthController.oauthCallback()
 


### PR DESCRIPTION
## What does this change?

- randomise values for `keywords` field in local ingestion-lambda
- add `/api/keywords` endpoint to expose all keywords in DB with a count of 'wire entry' where keyword is present - useful for filter options in UI plus a potential 'trending' feature
- add `inLastHours` and `limit` query params to the /api/keywords endpoint to better support a potential 'trending' feature (i.e. top 10 keywords in the last 24 hours)
- **split the `+` delimited string for `keywords` field into an array, during ingestion (ingestion-lambda)**
- update the API and client-side to expect keywords to be an array

### IMPORTANT
The data in CODE needed to have existing entries updated to convert the `keywords` field of `content` column converted from string to array, which can be done by executing... 
```sql
UPDATE fingerpost_wire_entry
SET content = jsonb_set(
	content, 
	'{keywords}', 
	to_jsonb(string_to_array(content ->> 'keywords', '+')), 
	true
)
WHERE jsonb_typeof(content -> 'keywords') = 'string'
```

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
With it deployed to CODE, try...

- https://newswires.code.dev-gutools.co.uk/api/keywords
- https://newswires.code.dev-gutools.co.uk/api/keywords?limit=5
- https://newswires.code.dev-gutools.co.uk/api/keywords?inLastHours=1&limit=5
- https://newswires.code.dev-gutools.co.uk/api/keywords?inLastHours=24&limit=10 

(or you can of course use local, either with local DB or with `--use-CODE` flag on the start script)

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
