### PR TITLE
Add timestamps to feed

### DIFF
--- a/newswires/client/src/Feed.tsx
+++ b/newswires/client/src/Feed.tsx
@@ -1,6 +1,6 @@
 import { EuiEmptyPrompt, EuiLoadingLogo, EuiPageTemplate } from '@elastic/eui';
 import type { SearchState } from './useSearch';
-import { WireCardList } from './WiresCards';
+import { WireCardTable } from './WiresCards';
 
 export const Feed = ({ searchState }: { searchState: SearchState }) => {
 	const data = 'data' in searchState ? searchState.data : undefined;
@@ -27,7 +27,9 @@ export const Feed = ({ searchState }: { searchState: SearchState }) => {
 					titleSize="s"
 				/>
 			)}
-			{data && data.results.length > 0 && <WireCardList wires={data.results} />}
+			{data && data.results.length > 0 && (
+				<WireCardTable wires={data.results} />
+			)}
 		</EuiPageTemplate.Section>
 	);
 };

--- a/newswires/client/src/Feed.tsx
+++ b/newswires/client/src/Feed.tsx
@@ -1,6 +1,6 @@
 import { EuiEmptyPrompt, EuiLoadingLogo, EuiPageTemplate } from '@elastic/eui';
 import type { SearchState } from './useSearch';
-import { WireCardTable } from './WiresCards';
+import { WireItemTable } from './WireItemTable';
 
 export const Feed = ({ searchState }: { searchState: SearchState }) => {
 	const data = 'data' in searchState ? searchState.data : undefined;
@@ -28,7 +28,7 @@ export const Feed = ({ searchState }: { searchState: SearchState }) => {
 				/>
 			)}
 			{data && data.results.length > 0 && (
-				<WireCardTable wires={data.results} />
+				<WireItemTable wires={data.results} />
 			)}
 		</EuiPageTemplate.Section>
 	);

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -3,6 +3,7 @@ import {
 	EuiDescriptionList,
 	EuiFlexGroup,
 	EuiFlexItem,
+	EuiScreenReaderLive,
 	EuiSpacer,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -52,13 +53,15 @@ export const WireDetail = ({ wire }: { wire: WireData }) => {
 
 	return (
 		<Fragment>
-			<h3
-				css={css`
-					font-weight: 300;
-				`}
-			>
-				{wire.content.subhead}
-			</h3>
+			<EuiScreenReaderLive focusRegionOnTextChange>
+				<h3
+					css={css`
+						font-weight: 300;
+					`}
+				>
+					{wire.content.subhead}
+				</h3>
+			</EuiScreenReaderLive>
 
 			<EuiSpacer size="m" />
 

--- a/newswires/client/src/WireItemTable.tsx
+++ b/newswires/client/src/WireItemTable.tsx
@@ -2,6 +2,7 @@ import {
 	EuiFlexGroup,
 	euiScreenReaderOnly,
 	EuiTable,
+	EuiTableBody,
 	EuiTableHeader,
 	EuiTableHeaderCell,
 	EuiTableRow,
@@ -46,15 +47,17 @@ export const WireItemTable = ({ wires }: { wires: WireData[] }) => {
 					<EuiTableHeaderCell>Headline</EuiTableHeaderCell>
 					<EuiTableHeaderCell>Version Created</EuiTableHeaderCell>
 				</EuiTableHeader>
-				{wires.map(({ id, content }) => (
-					<WireDataRow
-						key={id}
-						id={id}
-						content={content}
-						selected={selectedWireId == id.toString()}
-						handleSelect={handleSelect}
-					/>
-				))}
+				<EuiTableBody>
+					{wires.map(({ id, content }) => (
+						<WireDataRow
+							key={id}
+							id={id}
+							content={content}
+							selected={selectedWireId == id.toString()}
+							handleSelect={handleSelect}
+						/>
+					))}
+				</EuiTableBody>
 			</EuiTable>
 		</div>
 	);

--- a/newswires/client/src/WireItemTable.tsx
+++ b/newswires/client/src/WireItemTable.tsx
@@ -12,12 +12,12 @@ import {
 	useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useMemo } from 'react';
 import { formatTimestamp } from './formatTimestamp';
 import type { WireData } from './sharedTypes';
 import { isItemPath, useHistory } from './urlState';
 
-export const WireCardTable = ({ wires }: { wires: WireData[] }) => {
+export const WireItemTable = ({ wires }: { wires: WireData[] }) => {
 	const { currentState, pushState } = useHistory();
 
 	const selectedWireId = useMemo(

--- a/newswires/client/src/formatTimestamp.ts
+++ b/newswires/client/src/formatTimestamp.ts
@@ -1,0 +1,11 @@
+// timestamp string of format: 2024-09-24T14:22:07.603Z to HH:MM:ss
+// or if the date is not today, return the date in the format: 25/09/2024, 14:22:07
+// (these are the formats for UK locale)
+export function formatTimestamp(s: string) {
+	const date = new Date(s);
+	const now = new Date();
+	if (now.getDate() === date.getDate()) {
+		return date.toLocaleTimeString();
+	}
+	return date.toLocaleString();
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

* Refactor the Feed component to use a table instead of a list of cards, to represent wire items.
* Build on this to add a timestamp to the table entries.

Trying to build effective formatting into the EuiCard component meant pushing against the grain of the framework, whereas a table layout facilitates it pretty well. Using the lower-level building blocks in Eui, rather than their opinionated EuiBasicTable component, meant we could get a pretty simple layout that works fine, imo.

**nb.** More of an opportunity than a regression: Eui's table component auto-scrolls to whichever row has focus, which is quite nice. We might want to rework keyboard support (including focus order etc.) later to see if we can get away with just leveraging Eui builtins?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="1289" alt="image" src="https://github.com/user-attachments/assets/39e26aae-29f0-47ce-bac8-faf8c4474a41">


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
