### PR TITLE
Dedupe keywords and handle edge cases

### DIFF
--- a/ingestion-lambda/src/handler.test.ts
+++ b/ingestion-lambda/src/handler.test.ts
@@ -1,5 +1,40 @@
-describe('1+1', () => {
-	it('should be equal to 2', () => {
-		expect(1 + 1).toBe(2);
+import { processKeywords } from './handler';
+
+describe('processKeywords', () => {
+	it('should return an empty array if provided with `undefined`', () => {
+		expect(
+			Array.isArray(processKeywords(undefined)) &&
+				processKeywords(undefined).length === 0,
+		).toBe(true);
+	});
+
+	it('should return an array of keywords if provided with a string', () => {
+		expect(processKeywords('keyword1+keyword2')).toEqual([
+			'keyword1',
+			'keyword2',
+		]);
+	});
+
+	it('should remove duplicates from the array', () => {
+		expect(processKeywords('keyword1+keyword1')).toEqual(['keyword1']);
+	});
+
+	it('should handle empty strings', () => {
+		expect(processKeywords('')).toEqual([]);
+		expect(processKeywords('+')).toEqual([]);
+	});
+
+	it('should strip leading and trailing whitespace', () => {
+		expect(processKeywords(' keyword1 + keyword2 ')).toEqual([
+			'keyword1',
+			'keyword2',
+		]);
+	});
+
+	it('should not remove whitespace within keywords', () => {
+		expect(processKeywords('keyword 1+keyword 2')).toEqual([
+			'keyword 1',
+			'keyword 2',
+		]);
 	});
 });

--- a/ingestion-lambda/src/handler.ts
+++ b/ingestion-lambda/src/handler.ts
@@ -45,6 +45,17 @@ const safeBodyParse = (body: string): any => {
 	}
 };
 
+export const processKeywords = (keywords: string | undefined): string[] => {
+	if (keywords === undefined) {
+		return [];
+	}
+	const keywordsArray = keywords
+		.split('+')
+		.map((keyword) => keyword.trim())
+		.filter((keyword) => keyword.length > 0);
+	return [...new Set(keywordsArray)]; // remove duplicates
+};
+
 export const main = async (event: SQSEvent): Promise<SQSBatchResponse> => {
 	const records = event.Records;
 
@@ -89,7 +100,7 @@ export const main = async (event: SQSEvent): Promise<SQSBatchResponse> => {
 							? snsMessageContent
 							: {
 									...snsMessageContent,
-									keywords: snsMessageContent.keywords?.split('+') ?? [], // re-write the keywords field as an array
+									keywords: processKeywords(snsMessageContent.keywords), // re-write the keywords field as an array
 								};
 
 						await sql`


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

* Deduplicate keywords on ingestion.
* Strip leading and trailing whitespace.
* Don't save empty strings.
* Unit tests for the above.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
