### PR TITLE
Prefer slug for cards, fall back to headline

### DIFF
--- a/newswires/client/src/WireItemTable.tsx
+++ b/newswires/client/src/WireItemTable.tsx
@@ -63,6 +63,9 @@ const WireDataRow = ({
 	const theme = useEuiTheme();
 	const primaryBgColor = useEuiBackgroundColor('primary');
 	const accentBgColor = useEuiBackgroundColor('accent');
+
+	const hasSlug = content.slug && content.slug.length > 0;
+
 	return (
 		<EuiTableRow
 			key={id}
@@ -84,11 +87,16 @@ const WireDataRow = ({
 			<EuiTableRowCell valign="baseline">
 				<EuiFlexGroup direction="column" gutterSize="xs">
 					<EuiTitle size="xxs">
-						<h3>{content.headline ?? '<no headline>'}</h3>
+						<h3>
+							{hasSlug && content.slug}
+							{!hasSlug && (content.headline ?? 'No headline')}
+						</h3>
 					</EuiTitle>
-					<EuiText size="xs">
-						<p>{content.subhead}</p>
-					</EuiText>
+					{hasSlug && (
+						<EuiText size="s">
+							<p>{content.headline}</p>
+						</EuiText>
+					)}
 				</EuiFlexGroup>
 			</EuiTableRowCell>
 			<EuiTableRowCell align="right" valign="baseline">

--- a/newswires/client/src/WireItemTable.tsx
+++ b/newswires/client/src/WireItemTable.tsx
@@ -88,8 +88,7 @@ const WireDataRow = ({
 				<EuiFlexGroup direction="column" gutterSize="xs">
 					<EuiTitle size="xxs">
 						<h3>
-							{hasSlug && content.slug}
-							{!hasSlug && (content.headline ?? 'No headline')}
+							{hasSlug ? content.slug : (content.headline ?? 'No headline')}
 						</h3>
 					</EuiTitle>
 					{hasSlug && (


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Request from @KarenFrankel9 to put 'slug' field first in the wire cards, with `headline` as a fallback. Headline is displayed as the secondary line, unless it's used for the first line.

This resolves an issue where there were frequent cards with no heading at all. We also discussed whether it would make sense to put the headline first for some agencies, and the slug first for others. Should be easy to experiment with as we go.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->


## Images

<img width="1227" alt="image" src="https://github.com/user-attachments/assets/3ebed2a4-2056-479b-92c2-8bb24fa4937f">


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
