### PR TITLE
add `beforeId` query param to `/api/search` and remove offset param to facilitate id-based pagination (e.g. for infinite scroll)

### DIFF
--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -20,13 +20,15 @@ class QueryController(
 
   def query(
       maybeFreeTextQuery: Option[String],
-      maybeKeywords: Option[String]
+      maybeKeywords: Option[String],
+      maybeBeforeId: Option[Int]
   ): Action[AnyContent] = AuthAction {
     Ok(
       Json.toJson(
         FingerpostWireEntry.query(
           maybeFreeTextQuery,
           maybeKeywords.map(_.split(',').toList),
+          maybeBeforeId,
           pageSize = 30
         )
       )

--- a/newswires/conf/routes
+++ b/newswires/conf/routes
@@ -8,7 +8,7 @@ GET     /                           controllers.ViteController.index()
 GET     /feed                       controllers.ViteController.index()
 GET     /item/*id                   controllers.ViteController.item(id: String)
 GET     /api/                       controllers.HomeController.index()
-GET     /api/search                 controllers.QueryController.query(q: Option[String], keywords: Option[String])
+GET     /api/search                 controllers.QueryController.query(q: Option[String], keywords: Option[String], beforeId: Option[Int])
 GET     /api/keywords               controllers.QueryController.keywords(inLastHours: Option[Int], limit:Option[Int])
 GET     /api/item/*id               controllers.QueryController.item(id: Int)
 


### PR DESCRIPTION
Prior to this PR our 'paging' was based on numerical offset, which can be problematic if the underlying data is changing (which it is as incoming items on the feed, may match the current search), more sensible is using the ID. Fortunately our ID is a `SERIAL` (so sequential). So this PR adds a `beforeId` query param to fetch X records with ids less than the on specified.

This can be used to facilitate infinite scroll by passing the ID of the last search result from the 'previous page' to fetch the next X older items, matching the current search.