### PR TITLE
Display top keywords list on homepage

### DIFF
--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -116,7 +116,13 @@ object FingerpostWireEntry extends SQLSyntaxSupport[FingerpostWireEntry] {
         .map(rs => rs.string("keyword") -> rs.int("count"))
         .list()
         .apply()
-        .toMap // TODO would a list be better?
+        .map { case (keyword, count) => KeywordCount(keyword, count) }
     }
 
+}
+
+case class KeywordCount(keyword: String, count: Int)
+
+object KeywordCount {
+  implicit val format: OFormat[KeywordCount] = Json.format[KeywordCount]
 }

--- a/newswires/client/package-lock.json
+++ b/newswires/client/package-lock.json
@@ -15,7 +15,8 @@
         "moment": "2.30.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "sanitize-html": "^2.13.0"
+        "sanitize-html": "^2.13.0",
+        "zod": "3.23.8"
       },
       "devDependencies": {
         "@eslint/js": "^9.9.0",
@@ -7706,6 +7707,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.23.8",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zwitch": {

--- a/newswires/client/package.json
+++ b/newswires/client/package.json
@@ -21,7 +21,8 @@
     "moment": "2.30.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "sanitize-html": "^2.13.0"
+    "sanitize-html": "^2.13.0",
+    "zod": "3.23.8"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -24,7 +24,9 @@ export function App() {
 				<EuiHeader position="fixed">
 					<EuiHeaderSectionItem>
 						<EuiTitle size={'s'}>
-							<h1>Newswires</h1>
+							<a href="/">
+								<h1>Newswires</h1>
+							</a>
 						</EuiTitle>
 					</EuiHeaderSectionItem>
 					{currentState.location !== '' && (

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -1,5 +1,4 @@
 import {
-	EuiEmptyPrompt,
 	EuiHeader,
 	EuiHeaderSectionItem,
 	EuiPageTemplate,

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -8,6 +8,7 @@ import {
 } from '@elastic/eui';
 import '@elastic/eui/dist/eui_theme_light.css';
 import { Feed } from './Feed';
+import { Home } from './Home';
 import { SearchBox } from './SearchBox';
 import { useHistory } from './urlState';
 
@@ -42,17 +43,7 @@ export function App() {
 				{currentState.location === 'feed' && (
 					<Feed searchQuery={currentState.params?.q ?? ''} />
 				)}
-				{currentState.location === '' && (
-					<EuiEmptyPrompt
-						title={<h2>Search wires</h2>}
-						body={
-							<SearchBox
-								initialQuery={currentState.params?.q ?? ''}
-								update={updateQuery}
-							/>
-						}
-					/>
-				)}
+				{currentState.location === '' && <Home updateQuery={updateQuery} />}
 			</EuiPageTemplate>
 		</EuiProvider>
 	);

--- a/newswires/client/src/Home.tsx
+++ b/newswires/client/src/Home.tsx
@@ -1,5 +1,15 @@
-import { EuiEmptyPrompt } from '@elastic/eui';
+import {
+	EuiBadge,
+	EuiButton,
+	EuiEmptyPrompt,
+	EuiFlexGroup,
+	EuiFlexItem,
+	EuiListGroup,
+} from '@elastic/eui';
+import { Fragment, useEffect, useMemo, useState } from 'react';
 import { SearchBox } from './SearchBox';
+import type { KeywordCounts } from './sharedTypes';
+import { KeywordCountsSchema } from './sharedTypes';
 import { useHistory } from './urlState';
 
 export function Home({
@@ -8,15 +18,60 @@ export function Home({
 	updateQuery: (newQuery: string) => void;
 }) {
 	const { currentState } = useHistory();
-	return (
-		<EuiEmptyPrompt
-			title={<h2>Search wires</h2>}
-			body={
-				<SearchBox
-					initialQuery={currentState.params?.q ?? ''}
-					update={updateQuery}
-				/>
-			}
-		/>
+	const [keywords, setKeywords] = useState<KeywordCounts>([]);
+
+	useEffect(() => {
+		fetch('api/keywords?limit=5')
+			.then((response) => {
+				if (response.ok) {
+					return response.json();
+				}
+			})
+			.then((data) => {
+				const maybeKeywords = KeywordCountsSchema.safeParse(data);
+				if (maybeKeywords.success) {
+					setKeywords(maybeKeywords.data);
+				} else {
+					console.error('Error parsing keywords:', maybeKeywords.error);
+				}
+			})
+			.catch((error) => {
+				console.error('Error fetching keywords:', error);
+			});
+	});
+
+	const body = (
+		<EuiFlexGroup direction="column" justifyContent="center">
+			<SearchBox
+				initialQuery={currentState.params?.q ?? ''}
+				update={updateQuery}
+			/>
+			{keywords.length > 0 && <KeywordsList keywords={keywords} />}
+		</EuiFlexGroup>
 	);
+
+	return <EuiEmptyPrompt title={<h2>Search wires</h2>} body={body} />;
 }
+
+const KeywordsList = ({ keywords }: { keywords: KeywordCounts }) => {
+	const sortedKeywords = useMemo(() => {
+		return keywords.sort((a, b) => b.count - a.count);
+	}, [keywords]);
+
+	return (
+		<EuiFlexGroup>
+			<EuiListGroup flush={true}>
+				{sortedKeywords.map(({ keyword, count }) => (
+					// TODO: fix query when keyword support added to search:
+					//     - specify as keyword rather than 'q'
+					//     - make sure keyword text is properly encoded
+					//     - handle quote marks if still present in response
+					<EuiButton key={keyword} color="text" href={`/feed?q=${keyword}`}>
+						{keyword.replaceAll('"', '')}{' '}
+						<EuiBadge color={'subdued'}>{count}</EuiBadge>
+					</EuiButton>
+				))}
+			</EuiListGroup>
+		</EuiFlexGroup>
+	);
+};

--- a/newswires/client/src/Home.tsx
+++ b/newswires/client/src/Home.tsx
@@ -1,0 +1,22 @@
+import { EuiEmptyPrompt } from '@elastic/eui';
+import { SearchBox } from './SearchBox';
+import { useHistory } from './urlState';
+
+export function Home({
+	updateQuery,
+}: {
+	updateQuery: (newQuery: string) => void;
+}) {
+	const { currentState } = useHistory();
+	return (
+		<EuiEmptyPrompt
+			title={<h2>Search wires</h2>}
+			body={
+				<SearchBox
+					initialQuery={currentState.params?.q ?? ''}
+					update={updateQuery}
+				/>
+			}
+		/>
+	);
+}

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -1,20 +1,26 @@
-export type WireData = {
-	id: number;
-	externalId: string;
-	ingestedAt: string;
-	content: Partial<{
-		uri: string;
-		usn: string;
-		version: string;
-		firstVersion: string; // date
-		versionCreated: string; // date
-		dateTimeSent: string; //date
-		headline: string;
-		subhead: string;
-		byline: string;
-		keywords: string[];
-		usage: string;
-		location: string;
-		body_text: string;
-	}>;
-};
+import { z } from 'zod';
+
+const FingerpostContentSchema = z.object({
+	uri: z.string(),
+	usn: z.string(),
+	version: z.string(),
+	firstVersion: z.string(),
+	versionCreated: z.string(),
+	dateTimeSent: z.string(),
+	headline: z.string(),
+	subhead: z.string(),
+	byline: z.string(),
+	keywords: z.array(z.string()),
+	usage: z.string(),
+	location: z.string(),
+	body_text: z.string(),
+});
+
+export const WireDataSchema = z.object({
+	id: z.number(),
+	externalId: z.string(),
+	ingestedAt: z.string(),
+	content: FingerpostContentSchema.partial(),
+});
+
+export type WireData = z.infer<typeof WireDataSchema>;

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -24,3 +24,12 @@ export const WireDataSchema = z.object({
 });
 
 export type WireData = z.infer<typeof WireDataSchema>;
+
+const KeywordCountSchema = z.object({
+	keyword: z.string(),
+	count: z.number(),
+});
+
+export const KeywordCountsSchema = z.array(KeywordCountSchema);
+
+export type KeywordCounts = z.infer<typeof KeywordCountsSchema>;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add a list of top keywords on the 'home' view:

- [Make h1 a link to root](https://github.com/guardian/newswires/pull/25/commits/d966896477cba4d38c0134965205c8b5a2db5068)
- [Refactor: extract Home component](https://github.com/guardian/newswires/pull/25/commits/36e65549f714ce6005a0e35b3b55a0c140b250fc)
- [Add zod for WireData type](https://github.com/guardian/newswires/pull/25/commits/914d8a0d5e5fff205e0acbadbb6453ae309b0fcb)
- [Add case class for KeywordCount](https://github.com/guardian/newswires/pull/25/commits/4d782ffb87c65ab01e0c1c4efdd8149277f56488)
- [Basic list of keyword links on homepage](https://github.com/guardian/newswires/pull/25/commits/9b341c28349202a0c4586f37ade606b209a20bbc)


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Run locally, check that keywords are rendered as expected

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="380" alt="image" src="https://github.com/user-attachments/assets/9fad05c6-9699-4618-8f05-a83b45d4b9f4">


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
