### PR TITLE
temporarily set the RDS minor version to 16.4, until RDS defaults version 16 to 16.4 or higher, when we can re-enable autoMinorVersionUpgrade

### DIFF
--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -1278,7 +1278,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
       "DeletionPolicy": "Snapshot",
       "Properties": {
         "AllocatedStorage": "100",
-        "AutoMinorVersionUpgrade": true,
+        "AutoMinorVersionUpgrade": false,
         "CACertificateIdentifier": "rds-ca-rsa2048-g1",
         "CopyTagsToSnapshot": true,
         "DBInstanceClass": "db.t4g.small",
@@ -1289,7 +1289,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
         "DeletionProtection": true,
         "EnableIAMDatabaseAuthentication": true,
         "Engine": "postgres",
-        "EngineVersion": "16",
+        "EngineVersion": "16.4",
         "MasterUserPassword": {
           "Fn::Join": [
             "",

--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -63,9 +63,10 @@ export class Newswires extends GuStack {
 				subnets: privateSubnets,
 			},
 			engine: DatabaseInstanceEngine.postgres({
-				version: PostgresEngineVersion.VER_16,
+				version: PostgresEngineVersion.of("16.4", "16"),
+				// version: PostgresEngineVersion.VER_16, // FIXME temporary, until VER_16 defaults to 16.4
 			}),
-			autoMinorVersionUpgrade: true,
+			autoMinorVersionUpgrade: false, // FIXME temporary, until rds defaults version 16 to 16.4
 		});
 
 		const feedsBucket = new GuS3Bucket(this, `feeds-bucket-${this.stage}`, {


### PR DESCRIPTION
As on the title

Currently Cloudformation refuses to apply our stack definition, because version "16" currently defaults to "16.3", and our CODE instance is already running "16.4", and RDS cannot perform a downgrade.

We can revert this once "16" defaults to "16.4", and then go back to taking automatic minor version upgrades.