### PR TITLE
Richer search UI in sidebar

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -15,6 +15,7 @@ import { Feed } from './Feed';
 import { Item } from './Item';
 import { SearchBox } from './SearchBox';
 import { SideNav } from './SideNav';
+import { defaultQuery } from './urlState';
 import { useSearch } from './useSearch';
 
 export function App() {
@@ -111,7 +112,7 @@ export function App() {
 								Retry
 							</EuiButton>,
 							<EuiButton
-								onClick={() => handleEnterQuery({ q: '' })}
+								onClick={() => handleEnterQuery(defaultQuery)}
 								key="clear"
 								iconType={'cross'}
 							>

--- a/newswires/client/src/SearchBox.tsx
+++ b/newswires/client/src/SearchBox.tsx
@@ -1,35 +1,21 @@
-import {
-	EuiBadge,
-	EuiButton,
-	EuiButtonEmpty,
-	EuiFieldSearch,
-	EuiListGroup,
-	EuiPopover,
-	EuiText,
-} from '@elastic/eui';
+import { EuiFieldSearch } from '@elastic/eui';
 import { useMemo, useState } from 'react';
 import { debounce } from './debounce';
 import type { Query } from './sharedTypes';
-import { paramsToQuerystring } from './urlState';
-import type { SearchHistory } from './useSearch';
+import { type SearchHistory, useSearch } from './useSearch';
 
 export function SearchBox({
 	initialQuery,
 	update,
-	searchHistory,
 	incremental = false,
 }: {
 	initialQuery: Query;
-	update: (newQuery: Query) => void;
+	update: (query: Query) => void;
 	searchHistory: SearchHistory;
 	incremental?: boolean;
 }) {
+	const { config } = useSearch();
 	const [freeTextQuery, setFreeTextQuery] = useState<string>(initialQuery.q);
-	const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-
-	const onButtonClick = () =>
-		setIsPopoverOpen((isPopoverOpen) => !isPopoverOpen);
-	const closePopover = () => setIsPopoverOpen(false);
 
 	const debouncedUpdate = useMemo(() => debounce(update, 750), [update]);
 
@@ -37,7 +23,7 @@ export function SearchBox({
 		<form
 			onSubmit={(e) => {
 				e.preventDefault();
-				update({ q: freeTextQuery });
+				update({ ...config.query, q: freeTextQuery });
 			}}
 		>
 			<EuiFieldSearch
@@ -46,48 +32,10 @@ export function SearchBox({
 					const newQuery = e.target.value;
 					setFreeTextQuery(newQuery);
 					if (incremental) {
-						debouncedUpdate({ q: newQuery });
+						debouncedUpdate({ ...config.query, q: newQuery });
 					}
 				}}
 				aria-label="search wires"
-				append={
-					<EuiPopover
-						button={
-							<EuiButtonEmpty
-								iconType="clock"
-								iconSide="right"
-								onClick={onButtonClick}
-								aria-label="search history"
-							/>
-						}
-						isOpen={isPopoverOpen}
-						closePopover={closePopover}
-					>
-						{searchHistory.length === 0 ? (
-							<EuiText color="subdued">No search history</EuiText>
-						) : (
-							<EuiListGroup>
-								{searchHistory.map(({ query, resultsCount }) => (
-									<EuiButton
-										onClick={() => {
-											update(query);
-											closePopover();
-										}}
-										key={paramsToQuerystring(query)}
-									>
-										{paramsToQuerystring(query)}{' '}
-										<EuiBadge
-											color={resultsCount > 0 ? 'success' : 'text'}
-											aria-label={`${resultsCount} results`}
-										>
-											{resultsCount}
-										</EuiBadge>
-									</EuiButton>
-								))}
-							</EuiListGroup>
-						)}
-					</EuiPopover>
-				}
 			/>
 		</form>
 	);

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -50,7 +50,7 @@ export const SideNav = () => {
 			if (activeSuppliers.length === 0) {
 				handleEnterQuery({
 					...config.query,
-					supplier: recognisedSuppliers.filter((s) => s !== supplier),
+					supplier: [supplier],
 				});
 				return;
 			}

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -1,47 +1,93 @@
 import {
+	EuiBadge,
+	EuiBadgeGroup,
 	EuiCollapsibleNav,
 	EuiCollapsibleNavGroup,
 	EuiHeaderSectionItemButton,
 	EuiIcon,
 	EuiListGroup,
+	EuiListGroupItem,
+	EuiText,
 } from '@elastic/eui';
-import { useMemo, useState } from 'react';
+import { css } from '@emotion/react';
+import { useCallback, useMemo, useState } from 'react';
+import { brandColours } from './sharedStyles';
 import type { Query } from './sharedTypes';
 import { useSearch } from './useSearch';
 
-interface MenuItem {
-	label: string;
-	query: Query;
+function decideLabelForQueryBadge(query: Query): string {
+	const { supplier, q, subject } = query;
+	const supplierLabel = supplier.join(', ');
+	const qLabel = q.length > 0 ? `"${q}"` : '';
+	const subjectLabel = subject.join(', ');
+	const labels = [supplierLabel, qLabel, subjectLabel];
+	return labels.filter((label) => label.length > 0).join(' ');
 }
+
+const recognisedSuppliers = ['REUTERS', 'AP', 'AAP', 'PA'];
 
 export const SideNav = () => {
 	const [navIsOpen, setNavIsOpen] = useState<boolean>(false);
 
-	const { state } = useSearch();
+	const { state, config, handleEnterQuery } = useSearch();
 
 	const searchHistory = state.successfulQueryHistory;
+	const activeSuppliers = config.query.supplier;
 
-	const searchHistoryItems: MenuItem[] = useMemo(
+	const searchHistoryItems = useMemo(
 		() =>
-			searchHistory.map(({ query, resultsCount }) => ({
-				label: `${query.q} (${resultsCount})`,
+			searchHistory.slice(1).map(({ query, resultsCount }) => ({
+				label: decideLabelForQueryBadge(query),
 				query,
+				resultsCount,
 			})),
 		[searchHistory],
 	);
 
-	const agencies: MenuItem[] = [
-		{ label: 'All', query: { q: '' } },
-		{ label: 'Reuters', query: { q: '', supplier: ['REUTERS'] } },
-		{ label: 'AP', query: { q: '', supplier: ['AP'] } },
-		{ label: 'PA', query: { q: '', supplier: ['PA'] } },
-		{ label: 'AAP', query: { q: '', supplier: ['AAP'] } },
-	];
+	const toggleSupplier = useCallback(
+		(supplier: string) => {
+			// If 'activeSuppliers' is empty, that means that *all* suppliers are active.
+			if (activeSuppliers.length === 0) {
+				handleEnterQuery({
+					...config.query,
+					supplier: recognisedSuppliers.filter((s) => s !== supplier),
+				});
+				return;
+			}
+			const newSuppliers = activeSuppliers.includes(supplier)
+				? activeSuppliers.filter((s) => s !== supplier)
+				: [...activeSuppliers, supplier];
+			handleEnterQuery({
+				...config.query,
+				// if all the suppliers are active, we don't need to specify them in the query
+				supplier: recognisedSuppliers.every((s) => newSuppliers.includes(s))
+					? []
+					: newSuppliers,
+			});
+		},
+		[config.query, handleEnterQuery, activeSuppliers],
+	);
 
-	const savedSearches: MenuItem[] = [
-		{ label: 'My saved search', query: { q: 'sourceFeed:Reuters' } },
-		{ label: 'Another saved search', query: { q: 'sourceFeed:AP' } },
-	];
+	const supplierItems = useMemo(
+		() => [
+			{
+				label: 'All',
+				isActive:
+					activeSuppliers.length === 0 ||
+					activeSuppliers.length === recognisedSuppliers.length,
+				onClick: () => handleEnterQuery({ ...config.query, supplier: [] }),
+				colour: 'black',
+			},
+			...recognisedSuppliers.map((supplier) => ({
+				label: supplier,
+				isActive:
+					activeSuppliers.includes(supplier) || activeSuppliers.length === 0,
+				colour: brandColours.get(supplier) ?? 'black',
+				onClick: () => toggleSupplier(supplier),
+			})),
+		],
+		[activeSuppliers, config.query, handleEnterQuery, toggleSupplier],
+	);
 
 	return (
 		<>
@@ -59,48 +105,129 @@ export const SideNav = () => {
 				}
 				onClose={() => setNavIsOpen(false)}
 			>
-				<div>
-					<SearchGroup title="Agencies" items={agencies} />
-					<SearchGroup title="Saved searches" items={savedSearches} />
-					<SearchGroup
-						title="Search history"
-						items={searchHistoryItems}
-						isEmptyMessage="No search history available yet"
-					/>
-				</div>
+				<EuiCollapsibleNavGroup title={'Suppliers'}>
+					<EuiListGroup
+						maxWidth="none"
+						color="subdued"
+						gutterSize="none"
+						size="s"
+					>
+						{supplierItems.map(({ label, colour, isActive, onClick }) => {
+							return (
+								<EuiListGroupItem
+									key={label}
+									label={label}
+									onClick={onClick}
+									icon={
+										<div
+											css={css`
+												width: 0.5rem;
+												height: 1.5rem;
+												background-color: ${isActive ? colour : 'transparent'};
+											`}
+										/>
+									}
+									aria-current={isActive}
+								/>
+							);
+						})}
+					</EuiListGroup>
+				</EuiCollapsibleNavGroup>
+				<EuiCollapsibleNavGroup title={'Search history'}>
+					{searchHistoryItems.length === 0 ? (
+						<EuiText size="s">{'No history yet'}</EuiText>
+					) : (
+						<EuiBadgeGroup color="subdued" gutterSize="s">
+							{searchHistoryItems.map(({ label, query, resultsCount }) => {
+								return (
+									<EuiBadge
+										key={label}
+										color="secondary"
+										onClick={() => {
+											handleEnterQuery(query);
+										}}
+										onClickAriaLabel="Apply filters"
+									>
+										{label}{' '}
+										<EuiBadge color="hollow">
+											{resultsCount === 30 ? '30+' : resultsCount}
+										</EuiBadge>
+									</EuiBadge>
+								);
+							})}
+						</EuiBadgeGroup>
+					)}
+				</EuiCollapsibleNavGroup>
 			</EuiCollapsibleNav>
 		</>
 	);
 };
 
-const SearchGroup = ({
+/** 
+ * Feels worth leaving this code here but commented out for a while.
+ * I wrote it when adding keywords but we're removing this for the time being.
+ * Feels worth having in the code, rather than keeping it in a separate branch, to
+ * make it easier to discover. If it's not been used by, say, the end of October 2024
+ * then let's delete it.
+ * 
+const SingleSearchAsListOfBadges = ({
 	title,
-	items,
-	isEmptyMessage,
+	query,
 }: {
 	title: string;
-	items: MenuItem[];
-	isEmptyMessage?: string;
+	query: Query;
 }) => {
-	const { handleEnterQuery } = useSearch();
-
-	const listItems =
-		items.length > 0
-			? items.map(({ label, query }) => ({
-					label: label,
-					onClick: () => handleEnterQuery(query),
-				}))
-			: [{ label: isEmptyMessage ?? 'No items available' }];
-
 	return (
 		<EuiCollapsibleNavGroup title={title}>
-			<EuiListGroup
-				listItems={listItems}
-				maxWidth="none"
-				color="subdued"
-				gutterSize="none"
-				size="s"
-			/>
+			<SearchQueryBadges query={query} />
 		</EuiCollapsibleNavGroup>
 	);
 };
+
+const SearchQueryBadges = ({ query }: { query: Query }) => {
+	const { handleEnterQuery } = useSearch();
+	const { q, subject } = query;
+
+	if (q.length === 0 && subject.length === 0) {
+		return <EuiText size="s">No filters applied</EuiText>;
+	}
+
+	return (
+		<EuiFlexGroup wrap responsive={false} gutterSize="s">
+			{q.length > 0 && (
+				<EuiFlexItem grow={false}>
+					<EuiBadge
+						color="secondary"
+						iconType="cross"
+						iconSide="right"
+						iconOnClick={() => {
+							handleEnterQuery({ ...query, q: '' });
+						}}
+						iconOnClickAriaLabel="Remove text query filter"
+					>
+						{`"${q}"`}
+					</EuiBadge>
+				</EuiFlexItem>
+			)}
+			{subject.map((s) => (
+				<EuiFlexItem grow={false} key={s}>
+					<EuiBadge
+						color="accent"
+						iconType="cross"
+						iconSide="right"
+						iconOnClick={() => {
+							handleEnterQuery({
+								...query,
+								subject: subject.filter((sub) => sub !== s),
+							});
+						}}
+						iconOnClickAriaLabel={`Remove ${s} filter`}
+					>
+						{s}
+					</EuiBadge>
+				</EuiFlexItem>
+			))}
+		</EuiFlexGroup>
+	);
+};
+*/

--- a/newswires/client/src/sharedStyles.tsx
+++ b/newswires/client/src/sharedStyles.tsx
@@ -1,0 +1,13 @@
+export const reutersBrand = '#fb8023';
+export const APBrand = '#eb483b';
+export const AFPBrand = '#325aff';
+export const PABrand = '#6352ba';
+export const AAPBrand = '#013a81';
+
+export const brandColours = new Map<string, string>([
+	['REUTERS', reutersBrand],
+	['AP', APBrand],
+	['AFP', AFPBrand],
+	['PA', PABrand],
+	['AAP', AAPBrand],
+]);

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -44,7 +44,8 @@ export type WiresQueryResponse = z.infer<typeof WiresQueryResponseSchema>;
 
 export const QuerySchema = z.object({
 	q: z.string(),
-	supplier: z.array(z.string()).optional(),
+	supplier: z.array(z.string()),
+	subject: z.array(z.string()),
 });
 
 export type Query = z.infer<typeof QuerySchema>;

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -1,6 +1,11 @@
 import type { Config, Query } from './sharedTypes';
+import { QuerySchema } from './sharedTypes';
 
-export const defaultQuery: Query = { q: '', supplier: [] };
+export const defaultQuery: Query = {
+	q: '',
+	supplier: [],
+	subject: [],
+};
 
 export const defaultConfig: Config = Object.freeze({
 	view: 'home',
@@ -13,16 +18,14 @@ export function urlToConfig(location: {
 	search: string;
 }): Config {
 	const page = location.pathname.slice(1);
+
 	const urlSearchParams = new URLSearchParams(location.search);
-	const queryString = urlSearchParams.get('q');
-	const supplier = urlSearchParams.getAll('supplier');
-	const query: Query = {
-		q:
-			typeof queryString === 'string' || typeof queryString === 'number'
-				? queryString.toString()
-				: '',
-		supplier,
-	};
+
+	const query = QuerySchema.parse({
+		q: urlSearchParams.get('q') ?? '',
+		supplier: urlSearchParams.getAll('supplier'),
+		subject: urlSearchParams.getAll('subject'),
+	});
 
 	if (page === 'feed') {
 		return { view: 'feed', query };
@@ -58,10 +61,11 @@ export const paramsToQuerystring = (
 				const items: Array<[string, string]> = v
 					.filter((i) => typeof i === 'string' && i.trim().length > 0)
 					.map((i) => [k, i.trim()]);
-				return [...acc, ...items];
-			} else {
-				return acc;
+				if (items.length > 0) {
+					return [...acc, ...items];
+				}
 			}
+			return acc;
 		},
 		[],
 	);

--- a/newswires/client/src/useSearch.tsx
+++ b/newswires/client/src/useSearch.tsx
@@ -325,12 +325,13 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 		dispatch({ type: 'ENTER_QUERY' });
 		if (currentConfig.view === 'item') {
 			pushConfigState({
-				view: 'feed',
+				...currentConfig,
 				query,
 			});
 			return;
 		}
 		pushConfigState({
+			...currentConfig,
 			view: 'feed',
 			query,
 		});


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Add supplier filters and search history to the sidebar.
- Add support on the front end for `subject` searches.
- Updating the text search via the UI happens _within_ the selected set of suppliers, now, rather than overwriting the whole query.

<img width="538" alt="image" src="https://github.com/user-attachments/assets/c257903e-9c99-4f26-9fe5-7287237c3f87">


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
