### PR TITLE
Add side navigation and resizeable panels

### DIFF
--- a/newswires/app/AppComponents.scala
+++ b/newswires/app/AppComponents.scala
@@ -1,29 +1,24 @@
-import controllers.{
-  AssetsComponents,
-  AuthController,
-  HomeController,
-  ManagementController,
-  QueryController,
-  ViteController
+import com.amazonaws.auth.{
+  AWSCredentialsProviderChain,
+  DefaultAWSCredentialsProviderChain
 }
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
+import com.gu.permissions.{PermissionsConfig, PermissionsProvider}
+import conf.Database
+import controllers._
+import lib.RequestLoggingFilter
 import play.api.ApplicationLoader.Context
+import play.api.http.JsonHttpErrorHandler
+import play.api.libs.ws.ahc.AhcWSComponents
 import play.api.mvc.EssentialFilter
 import play.api.routing.Router
 import play.api.{BuiltInComponentsFromContext, Logging, Mode}
 import play.filters.HttpFiltersComponents
 import play.filters.gzip.GzipFilter
 import router.Routes
-import play.api.libs.ws.ahc.AhcWSComponents
-import com.amazonaws.auth.AWSCredentialsProviderChain
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
-import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
-import com.gu.permissions.PermissionsProvider
-import com.gu.permissions.PermissionsConfig
-import com.amazonaws.regions.Regions
-import conf.Database
-import lib.RequestLoggingFilter
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider
 import software.amazon.awssdk.regions.Region
 import software.amazon.awssdk.services.ssm.SsmClient
@@ -127,6 +122,8 @@ class AppComponents(context: Context)
     permissionsProvider = permissionsProvider,
     panDomainSettings = panDomainSettings
   )
+
+  override lazy val httpErrorHandler = new JsonHttpErrorHandler(environment)
 
   def router: Router = new Routes(
     errorHandler = httpErrorHandler,

--- a/newswires/client/package-lock.json
+++ b/newswires/client/package-lock.json
@@ -12,6 +12,7 @@
 				"@elastic/eui": "95.10.1",
 				"@emotion/css": "11.13.0",
 				"@emotion/react": "11.13.3",
+				"lodash": "4.17.21",
 				"moment": "2.30.1",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",

--- a/newswires/client/package.json
+++ b/newswires/client/package.json
@@ -19,6 +19,7 @@
 		"@elastic/eui": "95.10.1",
 		"@emotion/css": "11.13.0",
 		"@emotion/react": "11.13.3",
+		"lodash": "4.17.21",
 		"moment": "2.30.1",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -3,15 +3,18 @@ import {
 	EuiEmptyPrompt,
 	EuiHeader,
 	EuiHeaderSectionItem,
-	EuiLoadingLogo,
 	EuiPageTemplate,
 	EuiProvider,
+	EuiResizableContainer,
+	EuiShowFor,
+	EuiSpacer,
 	EuiTitle,
 } from '@elastic/eui';
-import '@elastic/eui/dist/eui_theme_light.css';
+import { css } from '@emotion/react';
 import { Feed } from './Feed';
 import { Item } from './Item';
 import { SearchBox } from './SearchBox';
+import { SideNav } from './SideNav';
 import { useSearch } from './useSearch';
 
 export function App() {
@@ -26,7 +29,7 @@ export function App() {
 	} = useSearch();
 
 	const { view, query, itemId: selectedItemId } = config;
-	const { successfulQueryHistory, status, queryData } = state;
+	const { successfulQueryHistory, status } = state;
 
 	return (
 		<EuiProvider colorMode="light">
@@ -46,12 +49,17 @@ export function App() {
 						}
 					}
 				}}
+				css={css`
+					max-height: 100vh;
+				`}
 			>
 				<EuiHeader position="fixed">
 					<EuiHeaderSectionItem>
 						<EuiTitle size={'s'}>
 							<h1>Newswires</h1>
 						</EuiTitle>
+						<EuiSpacer size={'s'} />
+						<SideNav />
 					</EuiHeaderSectionItem>
 					<EuiHeaderSectionItem>
 						<SearchBox
@@ -62,6 +70,49 @@ export function App() {
 						/>
 					</EuiHeaderSectionItem>
 				</EuiHeader>
+				{status !== 'error' && (
+					<>
+						<EuiShowFor sizes={['xs', 's']}>
+							{view !== 'item' && status == 'success' && <Feed />}
+							{view == 'item' && <Item id={selectedItemId} />}
+							{view !== 'item' && status == 'loading' && (
+								<EuiEmptyPrompt
+									body={<p>Loading</p>}
+									iconType={'clock'}
+									color="subdued"
+									layout="horizontal"
+									titleSize="s"
+								/>
+							)}
+						</EuiShowFor>
+						<EuiShowFor sizes={['m', 'l', 'xl']}>
+							{view !== 'item' && <Feed />}
+							{view == 'item' && (
+								<EuiResizableContainer className="eui-fullHeight">
+									{(EuiResizablePanel, EuiResizableButton) => (
+										<>
+											<EuiResizablePanel
+												minSize="25%"
+												initialSize={100}
+												className="eui-yScroll"
+											>
+												<Feed />
+											</EuiResizablePanel>
+											<EuiResizableButton />
+											<EuiResizablePanel
+												minSize="30%"
+												initialSize={100}
+												className="eui-yScroll"
+											>
+												<Item id={selectedItemId} />
+											</EuiResizablePanel>
+										</>
+									)}
+								</EuiResizableContainer>
+							)}
+						</EuiShowFor>
+					</>
+				)}
 				{status == 'error' && (
 					<EuiEmptyPrompt
 						actions={[
@@ -80,14 +131,6 @@ export function App() {
 						hasBorder={true}
 					/>
 				)}
-				{status == 'loading' && (
-					<EuiEmptyPrompt
-						icon={<EuiLoadingLogo logo="clock" size="l" />}
-						title={<h2>Loading Wires</h2>}
-					/>
-				)}{' '}
-				{status == 'success' && <Feed items={queryData.results} />}
-				{view == 'item' && <Item id={selectedItemId} />}
 			</EuiPageTemplate>
 		</EuiProvider>
 	);

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -73,21 +73,10 @@ export function App() {
 				{status !== 'error' && (
 					<>
 						<EuiShowFor sizes={['xs', 's']}>
-							{view !== 'item' && status == 'success' && <Feed />}
-							{view == 'item' && <Item id={selectedItemId} />}
-							{view !== 'item' && status == 'loading' && (
-								<EuiEmptyPrompt
-									body={<p>Loading</p>}
-									iconType={'clock'}
-									color="subdued"
-									layout="horizontal"
-									titleSize="s"
-								/>
-							)}
+							{view === 'item' ? <Item id={selectedItemId} /> : <Feed />}
 						</EuiShowFor>
 						<EuiShowFor sizes={['m', 'l', 'xl']}>
-							{view !== 'item' && <Feed />}
-							{view == 'item' && (
+							{view === 'item' ? (
 								<EuiResizableContainer className="eui-fullHeight">
 									{(EuiResizablePanel, EuiResizableButton) => (
 										<>
@@ -109,6 +98,8 @@ export function App() {
 										</>
 									)}
 								</EuiResizableContainer>
+							) : (
+								<Feed />
 							)}
 						</EuiShowFor>
 					</>

--- a/newswires/client/src/Feed.tsx
+++ b/newswires/client/src/Feed.tsx
@@ -1,11 +1,21 @@
-import { EuiEmptyPrompt, EuiPageTemplate } from '@elastic/eui';
-import type { WireData } from './sharedTypes';
+import { EuiEmptyPrompt, EuiLoadingLogo, EuiPageTemplate } from '@elastic/eui';
+import { useSearch } from './useSearch';
 import { WireItemTable } from './WireItemTable';
 
-export const Feed = ({ items }: { items: WireData[] }) => {
+export const Feed = () => {
+	const { state } = useSearch();
+
+	const { status, queryData } = state;
+
 	return (
 		<EuiPageTemplate.Section>
-			{items.length === 0 && (
+			{status == 'loading' && (
+				<EuiEmptyPrompt
+					icon={<EuiLoadingLogo logo="clock" size="l" />}
+					title={<h2>Loading Wires</h2>}
+				/>
+			)}
+			{status == 'success' && queryData.results.length === 0 && (
 				<EuiEmptyPrompt
 					body={<p>Try a different search term</p>}
 					color="subdued"
@@ -14,8 +24,9 @@ export const Feed = ({ items }: { items: WireData[] }) => {
 					titleSize="s"
 				/>
 			)}
-
-			{items.length > 0 && <WireItemTable wires={items} />}
+			{status == 'success' && queryData.results.length > 0 && (
+				<WireItemTable wires={queryData.results} />
+			)}
 		</EuiPageTemplate.Section>
 	);
 };

--- a/newswires/client/src/Item.tsx
+++ b/newswires/client/src/Item.tsx
@@ -12,7 +12,7 @@ import {
 	EuiTitle,
 	useGeneratedHtmlId,
 } from '@elastic/eui';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { type WireData, WireDataSchema } from './sharedTypes';
 import { useSearch } from './useSearch';
 import { WireDetail } from './WireDetail';
@@ -23,7 +23,7 @@ export const Item = ({ id }: { id: string }) => {
 	const [itemData, setItemData] = useState<WireData | undefined>(undefined);
 	const [error, setError] = useState<string | undefined>(undefined);
 
-	const currentUrl = useMemo(() => window.location.href, []);
+	const currentUrl = window.location.href;
 	const [isShowingJson, setIsShowingJson] = useState<boolean>(false);
 
 	const pushedFlyoutTitleId = useGeneratedHtmlId({

--- a/newswires/client/src/Item.tsx
+++ b/newswires/client/src/Item.tsx
@@ -1,16 +1,18 @@
 import {
 	EuiButton,
-	EuiFlyout,
-	EuiFlyoutBody,
-	EuiFlyoutFooter,
+	EuiButtonIcon,
+	EuiCopy,
+	EuiFlexGroup,
+	EuiFlexItem,
+	EuiHorizontalRule,
 	EuiPageTemplate,
 	EuiSpacer,
+	EuiSplitPanel,
 	EuiSwitch,
 	EuiTitle,
 	useGeneratedHtmlId,
 } from '@elastic/eui';
-import { css } from '@emotion/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { type WireData, WireDataSchema } from './sharedTypes';
 import { useSearch } from './useSearch';
 import { WireDetail } from './WireDetail';
@@ -20,6 +22,8 @@ export const Item = ({ id }: { id: string }) => {
 
 	const [itemData, setItemData] = useState<WireData | undefined>(undefined);
 	const [error, setError] = useState<string | undefined>(undefined);
+
+	const currentUrl = useMemo(() => window.location.href, []);
 	const [isShowingJson, setIsShowingJson] = useState<boolean>(false);
 
 	const pushedFlyoutTitleId = useGeneratedHtmlId({
@@ -60,45 +64,79 @@ export const Item = ({ id }: { id: string }) => {
 	}, [id]);
 
 	return (
-		<EuiPageTemplate.Section>
+		<EuiSplitPanel.Outer>
 			{error && (
 				<EuiPageTemplate.EmptyPrompt>
 					<p>{error}</p>
 				</EuiPageTemplate.EmptyPrompt>
 			)}
 			{itemData && (
-				<EuiFlyout
-					type="push"
-					size="m"
-					onClose={() => handleDeselectItem()}
-					closeButtonProps={{
-						'aria-label': 'Close wire detail',
-						autoFocus: true,
-					}}
-					aria-labelledby={pushedFlyoutTitleId}
-				>
-					<EuiFlyoutBody>
-						<EuiTitle size="s">
-							<h2 id={pushedFlyoutTitleId}>{itemData.content.headline}</h2>
-						</EuiTitle>
+				<>
+					<EuiSplitPanel.Inner>
+						<EuiFlexGroup justifyContent="spaceBetween" alignItems="center">
+							<EuiButtonIcon
+								iconType="arrowLeft"
+								onClick={handleDeselectItem}
+							/>
+							<EuiFlexGroup justifyContent="flexEnd" alignItems="center">
+								<EuiButtonIcon
+									iconType={'launch'}
+									aria-label="send to composer"
+									size="s"
+								/>
+								<EuiButtonIcon iconType={'heart'} aria-label="save" size="s" />
+								<CopyButton textToCopy={currentUrl} />
+							</EuiFlexGroup>
+						</EuiFlexGroup>
+						<EuiHorizontalRule margin="s" />
+						<EuiFlexGroup justifyContent="spaceBetween">
+							<EuiFlexItem grow={true}>
+								<EuiTitle size="xs">
+									<h2 id={pushedFlyoutTitleId}>{itemData.content.headline}</h2>
+								</EuiTitle>
+							</EuiFlexItem>
+						</EuiFlexGroup>
 						<EuiSpacer size="xs" />
 						<WireDetail wire={itemData} isShowingJson={isShowingJson} />
-					</EuiFlyoutBody>
-					<EuiFlyoutFooter
-						css={css`
-							display: flex;
-							justify-content: space-between;
-						`}
-					>
-						<EuiButton onClick={() => handleDeselectItem()}>Close</EuiButton>
-						<EuiSwitch
-							label="Show JSON"
-							checked={isShowingJson}
-							onChange={() => setIsShowingJson(!isShowingJson)}
-						/>
-					</EuiFlyoutFooter>
-				</EuiFlyout>
+					</EuiSplitPanel.Inner>
+					<EuiSplitPanel.Inner>
+						<EuiFlexGroup justifyContent="spaceBetween">
+							<EuiButton onClick={() => handleDeselectItem()}>Close</EuiButton>
+							<EuiSwitch
+								label="Show JSON"
+								checked={isShowingJson}
+								onChange={() => setIsShowingJson(!isShowingJson)}
+							/>
+						</EuiFlexGroup>
+					</EuiSplitPanel.Inner>
+				</>
 			)}
-		</EuiPageTemplate.Section>
+		</EuiSplitPanel.Outer>
+	);
+};
+
+const CopyButton = ({ textToCopy }: { textToCopy: string }) => {
+	const [showSuccessIcon, setShowSuccessIcon] = useState(false);
+
+	return (
+		/**
+		 * @todo: work out why EuiToolTip is not working
+		 */
+		<EuiCopy textToCopy={textToCopy}>
+			{(copy) => (
+				<EuiButtonIcon
+					iconType={showSuccessIcon ? 'check' : 'link'}
+					size="s"
+					onClick={() => {
+						copy();
+						setShowSuccessIcon(true);
+						setInterval(() => setShowSuccessIcon(false), 2000);
+					}}
+					aria-label="Copy link to clipboard"
+				>
+					Copy
+				</EuiButtonIcon>
+			)}
+		</EuiCopy>
 	);
 };

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -1,0 +1,105 @@
+import {
+	EuiCollapsibleNav,
+	EuiCollapsibleNavGroup,
+	EuiHeaderSectionItemButton,
+	EuiIcon,
+	EuiListGroup,
+} from '@elastic/eui';
+import { useMemo, useState } from 'react';
+import type { Query } from './sharedTypes';
+import { useSearch } from './useSearch';
+
+interface MenuItem {
+	label: string;
+	query: Query;
+}
+
+export const SideNav = () => {
+	const [navIsOpen, setNavIsOpen] = useState<boolean>(false);
+
+	const { state } = useSearch();
+
+	const searchHistory = state.successfulQueryHistory;
+
+	const searchHistoryItems: MenuItem[] = useMemo(
+		() =>
+			searchHistory.map(({ query, resultsCount }) => ({
+				label: `${query.q} (${resultsCount})`,
+				query,
+			})),
+		[searchHistory],
+	);
+
+	const agencies: MenuItem[] = [
+		{ label: 'All', query: { q: '' } },
+		{ label: 'Reuters', query: { q: 'sourceFeed:Reuters' } },
+		{ label: 'AP', query: { q: 'sourceFeed:AP' } },
+		{ label: 'AFP', query: { q: 'sourceFeed:AFP' } },
+	];
+
+	const savedSearches: MenuItem[] = [
+		{ label: 'My saved search', query: { q: 'sourceFeed:Reuters' } },
+		{ label: 'Another saved search', query: { q: 'sourceFeed:AP' } },
+	];
+
+	return (
+		<>
+			<EuiCollapsibleNav
+				isOpen={navIsOpen}
+				isDocked={true}
+				size={240}
+				button={
+					<EuiHeaderSectionItemButton
+						aria-label="Toggle main navigation"
+						onClick={() => setNavIsOpen((isOpen) => !isOpen)}
+					>
+						<EuiIcon type={'menu'} size="m" aria-hidden="true" />
+					</EuiHeaderSectionItemButton>
+				}
+				onClose={() => setNavIsOpen(false)}
+			>
+				<div>
+					<SearchGroup title="Agencies" items={agencies} />
+					<SearchGroup title="Saved searches" items={savedSearches} />
+					<SearchGroup
+						title="Search history"
+						items={searchHistoryItems}
+						isEmptyMessage="No search history available yet"
+					/>
+				</div>
+			</EuiCollapsibleNav>
+		</>
+	);
+};
+
+const SearchGroup = ({
+	title,
+	items,
+	isEmptyMessage,
+}: {
+	title: string;
+	items: MenuItem[];
+	isEmptyMessage?: string;
+}) => {
+	const { handleEnterQuery } = useSearch();
+
+	const listItems =
+		items.length > 0
+			? items.map(({ label, query }) => ({
+					label: label,
+					onClick: () => handleEnterQuery(query),
+				}))
+			: [{ label: isEmptyMessage ?? 'No items available' }];
+
+	return (
+		<EuiCollapsibleNavGroup title={title}>
+			<EuiListGroup
+				listItems={listItems}
+				maxWidth="none"
+				color="subdued"
+				gutterSize="none"
+				size="s"
+			/>
+		</EuiCollapsibleNavGroup>
+	);
+};

--- a/newswires/client/src/icons.ts
+++ b/newswires/client/src/icons.ts
@@ -6,14 +6,22 @@ import { icon as arrowLeft } from '@elastic/eui/es/components/icon/assets/arrow_
 import { icon as arrowRight } from '@elastic/eui/es/components/icon/assets/arrow_right';
 import { icon as arrowEnd } from '@elastic/eui/es/components/icon/assets/arrowEnd';
 import { icon as arrowStart } from '@elastic/eui/es/components/icon/assets/arrowStart';
+import { icon as boxesHorizontal } from '@elastic/eui/es/components/icon/assets/boxes_horizontal';
+import { icon as boxesVertical } from '@elastic/eui/es/components/icon/assets/boxes_vertical';
 import { icon as check } from '@elastic/eui/es/components/icon/assets/check';
 import { icon as clock } from '@elastic/eui/es/components/icon/assets/clock';
+import { icon as copyClipboard } from '@elastic/eui/es/components/icon/assets/copy_clipboard';
 import { icon as cross } from '@elastic/eui/es/components/icon/assets/cross';
 import { icon as dot } from '@elastic/eui/es/components/icon/assets/dot';
 import { icon as doubleArrowLeft } from '@elastic/eui/es/components/icon/assets/doubleArrowLeft';
 import { icon as empty } from '@elastic/eui/es/components/icon/assets/empty';
 import { icon as faceSad } from '@elastic/eui/es/components/icon/assets/face_sad';
+import { icon as heart } from '@elastic/eui/es/components/icon/assets/heart';
+import { icon as launch } from '@elastic/eui/es/components/icon/assets/launch';
+import { icon as link } from '@elastic/eui/es/components/icon/assets/link';
 import { icon as menu } from '@elastic/eui/es/components/icon/assets/menu';
+import { icon as menuLeft } from '@elastic/eui/es/components/icon/assets/menuLeft';
+import { icon as menuRight } from '@elastic/eui/es/components/icon/assets/menuRight';
 import { icon as refresh } from '@elastic/eui/es/components/icon/assets/refresh';
 import { icon as returnKey } from '@elastic/eui/es/components/icon/assets/return_key';
 import { icon as search } from '@elastic/eui/es/components/icon/assets/search';
@@ -39,4 +47,12 @@ appendIconComponentCache({
 	returnKey,
 	check,
 	refresh,
+	menuRight,
+	menuLeft,
+	boxesVertical,
+	boxesHorizontal,
+	launch,
+	heart,
+	link,
+	copyClipboard,
 });

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -1,6 +1,6 @@
 import type { Config, Query } from './sharedTypes';
 
-const defaultQuery: Query = { q: '' };
+export const defaultQuery: Query = { q: '' };
 
 export const defaultConfig: Config = Object.freeze({
 	view: 'home',


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add a side navigation panel, and rework the feed/item split to use resizeable containers (on desktop)

<img width="1310" alt="image" src="https://github.com/user-attachments/assets/b96d6258-c5ec-46fd-8610-a6dc8e4e5252">

(more images below)

- [Filter & dedupe queries before adding to history](https://github.com/guardian/newswires/pull/51/commits/ba3abd29ea5d7cdfc2d050b45449bf30ccc71945)
- [Use JsonHttpErrorHandler](https://github.com/guardian/newswires/pull/51/commits/bae1c9bc2f631538a94be0efc3512b9d5c915d76)
- [Handle API errors better](https://github.com/guardian/newswires/pull/51/commits/50783c14ec98cd8358001eed4c4d1075251933fc)
- [Add side nav, hide feed for mobile item view](https://github.com/guardian/newswires/pull/51/commits/601b5d02e13becc00ae049e4066a8f0a8f3e2f3d)


## Images

<details>
  <summary>
    Item view (mobile and desktop)
  </summary> 
  <img width="1305" alt="image" src="https://github.com/user-attachments/assets/c7a23723-cb42-47d6-997b-339e77f8e9bb">
<img width="1310" alt="image" src="https://github.com/user-attachments/assets/8afe6cbb-ee34-4f3a-9796-edc54c6a8cd4">
<img width="1311" alt="image" src="https://github.com/user-attachments/assets/26fae97d-149b-4288-a2ec-6416d7037b1d">
</details>

<details>
  <summary>
    Feed view (mobile, desktop, with resizeable sections)
  </summary>
  <img width="1307" alt="image" src="https://github.com/user-attachments/assets/e8ebcf6d-8d85-4e94-875e-e96593bd01aa">
  <img width="1311" alt="image" src="https://github.com/user-attachments/assets/ffc993c3-af78-49dc-9893-49343a9c506f">
</details>


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

