### PR TITLE
ability to filter results by supplier

### DIFF
--- a/db/migrations/V5__supplier_lookup.sql
+++ b/db/migrations/V5__supplier_lookup.sql
@@ -1,0 +1,6 @@
+CREATE TABLE source_feed_to_supplier (
+  source_feed TEXT NOT NULL,
+  supplier TEXT NOT NULL,
+
+  PRIMARY KEY(source_feed, supplier)
+);

--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -21,6 +21,7 @@ class QueryController(
   def query(
       maybeFreeTextQuery: Option[String],
       maybeKeywords: Option[String],
+      maybeSupplier: Option[String],
       maybeBeforeId: Option[Int],
       maybeSinceId: Option[Int]
   ): Action[AnyContent] = AuthAction {
@@ -29,6 +30,7 @@ class QueryController(
         FingerpostWireEntry.query(
           maybeFreeTextQuery,
           maybeKeywords.map(_.split(',').toList),
+          maybeSupplier,
           maybeBeforeId,
           maybeSinceId,
           pageSize = 30

--- a/newswires/app/db/SourceFeedToSupplier.scala
+++ b/newswires/app/db/SourceFeedToSupplier.scala
@@ -1,0 +1,12 @@
+package db
+
+import scalikejdbc.SQLSyntaxSupport
+
+case class SourceFeedToSupplier(
+    sourceFeed: String,
+    supplier: String
+)
+
+object SourceFeedToSupplier extends SQLSyntaxSupport[SourceFeedToSupplier] {
+  val syn = this.syntax("supplier")
+}

--- a/newswires/conf/routes
+++ b/newswires/conf/routes
@@ -8,7 +8,7 @@ GET     /                           controllers.ViteController.index()
 GET     /feed                       controllers.ViteController.index()
 GET     /item/*id                   controllers.ViteController.item(id: String)
 GET     /api/                       controllers.HomeController.index()
-GET     /api/search                 controllers.QueryController.query(q: Option[String], keywords: Option[String], beforeId: Option[Int], sinceId: Option[Int])
+GET     /api/search                 controllers.QueryController.query(q: Option[String], keywords: Option[String], supplier: Option[String], beforeId: Option[Int], sinceId: Option[Int])
 GET     /api/keywords               controllers.QueryController.keywords(inLastHours: Option[Int], limit:Option[Int])
 GET     /api/item/*id               controllers.QueryController.item(id: Int)
 


### PR DESCRIPTION
requires categorisation of suppliers by one form or another: currently we can get there purely by source-feed. further suppliers may require more attributes, if eg. multiple small suppliers share a feed