### PR TITLE
update start script required dependencies, and install scala-cli in setup script

### DIFF
--- a/db/flyway.sc
+++ b/db/flyway.sc
@@ -1,5 +1,7 @@
 #!/usr/bin/env -S scala-cli shebang -S 3.3
 
+//> using jvm corretto:17
+
 //> using dep com.lihaoyi::ujson:3.3.1
 //> using dep org.flywaydb:flyway-core:10.18.0
 //> using dep org.flywaydb:flyway-database-postgresql:10.18.0

--- a/newswires/scripts/setup
+++ b/newswires/scripts/setup
@@ -27,6 +27,11 @@ setup_nginx() {
   dev-nginx restart-nginx
 }
 
+setup_dependencies() {
+  hash "scala-cli" 2>/dev/null || brew install Virtuslab/scala-cli/scala-cli
+}
+
 setup_nginx
 setup_config
+setup_dependencies
 

--- a/scripts/start
+++ b/scripts/start
@@ -65,7 +65,7 @@ checkRequirements() {
   # other
   checkRequirement nginx
   checkRequirement aws
-  checkRequirement flyway
+  checkRequirement scala-cli
 }
 
 tunnelToAwsDb() {


### PR DESCRIPTION
This requirement is from an earlier iteration of #19 which used flyway directly, rather than through scala-cli. Update the dependencies and the setup script to account for the changes.