### PR TITLE
add `sinceId` query param to `/api/search` to ultimately facilitate polling

### DIFF
--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -21,7 +21,8 @@ class QueryController(
   def query(
       maybeFreeTextQuery: Option[String],
       maybeKeywords: Option[String],
-      maybeBeforeId: Option[Int]
+      maybeBeforeId: Option[Int],
+      maybeSinceId: Option[Int]
   ): Action[AnyContent] = AuthAction {
     Ok(
       Json.toJson(
@@ -29,6 +30,7 @@ class QueryController(
           maybeFreeTextQuery,
           maybeKeywords.map(_.split(',').toList),
           maybeBeforeId,
+          maybeSinceId,
           pageSize = 30
         )
       )

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -82,6 +82,7 @@ object FingerpostWireEntry extends SQLSyntaxSupport[FingerpostWireEntry] {
       maybeFreeTextQuery: Option[String],
       maybeKeywords: Option[List[String]],
       maybeBeforeId: Option[Int],
+      maybeSinceId: Option[Int],
       pageSize: Int = 250
   ): QueryResponse = DB readOnly { implicit session =>
     val effectivePageSize = clamp(0, pageSize, 250)
@@ -100,6 +101,9 @@ object FingerpostWireEntry extends SQLSyntaxSupport[FingerpostWireEntry] {
     val dataOnlyWhereClauses = List(
       maybeBeforeId.map(beforeId =>
         sqls"${FingerpostWireEntry.syn.id} < $beforeId"
+      ),
+      maybeSinceId.map(sinceId =>
+        sqls"${FingerpostWireEntry.syn.id} > $sinceId"
       )
     ).flatten
 

--- a/newswires/conf/routes
+++ b/newswires/conf/routes
@@ -8,7 +8,7 @@ GET     /                           controllers.ViteController.index()
 GET     /feed                       controllers.ViteController.index()
 GET     /item/*id                   controllers.ViteController.item(id: String)
 GET     /api/                       controllers.HomeController.index()
-GET     /api/search                 controllers.QueryController.query(q: Option[String], keywords: Option[String], beforeId: Option[Int])
+GET     /api/search                 controllers.QueryController.query(q: Option[String], keywords: Option[String], beforeId: Option[Int], sinceId: Option[Int])
 GET     /api/keywords               controllers.QueryController.keywords(inLastHours: Option[Int], limit:Option[Int])
 GET     /api/item/*id               controllers.QueryController.item(id: Int)
 


### PR DESCRIPTION
To complement https://github.com/guardian/newswires/pull/33 (which introduced `beforeId` query param, mainly for infinite scroll purposes), here we add a `sinceId` query param to fetch only items since the most recent one that we're already aware of. This should be useful for polling (efficiently).