### PR TITLE
load pinboard 📌

### DIFF
--- a/newswires/client/src/main.tsx
+++ b/newswires/client/src/main.tsx
@@ -4,6 +4,13 @@ import { App } from './App.tsx';
 import './icons';
 import { HistoryContextProvider } from './urlState.tsx';
 
+const toolsDomain = window.location.hostname.substring(
+	window.location.hostname.indexOf('.'),
+);
+const script = document.createElement('script');
+script.src = `https://pinboard${toolsDomain}/pinboard.loader.js`;
+document.head.appendChild(script);
+
 createRoot(document.getElementById('root')!).render(
 	<StrictMode>
 		<HistoryContextProvider>


### PR DESCRIPTION
This integrates https://github.com/guardian/pinboard in its current form. This is just the initial integration phase, and hopefully some additional/deeper integrations will follow (mostly on the pinboard side most likely).
![image](https://github.com/user-attachments/assets/9f7109d5-80f7-4f7b-997b-00ce77f8de00)
