### PR TITLE
Log-shipping fix: adopt crosswordv2 log settings

### DIFF
--- a/.sbtopts
+++ b/.sbtopts
@@ -1,0 +1,1 @@
+-DSTAGE=DEV

--- a/newswires/build.sbt
+++ b/newswires/build.sbt
@@ -3,7 +3,6 @@ import sbt.Package.FixedTimestamp
 
 import scala.sys.process._
 
-
 name := """newswires"""
 organization := "com.gu"
 
@@ -15,12 +14,12 @@ libraryDependencies += ws
 libraryDependencies += "com.gu" %% "simple-configuration-ssm" % "1.6.4"
 libraryDependencies += "com.gu" %% "pan-domain-auth-play_3-0" % "4.0.0"
 libraryDependencies += "com.gu" %% "editorial-permissions-client" % "2.15"
+libraryDependencies += "net.logstash.logback" % "logstash-logback-encoder" % "7.4"
 libraryDependencies += "org.scalikejdbc" %% "scalikejdbc" % "3.5.0"
 libraryDependencies += "org.postgresql" % "postgresql" % "42.7.4"
 libraryDependencies += "software.amazon.jdbc" % "aws-advanced-jdbc-wrapper" % "2.3.7"
 
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % Test
-
 
 lazy val root = (project in file(".")).enablePlugins(
   PlayScala,
@@ -41,6 +40,35 @@ buildInfoKeys := Seq[BuildInfoKey](
   }))
 )
 
+/* Start of fix for CVE-2020-36518 in Jackson See:https://github.com/orgs/playframework/discussions/11222 */
+val jacksonVersion = "2.13.4" // or 2.12.7
+val jacksonDatabindVersion = "2.13.4.2" // or 2.12.7.1
+
+val jacksonOverrides = Seq(
+  "com.fasterxml.jackson.core" % "jackson-core",
+  "com.fasterxml.jackson.core" % "jackson-annotations",
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jdk8",
+  "com.fasterxml.jackson.datatype" % "jackson-datatype-jsr310"
+).map(_ % jacksonVersion)
+
+val jacksonDatabindOverrides = Seq(
+  "com.fasterxml.jackson.core" % "jackson-databind" % jacksonDatabindVersion
+)
+
+val akkaSerializationJacksonOverrides = Seq(
+  "com.fasterxml.jackson.dataformat" % "jackson-dataformat-cbor",
+  "com.fasterxml.jackson.module" % "jackson-module-parameter-names",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala"
+).map(_ % jacksonVersion)
+
+dependencyOverrides ++= jacksonDatabindOverrides ++ jacksonOverrides ++ akkaSerializationJacksonOverrides
+/* End of fix for CVE-2020-36518 in Jackson */
+
+// needed to parse conditional statements in `logback.xml`
+// i.e. to only log to disk in DEV
+// see: https://logback.qos.ch/setup.html#janino
+libraryDependencies += "org.codehaus.janino" % "janino" % "3.1.12"
+
 // Quietly remove logback from the classpath and replace with a no-op logger for nice, quiet tests :)
 // based on https://stackoverflow.com/q/41429625
 libraryDependencies += "org.slf4j" % "slf4j-nop" % "2.0.12" % Test
@@ -57,9 +85,7 @@ Compile / packageDoc / publishArtifact := false
 // Adds additional packages into conf/routes
 // play.sbt.routes.RoutesKeys.routesImport += "com.gu.binders._"
 
-
 // ------ Packaging settings ------
-
 
 /* use package name without version and `_all` */
 Debian / packageName := normalizedName.value
@@ -104,5 +130,3 @@ Universal / javaOptions ++= Seq(
   // Remove the PID file
   "-Dpidfile.path=/dev/null"
 )
-
-

--- a/newswires/conf/logback.xml
+++ b/newswires/conf/logback.xml
@@ -1,50 +1,50 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-
 <!-- https://www.playframework.com/documentation/latest/SettingsLogger -->
-
-<!DOCTYPE configuration>
-
 <configuration>
-  <import class="ch.qos.logback.classic.encoder.PatternLayoutEncoder"/>
-  <import class="ch.qos.logback.classic.AsyncAppender"/>
-  <import class="ch.qos.logback.core.FileAppender"/>
-  <import class="ch.qos.logback.core.ConsoleAppender"/>
 
-  <appender name="FILE" class="FileAppender">
+  <appender name="FILE" class="ch.qos.logback.core.FileAppender">
     <file>${application.home:-.}/logs/application.log</file>
-    <encoder class="PatternLayoutEncoder">
+    <encoder>
       <charset>UTF-8</charset>
-      <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) %magenta(%X{pekkoSource}) %msg%n</pattern>
+      <pattern>
+        %d{yyyy-MM-dd HH:mm:ss} - [%level] - from %logger with markers=%marker %n%message%n%xException%n
+      </pattern>
     </encoder>
   </appender>
 
-  <appender name="STDOUT" class="ConsoleAppender">
-    <!--
-         On Windows, enabling Jansi is recommended to benefit from color code interpretation on DOS command prompts,
-         which otherwise risk being sent ANSI escape sequences that they cannot interpret.
-         See https://logback.qos.ch/manual/layouts.html#coloring
-    -->
-    <!-- <withJansi>true</withJansi> -->
-    <encoder class="PatternLayoutEncoder">
-      <charset>UTF-8</charset>
-      <pattern>%d{yyyy-MM-dd HH:mm:ss} %highlight(%-5level) %cyan(%logger{36}) %magenta(%X{pekkoSource}) %msg%n</pattern>
-    </encoder>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <if condition='property("STAGE").contains("DEV")'>
+      <then>
+        <encoder>
+          <pattern>
+            %n%d{yyyy-MM-dd HH:mm:ss} - [%level] - from %logger with markers=%marker %n%message%n%xException%n
+          </pattern>
+        </encoder>
+      </then>
+      <else>
+        <!--
+          output with logstash JSON when deployed
+          possibly can be replaced with a JsonEncoder when we can upgrade to
+          logback 1.3 https://logback.qos.ch/manual/encoders.html#JsonEncoder
+        -->
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder" />
+      </else>
+    </if>
   </appender>
 
-  <appender name="ASYNCFILE" class="AsyncAppender">
-    <appender-ref ref="FILE"/>
+  <appender name="ASYNCFILE" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="FILE" />
   </appender>
 
-  <appender name="ASYNCSTDOUT" class="AsyncAppender">
-    <appender-ref ref="STDOUT"/>
+  <appender name="ASYNCSTDOUT" class="ch.qos.logback.classic.AsyncAppender">
+    <appender-ref ref="STDOUT" />
   </appender>
 
-  <logger name="play" level="INFO"/>
-  <logger name="application" level="DEBUG"/>
+  <logger name="play" level="INFO" />
+  <logger name="application" level="DEBUG" />
 
-  <root level="WARN">
-    <appender-ref ref="ASYNCFILE"/>
-    <appender-ref ref="ASYNCSTDOUT"/>
+  <root level="INFO">
+    <appender-ref ref="ASYNCFILE" />
+    <appender-ref ref="ASYNCSTDOUT" />
   </root>
 
 </configuration>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Copies the logback config that we're using in [crosswordv2](https://github.com/guardian/crosswordv2/commit/ad3cd755a1b04e94936fec2c18f1574b66cfb2d1)

It includes a number of changes to `build.sbt` as well. It might be that not all of these changes are necessary but I don't understand the jackson eviction stuff well enough to know what's needed and what's not.

Initially created because we thought that the broken log shipping was due to our config, though have since realised that there was an upstream issue with logging. Nevertheless, could be a QoL improvement to have nicer logs?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
