### PR TITLE
Set max concurrency for ingestor

### DIFF
--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -655,6 +655,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
           "LogFormat": "JSON",
         },
         "MemorySize": 512,
+        "ReservedConcurrentExecutions": 10,
         "Role": {
           "Fn::GetAtt": [
             "IngestionLambdaTESTServiceRole62DE083D",

--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -81,6 +81,10 @@ export class Newswires extends GuStack {
 				app: 'ingestion-lambda',
 				runtime: Runtime.NODEJS_20_X,
 				handler: 'handler.main',
+				// each execution can handle up to 10 messages, so this is up
+				// to 100 messages in flight; should be more than powerful enough
+				// in high news events
+				reservedConcurrentExecutions: 10,
 				fileName: 'ingestion-lambda.zip',
 				environment: {
 					FEEDS_BUCKET_NAME: feedsBucket.bucketName,


### PR DESCRIPTION


<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

When dumping lots of messages onto the queues at once (eg. redriving the DLQ) we dont want the lambda to spin up hundreds of simultaneous executions... this will overwhelm the database which is bad!

Sets the max concurrency to 10, and since each execution can handle up to 10 messages, this is up-to 100 messages inflight simultaneously which should be more than enough even for redrives!
