### PR TITLE
Side nav supplier searches

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,6 +63,7 @@ jobs:
           npm ci
           npm run lint:ci
           npm run format:ci
+          npm test
           popd
 
           sbt clean scalafmtCheckAll compile test Debian/packageBin normalisePackageName

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -32,9 +32,10 @@ export const SideNav = () => {
 
 	const agencies: MenuItem[] = [
 		{ label: 'All', query: { q: '' } },
-		{ label: 'Reuters', query: { q: 'sourceFeed:Reuters' } },
-		{ label: 'AP', query: { q: 'sourceFeed:AP' } },
-		{ label: 'AFP', query: { q: 'sourceFeed:AFP' } },
+		{ label: 'Reuters', query: { q: '', supplier: ['REUTERS'] } },
+		{ label: 'AP', query: { q: '', supplier: ['AP'] } },
+		{ label: 'PA', query: { q: '', supplier: ['PA'] } },
+		{ label: 'AAP', query: { q: '', supplier: ['AAP'] } },
 	];
 
 	const savedSearches: MenuItem[] = [

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -44,6 +44,7 @@ export type WiresQueryResponse = z.infer<typeof WiresQueryResponseSchema>;
 
 export const QuerySchema = z.object({
 	q: z.string(),
+	supplier: z.array(z.string()).optional(),
 });
 
 export type Query = z.infer<typeof QuerySchema>;

--- a/newswires/client/src/urlState.test.ts
+++ b/newswires/client/src/urlState.test.ts
@@ -12,7 +12,10 @@ describe('urlToConfig', () => {
 	it('parses querystring into config', () => {
 		const url = makeFakeLocation('/feed?q=abc');
 		const config = urlToConfig(url);
-		expect(config).toEqual({ view: 'feed', query: { q: 'abc' } });
+		expect(config).toEqual({
+			view: 'feed',
+			query: { ...defaultQuery, q: 'abc' },
+		});
 	});
 
 	it('parses empty querystring into default query', () => {
@@ -24,7 +27,7 @@ describe('urlToConfig', () => {
 	it('parses unrecognised path to default config', () => {
 		const url = makeFakeLocation('/doesnt_exist_feed');
 		const config = urlToConfig(url);
-		expect(config).toEqual({ view: 'home', query: { q: '' } });
+		expect(config).toEqual(defaultConfig);
 	});
 
 	it('parses item path into config', () => {
@@ -33,7 +36,16 @@ describe('urlToConfig', () => {
 		expect(config).toEqual({
 			view: 'item',
 			itemId: '123',
-			query: { q: 'abc' },
+			query: { ...defaultQuery, q: 'abc' },
+		});
+	});
+
+	it('can handle multiple suppliers', () => {
+		const url = makeFakeLocation('/feed?q=abc&supplier=AP&supplier=PA');
+		const config = urlToConfig(url);
+		expect(config).toEqual({
+			view: 'feed',
+			query: { q: 'abc', supplier: ['AP', 'PA'] },
 		});
 	});
 });
@@ -72,6 +84,7 @@ describe('configToUrl', () => {
 		const url = configToUrl(config);
 		expect(url).toBe('/item/123?q=abc');
 	});
+
 	it('converts config with many suppliers to querystring', () => {
 		const config = {
 			view: 'item' as const,

--- a/newswires/client/src/urlState.test.ts
+++ b/newswires/client/src/urlState.test.ts
@@ -40,9 +40,12 @@ describe('urlToConfig', () => {
 
 describe('configToUrl', () => {
 	it('converts config to querystring', () => {
-		const config = { view: 'feed', query: { q: 'abc' } } as const;
+		const config = {
+			view: 'feed' as const,
+			query: { q: 'abc', supplier: ['REUTERS'] },
+		};
 		const url = configToUrl(config);
-		expect(url).toBe('/feed?q=abc');
+		expect(url).toBe('/feed?q=abc&supplier=REUTERS');
 	});
 
 	it('converts default query config to empty querystring', () => {
@@ -52,11 +55,32 @@ describe('configToUrl', () => {
 
 	it('converts item config to querystring', () => {
 		const config = {
-			view: 'item',
+			view: 'item' as const,
 			itemId: '123',
-			query: { q: 'abc' },
-		} as const;
+			query: { q: 'abc', supplier: ['REUTERS'] },
+		};
+		const url = configToUrl(config);
+		expect(url).toBe('/item/123?q=abc&supplier=REUTERS');
+	});
+
+	it('converts config with no supplier to querystring', () => {
+		const config = {
+			view: 'item' as const,
+			itemId: '123',
+			query: { q: 'abc', supplier: [] },
+		};
 		const url = configToUrl(config);
 		expect(url).toBe('/item/123?q=abc');
+	});
+	it('converts config with many suppliers to querystring', () => {
+		const config = {
+			view: 'item' as const,
+			itemId: '123',
+			query: { q: 'abc', supplier: ['AP', 'PA', 'REUTERS'] },
+		};
+		const url = configToUrl(config);
+		expect(url).toBe(
+			'/item/123?q=abc&supplier=AP&supplier=PA&supplier=REUTERS',
+		);
 	});
 });

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -1,6 +1,6 @@
 import type { Config, Query } from './sharedTypes';
 
-export const defaultQuery: Query = { q: '' };
+export const defaultQuery: Query = { q: '', supplier: [] };
 
 export const defaultConfig: Config = Object.freeze({
 	view: 'home',
@@ -15,11 +15,13 @@ export function urlToConfig(location: {
 	const page = location.pathname.slice(1);
 	const urlSearchParams = new URLSearchParams(location.search);
 	const queryString = urlSearchParams.get('q');
+	const supplier = urlSearchParams.getAll('supplier');
 	const query: Query = {
 		q:
 			typeof queryString === 'string' || typeof queryString === 'number'
 				? queryString.toString()
 				: '',
+		supplier,
 	};
 
 	if (page === 'feed') {
@@ -49,6 +51,11 @@ export const paramsToQuerystring = (config: Query): string => {
 		Object.entries(config).reduce<Array<[string, string]>>((acc, [k, v]) => {
 			if (typeof v === 'string' && v.trim().length > 0) {
 				return [...acc, [k, v.trim()]];
+			} else if (Array.isArray(v)) {
+				const items: Array<[string, string]> = v
+					.filter((i) => typeof i === 'string' && i.trim().length > 0)
+					.map((i) => [k, i.trim()]);
+				return [...acc, ...items];
 			} else {
 				return acc;
 			}

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -47,8 +47,8 @@ export const configToUrl = (config: Config): string => {
 };
 
 export const paramsToQuerystring = (config: Query): string => {
-	const params = Object.fromEntries(
-		Object.entries(config).reduce<Array<[string, string]>>((acc, [k, v]) => {
+	const params = Object.entries(config).reduce<Array<[string, string]>>(
+		(acc, [k, v]) => {
 			if (typeof v === 'string' && v.trim().length > 0) {
 				return [...acc, [k, v.trim()]];
 			} else if (Array.isArray(v)) {
@@ -59,7 +59,8 @@ export const paramsToQuerystring = (config: Query): string => {
 			} else {
 				return acc;
 			}
-		}, []),
+		},
+		[],
 	);
 	const querystring = new URLSearchParams(params).toString();
 	return querystring.length !== 0 ? `?${querystring}` : '';


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates the Query type, and the URLs that the currently hardcoded side navs link to, to match the new supplier searches added in #60 
