### PR TITLE
add proper `keywords` support to `/api/search` endpoint

### DIFF
--- a/db/migrations/V4__keywords_index.sql
+++ b/db/migrations/V4__keywords_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX keywords_index ON fingerpost_wire_entry
+    USING GIN ((content -> 'keywords') jsonb_path_ops)

--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -18,10 +18,17 @@ class QueryController(
     with Logging
     with AppAuthActions {
 
-  def query(q: Option[String]): Action[AnyContent] = AuthAction {
+  def query(
+      maybeFreeTextQuery: Option[String],
+      maybeKeywords: Option[String]
+  ): Action[AnyContent] = AuthAction {
     Ok(
       Json.toJson(
-        FingerpostWireEntry.query(q, pageSize = 30)
+        FingerpostWireEntry.query(
+          maybeFreeTextQuery,
+          maybeKeywords.map(_.split(',').toList),
+          pageSize = 30
+        )
       )
     )
   }

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -79,6 +79,7 @@ object FingerpostWireEntry extends SQLSyntaxSupport[FingerpostWireEntry] {
 
   def query(
       maybeFreeTextQuery: Option[String],
+      maybeKeywords: Option[List[String]],
       page: Int = 0,
       pageSize: Int = 250
   ): QueryResponse = DB readOnly { implicit session =>
@@ -87,6 +88,11 @@ object FingerpostWireEntry extends SQLSyntaxSupport[FingerpostWireEntry] {
     val position = effectivePage * effectivePageSize
 
     val whereClause = List(
+      maybeKeywords.map(keywords =>
+        sqls"""(${FingerpostWireEntry.syn.column(
+            "content"
+          )} -> 'keywords') @> ${Json.toJson(keywords).toString()}::jsonb"""
+      ),
       maybeFreeTextQuery.map(query =>
         sqls"phraseto_tsquery($query) @@ ${FingerpostWireEntry.syn.column("combined_textsearch")}"
       )

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -27,6 +27,7 @@ export type WireData = z.infer<typeof WireDataSchema>;
 
 export const WiresQueryResponseSchema = z.object({
 	results: z.array(WireDataSchema),
+	keywordCounts: z.record(z.string(), z.number()),
 });
 
 export type WiresQueryResponse = z.infer<typeof WiresQueryResponseSchema>;

--- a/newswires/conf/routes
+++ b/newswires/conf/routes
@@ -8,7 +8,7 @@ GET     /                           controllers.ViteController.index()
 GET     /feed                       controllers.ViteController.index()
 GET     /item/*id                   controllers.ViteController.item(id: String)
 GET     /api/                       controllers.HomeController.index()
-GET     /api/search                 controllers.QueryController.query(q: Option[String])
+GET     /api/search                 controllers.QueryController.query(q: Option[String], keywords: Option[String])
 GET     /api/keywords               controllers.QueryController.keywords(inLastHours: Option[Int], limit:Option[Int])
 GET     /api/item/*id               controllers.QueryController.item(id: Int)
 


### PR DESCRIPTION
- [add `keywords_index` via a DB migration](https://github.com/guardian/newswires/commit/4f29159f72259a8ddb55d7871ea9d0a32f4fd9f7)
- [add `keywords` query param option to the `/api/search` endpoint which takes a comma separated list of keywords that must all be matched](https://github.com/guardian/newswires/commit/9e7881f351e562ed6932b11485b3f2c9aaff81d3) 
- [return `keywordCounts` as an additional field in the `/api/search` response, to show the count of keywords (within the search results, but not limited like the actual data)](https://github.com/guardian/newswires/pull/30/commits/b0e26accee445ae8e5e82d5515ca80bc2064754a)

... this combined with #21 before it, should mean we can build an improved keyword aware search component 🎉 