### PR TITLE
Use EuiCodeBlock for JSON display

### DIFF
--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -1,5 +1,6 @@
 import {
 	EuiBadge,
+	EuiCodeBlock,
 	EuiDescriptionList,
 	EuiDescriptionListDescription,
 	EuiDescriptionListTitle,
@@ -36,15 +37,9 @@ export const WireDetail = ({
 	return (
 		<Fragment>
 			{isShowingJson ? (
-				<div
-					css={css`
-						white-space: pre;
-						font-family: monospace;
-						overflow-x: auto;
-					`}
-				>
+				<EuiCodeBlock language="json">
 					{JSON.stringify(wire.content, null, 2)}
-				</div>
+				</EuiCodeBlock>
 			) : (
 				<>
 					<EuiScreenReaderLive focusRegionOnTextChange>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

`EuiCodeBlock` can do syntax highlighting for us, and applies `pre-wrap` to the JSON text, which imo makes it a little easier to read?

<img width="503" alt="screenshot of formatted text" src="https://github.com/user-attachments/assets/4ec18c3a-72df-4250-8da5-1952d8d3d67f">


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
