### PR TITLE
Remove icon from card and adjust hover styling

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -11,6 +11,7 @@ import { useMemo } from 'react';
 import { Feed } from './Feed';
 import { Item } from './Item';
 import { SearchBox } from './SearchBox';
+import { themeModifications } from './themeModifications';
 import { isItemPath, useHistory } from './urlState';
 import { useSearch } from './useSearch';
 
@@ -66,19 +67,7 @@ export function App() {
 	}, [currentSearchState, maybeSelectedWireId]);
 
 	return (
-		<EuiProvider
-			colorMode="light"
-			modify={{
-				colors: {
-					LIGHT: {
-						// primary: '#17cea0',
-						primary: '#ffabdb',
-						primaryText: '#670056',
-						accent: '#003b38',
-					},
-				},
-			}}
-		>
+		<EuiProvider colorMode="light" modify={themeModifications}>
 			<EuiPageTemplate
 				onKeyUp={(e) => {
 					if (

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -5,8 +5,10 @@ import {
 	EuiPageTemplate,
 	EuiProvider,
 	EuiTitle,
+	useEuiBackgroundColor,
 } from '@elastic/eui';
 import '@elastic/eui/dist/eui_theme_light.css';
+import { css } from '@emotion/react';
 import { useMemo } from 'react';
 import { Feed } from './Feed';
 import { Item } from './Item';
@@ -66,7 +68,19 @@ export function App() {
 	}, [currentSearchState, maybeSelectedWireId]);
 
 	return (
-		<EuiProvider colorMode="light">
+		<EuiProvider
+			colorMode="light"
+			modify={{
+				colors: {
+					LIGHT: {
+						// primary: '#17cea0',
+						primary: '#ffabdb',
+						primaryText: '#670056',
+						accent: '#003b38',
+					},
+				},
+			}}
+		>
 			<EuiPageTemplate
 				onKeyUp={(e) => {
 					if (

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -5,10 +5,8 @@ import {
 	EuiPageTemplate,
 	EuiProvider,
 	EuiTitle,
-	useEuiBackgroundColor,
 } from '@elastic/eui';
 import '@elastic/eui/dist/eui_theme_light.css';
-import { css } from '@emotion/react';
 import { useMemo } from 'react';
 import { Feed } from './Feed';
 import { Item } from './Item';

--- a/newswires/client/src/WiresCards.tsx
+++ b/newswires/client/src/WiresCards.tsx
@@ -2,8 +2,6 @@ import {
 	EuiCard,
 	EuiFlexGroup,
 	EuiFlexItem,
-	EuiIcon,
-	EuiPanel,
 	EuiText,
 	EuiThemeProvider,
 	EuiTitle,

--- a/newswires/client/src/WiresCards.tsx
+++ b/newswires/client/src/WiresCards.tsx
@@ -2,9 +2,13 @@ import {
 	EuiCard,
 	EuiFlexGroup,
 	EuiFlexItem,
+	EuiIcon,
 	EuiPanel,
 	EuiText,
+	EuiThemeProvider,
 	EuiTitle,
+	useEuiBackgroundColor,
+	useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useMemo } from 'react';
@@ -51,32 +55,35 @@ const WirePanel = ({
 	onClick: () => void;
 	selected?: boolean;
 }) => {
+	const { euiTheme } = useEuiTheme();
+	const primaryBgColor = useEuiBackgroundColor('primary');
+	const accentBgColor = useEuiBackgroundColor('accent');
+
 	return (
-		<EuiFlexItem key={wire.id}>
-			<EuiCard
-				paddingSize="xs"
-				title={
-					<EuiTitle size="xxs">
-						<h2>{wire.content.headline ?? '<missing headline>'}</h2>
-					</EuiTitle>
-				}
-				icon={
-					<EuiPanel
-						css={css`
-							background-color: rgba(255, 0, 0, 0.5);
-							font-size: 0.75rem;
-						`}
-						paddingSize="s"
-					>
-						PA
-					</EuiPanel>
-				}
-				layout="horizontal"
-				display={selected ? 'primary' : 'plain'}
-				onClick={onClick}
-			>
-				<EuiText size="xs">{wire.content.subhead ?? ''}</EuiText>
-			</EuiCard>
-		</EuiFlexItem>
+		<EuiThemeProvider>
+			<EuiFlexItem key={wire.id}>
+				<EuiCard
+					title={
+						<EuiTitle size="xxs">
+							<h2>{wire.content.headline ?? '<missing headline>'}</h2>
+						</EuiTitle>
+					}
+					layout="horizontal"
+					display={'primary'}
+					onClick={onClick}
+					css={css`
+						padding: ${euiTheme.size.xs} ${euiTheme.size.s};
+						background-color: ${selected ? primaryBgColor : 'inherit'};
+						&:hover {
+							box-shadow: none;
+							transform: none;
+							background-color: ${accentBgColor};
+						}
+					`}
+				>
+					<EuiText size="xs">{wire.content.subhead ?? ''}</EuiText>
+				</EuiCard>
+			</EuiFlexItem>
+		</EuiThemeProvider>
 	);
 };

--- a/newswires/client/src/themeModifications.ts
+++ b/newswires/client/src/themeModifications.ts
@@ -1,0 +1,13 @@
+/**
+ * There's an interactive tool in the Eui docs that helps to generate these values:
+ * @see https://eui.elastic.co/#/theming/customizing-themes
+ */
+export const themeModifications = {
+	colors: {
+		LIGHT: {
+			primary: '#ffabdb',
+			primaryText: '#670056',
+			accent: '#003b38',
+		},
+	},
+};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

* Remove the hard-coded 'PA' badge on wire cards. (Perhaps add something like that back in once we work out how best to derive agency from the feed items.)
* Remove the default animated shadow hover styling from the cards.
* Add plainer hover styling, incorporating an experiment to see how Eui theming works, drawing from the Lucky Generals Guardian branding palette (below).

<img width="178" alt="lucky generals brand palette" src="https://github.com/user-attachments/assets/e7a1542c-629b-4791-a6e8-a2b8ac8907d9">


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

|Before|After|
|-|-|
|<img width="412" alt="image" src="https://github.com/user-attachments/assets/7a9ccab9-b3e0-4215-9e3f-27dc856a352f">|<img width="481" alt="image" src="https://github.com/user-attachments/assets/1af3485b-7b78-4584-9535-304a86e3299d">|
|<img width="221" alt="image" src="https://github.com/user-attachments/assets/de1a1f57-0e2c-4a46-99bf-ccc296dd5ac7">|<img width="219" alt="image" src="https://github.com/user-attachments/assets/10da13cc-56ef-4eeb-a108-4dd5a1ca0373">|


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
