### PR TITLE
always split stringy keywords, even if empty string

### DIFF
--- a/ingestion-lambda/src/handler.ts
+++ b/ingestion-lambda/src/handler.ts
@@ -55,16 +55,15 @@ export const main = async (event: SQSEvent): Promise<SQSBatchResponse> => {
 						);
 
 						// eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- seems like postgres.js requires this format? https://github.com/porsager/postgres/issues/587#issuecomment-1563262612
-						const snsMessageContent: { keywords?: string } = JSON.parse(body);
+						const snsMessageContent: { keywords?: string | string[] } =
+							JSON.parse(body);
 
-						const finalContent =
-							!snsMessageContent.keywords ||
-							Array.isArray(snsMessageContent.keywords)
-								? snsMessageContent
-								: {
-										...snsMessageContent,
-										keywords: snsMessageContent.keywords.split('+'), // re-write the keywords field as an array
-									};
+						const finalContent = Array.isArray(snsMessageContent.keywords)
+							? snsMessageContent
+							: {
+									...snsMessageContent,
+									keywords: snsMessageContent.keywords?.split('+') ?? [], // re-write the keywords field as an array
+								};
 
 						await sql`
 						INSERT INTO ${sql(tableName)}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

empty strings are falsy, so messages with `keywords: ""` escaped being split into an array, but remained as strings so broke the deserializer in scala-land.

instead, always run split if a split function exists (ie. keywords is `string`), and default to an empty array (so the resulting entry can be parsed)