### PR TITLE
consolidate `getAll` into `query` function and wrap results array in an object with single key `results`

### DIFF
--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -19,12 +19,11 @@ class QueryController(
     with AppAuthActions {
 
   def query(q: Option[String]): Action[AnyContent] = AuthAction {
-    val results = q match {
-      case None        => FingerpostWireEntry.getAll(pageSize = 30)
-      case Some(query) => FingerpostWireEntry.query(query, pageSize = 30)
-    }
-
-    Ok(Json.toJson(results))
+    Ok(
+      Json.toJson(
+        FingerpostWireEntry.query(q, pageSize = 30)
+      )
+    )
   }
 
   def keywords(

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -91,17 +91,7 @@ object FingerpostWireEntry extends SQLSyntaxSupport[FingerpostWireEntry] {
       page: Int = 0,
       pageSize: Int = 250
   ): List[FingerpostWireEntry] = DB readOnly { implicit session =>
-    def filterElement(fieldName: String) =
-      sqls"$query <% (${FingerpostWireEntry.syn.column("content")}->>$fieldName)"
 
-    val headline = filterElement("headline")
-    val subhead = filterElement("subhead")
-    val byline = filterElement("byline")
-    val keywords = filterElement("keywords")
-    val bodyText = filterElement("body_text")
-
-    val filters =
-      sqls"$headline OR $subhead OR $byline OR $keywords OR $bodyText"
     val effectivePage = clamp(0, page, 10)
     val effectivePageSize = clamp(0, pageSize, 250)
     val position = effectivePage * effectivePageSize

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -33,24 +33,24 @@ export function App() {
 
 	const nextWireId = useMemo(() => {
 		if (currentSearchState.state === 'data') {
-			const currentIndex = currentSearchState.data.findIndex(
+			const currentIndex = currentSearchState.data.results.findIndex(
 				(wire) => wire.id.toString() === maybeSelectedWireId,
 			);
 			if (currentIndex === -1) {
 				return undefined;
 			}
 			const nextIndex = currentIndex + 1;
-			if (nextIndex >= currentSearchState.data.length) {
+			if (nextIndex >= currentSearchState.data.results.length) {
 				return undefined;
 			}
-			return currentSearchState.data[nextIndex].id.toString();
+			return currentSearchState.data.results[nextIndex].id.toString();
 		}
 		return undefined;
 	}, [currentSearchState, maybeSelectedWireId]);
 
 	const previousWireId = useMemo(() => {
 		if (currentSearchState.state === 'data') {
-			const currentIndex = currentSearchState.data.findIndex(
+			const currentIndex = currentSearchState.data.results.findIndex(
 				(wire) => wire.id.toString() === maybeSelectedWireId,
 			);
 			if (currentIndex === -1) {
@@ -60,7 +60,7 @@ export function App() {
 			if (previousIndex < 0) {
 				return undefined;
 			}
-			return currentSearchState.data[previousIndex].id.toString();
+			return currentSearchState.data.results[previousIndex].id.toString();
 		}
 		return undefined;
 	}, [currentSearchState, maybeSelectedWireId]);

--- a/newswires/client/src/Feed.tsx
+++ b/newswires/client/src/Feed.tsx
@@ -18,7 +18,7 @@ export const Feed = ({ searchState }: { searchState: SearchState }) => {
 					title={<h2>Loading Wires</h2>}
 				/>
 			)}
-			{data && data.length === 0 && (
+			{data && data.results.length === 0 && (
 				<EuiEmptyPrompt
 					body={<p>Try a different search term</p>}
 					color="subdued"
@@ -27,7 +27,7 @@ export const Feed = ({ searchState }: { searchState: SearchState }) => {
 					titleSize="s"
 				/>
 			)}
-			{data && data.length > 0 && <WireCardList wires={data} />}
+			{data && data.results.length > 0 && <WireCardList wires={data.results} />}
 		</EuiPageTemplate.Section>
 	);
 };

--- a/newswires/client/src/SearchBox.tsx
+++ b/newswires/client/src/SearchBox.tsx
@@ -7,7 +7,7 @@ import {
 	EuiPopover,
 	EuiText,
 } from '@elastic/eui';
-import { Fragment, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { debounce } from './debounce';
 import type { SearchState } from './useSearch';
 
@@ -31,7 +31,7 @@ export function SearchBox({
 			.filter((search) => 'data' in search)
 			.filter((search) => search.query !== '') // todo -- combine this with the above filter (ts type inference needs wrangling)
 			.reduce((acc, search) => {
-				acc.set(search.query, search.data.length);
+				acc.set(search.query, search.data.results.length);
 				return acc;
 			}, new Map<string, number>());
 		return Array.from(successfulSearchesWithResultsCount.entries());

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -25,4 +25,8 @@ export const WireDataSchema = z.object({
 
 export type WireData = z.infer<typeof WireDataSchema>;
 
-export const WireDataArraySchema = z.array(WireDataSchema);
+export const WiresQueryResponseSchema = z.object({
+	results: z.array(WireDataSchema),
+});
+
+export type WiresQueryResponse = z.infer<typeof WiresQueryResponseSchema>;

--- a/newswires/client/src/useSearch.ts
+++ b/newswires/client/src/useSearch.ts
@@ -1,8 +1,8 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { z } from 'zod';
 import { querify } from './querify';
-import { type WireData } from './sharedTypes';
-import { WireDataArraySchema } from './sharedTypes';
+import { WiresQueryResponseSchema } from './sharedTypes';
+import type { WiresQueryResponse } from './sharedTypes';
 import { useHistory } from './urlState';
 
 const SearchStateSchema = z.discriminatedUnion('state', [
@@ -18,7 +18,7 @@ const SearchStateSchema = z.discriminatedUnion('state', [
 	z.object({
 		query: z.string(),
 		state: z.literal('data'),
-		data: WireDataArraySchema,
+		data: WiresQueryResponseSchema,
 	}),
 	z.object({
 		state: z.literal('initialised'),
@@ -116,12 +116,13 @@ export function useSearch() {
 		fetch('/api/search' + quer)
 			.then((res) => res.json())
 			.then((data) => {
-				const maybeData = WireDataArraySchema.safeParse(data);
-				if (maybeData.success) {
+				const queryResponseParseResult =
+					WiresQueryResponseSchema.safeParse(data);
+				if (queryResponseParseResult.success) {
 					pushSearchState({
 						state: 'data',
 						query: searchQuery,
-						data: maybeData.data,
+						data: queryResponseParseResult.data,
 					});
 				} else {
 					pushSearchState({
@@ -133,7 +134,7 @@ export function useSearch() {
 				pushSearchState({
 					state: 'data',
 					query: searchQuery,
-					data: data as WireData[],
+					data: data as WiresQueryResponse,
 				});
 			})
 			.catch((e) =>


### PR DESCRIPTION
- Since #27 the `query` function now takes limit and offset, making it virtually the same as `getAll` just with the addition of a WHERE clause. So, in anticipation of #30 (i.e. another where clause) it made sense to make the query/search string an Option and conditionally add the where clause, meaning we can remove the `getAll`. 
- In the process we clean up some redundant code left behind from #28.
- In anticipation of #30 returning some keyword counts/aggs alongside the (limited) search results, this PR wraps the results array in an object with a single key `results` and updates the client-side accordingly.
