### PR TITLE
add the tsvector search column and indices

### DIFF
--- a/db/migrations/V3__tsvector_indices.sql
+++ b/db/migrations/V3__tsvector_indices.sql
@@ -1,0 +1,11 @@
+ALTER TABLE fingerpost_wire_entry
+  ADD COLUMN combined_textsearch tsvector
+    GENERATED ALWAYS AS (to_tsvector('english',
+        coalesce(content->>'headline', '') || ' ' ||
+        coalesce(content->>'subhead', '') || ' ' ||
+        coalesce(content->>'keywords', '') || ' ' ||
+        coalesce(content->>'body_text', '')
+    )) STORED;
+
+CREATE INDEX combined_textsearch_idx ON fingerpost_wire_entry
+  USING GIN (combined_textsearch);

--- a/db/migrations/V3__tsvector_indices.sql
+++ b/db/migrations/V3__tsvector_indices.sql
@@ -4,7 +4,9 @@ ALTER TABLE fingerpost_wire_entry
         coalesce(content->>'headline', '') || ' ' ||
         coalesce(content->>'subhead', '') || ' ' ||
         coalesce(content->>'keywords', '') || ' ' ||
-        coalesce(content->>'body_text', '')
+        coalesce(content->>'body_text', '') || ' ' ||
+        coalesce(content->>'byline', '') || ' ' ||
+        coalesce(content->>'abstract', '')
     )) STORED;
 
 CREATE INDEX combined_textsearch_idx ON fingerpost_wire_entry

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -35,7 +35,8 @@ object FingerpostWireEntry extends SQLSyntaxSupport[FingerpostWireEntry] {
   implicit val format: OFormat[FingerpostWireEntry] =
     Json.format[FingerpostWireEntry]
 
-  override val columns = Seq("id", "external_id", "ingested_at", "content")
+  override val columns =
+    Seq("id", "external_id", "ingested_at", "content", "combined_textsearch")
   val syn = this.syntax("fm")
 
   def apply(
@@ -100,7 +101,8 @@ object FingerpostWireEntry extends SQLSyntaxSupport[FingerpostWireEntry] {
 
     sql"""| SELECT ${FingerpostWireEntry.syn.result.*}
             | FROM ${FingerpostWireEntry as syn}
-            | WHERE $filters
+            | WHERE phraseto_tsquery($query) @@ ${FingerpostWireEntry.syn
+             .column("combined_textsearch")}
             | ORDER BY ${FingerpostWireEntry.syn.ingestedAt} DESC
             | LIMIT $effectivePageSize
             | OFFSET $position

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -39,6 +39,13 @@ object FingerpostWireEntry extends SQLSyntaxSupport[FingerpostWireEntry] {
     Seq("id", "external_id", "ingested_at", "content", "combined_textsearch")
   val syn = this.syntax("fm")
 
+  private val selectAllStatement = sqls"""
+    |   ${FingerpostWireEntry.syn.result.id},
+    |   ${FingerpostWireEntry.syn.result.externalId},
+    |   ${FingerpostWireEntry.syn.result.ingestedAt},
+    |   ${FingerpostWireEntry.syn.result.content}
+    |""".stripMargin
+
   def apply(
       fm: ResultName[FingerpostWireEntry]
   )(rs: WrappedResultSet): FingerpostWireEntry =
@@ -57,7 +64,7 @@ object FingerpostWireEntry extends SQLSyntaxSupport[FingerpostWireEntry] {
       val effectivePage = clamp(0, page, 10)
       val effectivePageSize = clamp(0, pageSize, 250)
       val position = effectivePage * effectivePageSize
-      sql"""| SELECT ${FingerpostWireEntry.syn.result.*}
+      sql"""| SELECT $selectAllStatement
             | FROM ${FingerpostWireEntry as syn}
             | ORDER BY ${FingerpostWireEntry.syn.ingestedAt} DESC
             | LIMIT $effectivePageSize
@@ -99,10 +106,10 @@ object FingerpostWireEntry extends SQLSyntaxSupport[FingerpostWireEntry] {
     val effectivePageSize = clamp(0, pageSize, 250)
     val position = effectivePage * effectivePageSize
 
-    sql"""| SELECT ${FingerpostWireEntry.syn.result.*}
+    sql"""| SELECT $selectAllStatement
             | FROM ${FingerpostWireEntry as syn}
             | WHERE phraseto_tsquery($query) @@ ${FingerpostWireEntry.syn
-             .column("combined_textsearch")}
+           .column("combined_textsearch")}
             | ORDER BY ${FingerpostWireEntry.syn.ingestedAt} DESC
             | LIMIT $effectivePageSize
             | OFFSET $position


### PR DESCRIPTION
Adds a brand new, generated tsvector column to all entries, which builds vector for the interesting text fields in the JSON data, then updates the query method to use that to search all the text fields together, and gets rid of the (pretty poor) trigram search