### PR TITLE
Refactor detail list and don't render fields without meaningful data

### DIFF
--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -1,8 +1,11 @@
 import {
 	EuiBadge,
 	EuiDescriptionList,
+	EuiDescriptionListDescription,
+	EuiDescriptionListTitle,
 	EuiFlexGroup,
 	EuiFlexItem,
+	EuiScreenReaderLive,
 	EuiSpacer,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -19,50 +22,67 @@ export const WireDetail = ({ wire }: { wire: WireData }) => {
 			: undefined;
 	}, [wire]);
 
-	const listItems = [
-		{
-			title: 'Byline',
-			description: byline ?? 'Not found',
-		},
-		{
-			title: 'Keywords',
-			description: (
-				<EuiFlexGroup wrap responsive={false} gutterSize="xs">
-					{keywords?.map((keyword) => (
-						<EuiFlexItem key={keyword} grow={false}>
-							<EuiBadge color="primary">{keyword}</EuiBadge>
-						</EuiFlexItem>
-					))}
-				</EuiFlexGroup>
-			),
-		},
-		{
-			title: 'Usage restrictions',
-			description: usage ?? 'Not found',
-		},
-		{
-			title: 'Body text',
-			description: safeBodyText ? (
-				<article dangerouslySetInnerHTML={{ __html: safeBodyText }} />
-			) : (
-				'Not found'
-			),
-		},
-	];
+	const nonEmptyKeywords = useMemo(
+		() => keywords?.filter((keyword) => keyword.trim().length > 0) ?? [],
+		[keywords],
+	);
 
 	return (
 		<Fragment>
-			<h3
-				css={css`
-					font-weight: 300;
-				`}
-			>
-				{wire.content.subhead}
-			</h3>
+			<EuiScreenReaderLive focusRegionOnTextChange>
+				<h3
+					css={css`
+						font-weight: 300;
+					`}
+				>
+					{wire.content.subhead}
+				</h3>
+			</EuiScreenReaderLive>
 
 			<EuiSpacer size="m" />
 
-			<EuiDescriptionList listItems={listItems} />
+			<EuiDescriptionList>
+				{byline && (
+					<>
+						<EuiDescriptionListTitle>Byline</EuiDescriptionListTitle>
+						<EuiDescriptionListDescription>
+							{byline}
+						</EuiDescriptionListDescription>
+					</>
+				)}
+				{nonEmptyKeywords.length > 0 && (
+					<>
+						<EuiDescriptionListTitle>Keywords</EuiDescriptionListTitle>
+						<EuiDescriptionListDescription>
+							<EuiFlexGroup wrap responsive={false} gutterSize="xs">
+								{nonEmptyKeywords.map((keyword) => (
+									<EuiFlexItem key={keyword} grow={false}>
+										<EuiBadge color="primary">{keyword}</EuiBadge>
+									</EuiFlexItem>
+								))}
+							</EuiFlexGroup>
+						</EuiDescriptionListDescription>
+					</>
+				)}
+				{usage && (
+					<>
+						<EuiDescriptionListTitle>
+							Usage restrictions
+						</EuiDescriptionListTitle>
+						<EuiDescriptionListDescription>
+							{usage}
+						</EuiDescriptionListDescription>
+					</>
+				)}
+				{safeBodyText && (
+					<>
+						<EuiDescriptionListTitle>Body text</EuiDescriptionListTitle>
+						<EuiDescriptionListDescription>
+							<article dangerouslySetInnerHTML={{ __html: safeBodyText }} />
+						</EuiDescriptionListDescription>
+					</>
+				)}
+			</EuiDescriptionList>
 		</Fragment>
 	);
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Now we're getting more wires in, there are a lot of entries that don't have fields like bylines. We've also got quite a lot of records with `keywords: [""]`, which was getting rendered as a single empty keyword badge.

* Refactor to use JSX components directly as children, to make conditional rendering logic more familiar.
* Do some checks on the presence of fields before trying to render them.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
