### PR TITLE
use websearch_to_tsquery for textsearch

### DIFF
--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -137,7 +137,7 @@ object FingerpostWireEntry extends SQLSyntaxSupport[FingerpostWireEntry] {
             .toString()}::jsonb"""
       ),
       maybeFreeTextQuery.map(query =>
-        sqls"phraseto_tsquery($query) @@ ${FingerpostWireEntry.syn.column("combined_textsearch")}"
+        sqls"websearch_to_tsquery('english', $query) @@ ${FingerpostWireEntry.syn.column("combined_textsearch")}"
       ),
       sourceFeedsQuery
     ).flatten


### PR DESCRIPTION
Also clearly parse querytext as English

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

`phraseto_tsquery` parses the query text with the same idea as googling, or github searching with double quotes around the text - ie. looks for runs of the same words, not just a document which contains each word somewhere, even if there's little or no relation between them. 

`websearch_to_tsquery` parses queries in a similar manner as users familiar with Google would expect - double quotes for phrase searches (as above), `-` for negative searches, and even respects `or` as a keyword for optional searches.
