### PR TITLE
include panda-session for automatic session refreshes

### DIFF
--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -24,7 +24,7 @@ class QueryController(
       suppliers: List[String],
       maybeBeforeId: Option[Int],
       maybeSinceId: Option[Int]
-  ): Action[AnyContent] = AuthAction {
+  ): Action[AnyContent] = apiAuthAction {
 
     Ok(
       Json.toJson(
@@ -43,7 +43,7 @@ class QueryController(
   def keywords(
       maybeInLastHours: Option[Int],
       maybeLimit: Option[Int]
-  ): Action[AnyContent] = AuthAction {
+  ): Action[AnyContent] = apiAuthAction {
     val results = FingerpostWireEntry.getKeywords(maybeInLastHours, maybeLimit)
     Ok(Json.toJson(results))
   }

--- a/newswires/client/.eslintrc.cjs
+++ b/newswires/client/.eslintrc.cjs
@@ -34,6 +34,14 @@ module.exports = {
 		],
 		'prettier/prettier': 'warn',
 		'react/no-unknown-property': ['error', { ignore: ['css'] }],
+		'no-restricted-syntax': [
+			'error',
+			{
+				message:
+					"Don't use `fetch` directly, please use the `pandaFetch` abstraction, to get automatic session refreshes",
+				selector: "CallExpression[callee.name='fetch']",
+			},
+		],
 	},
 	settings: {
 		react: {

--- a/newswires/client/src/Item.tsx
+++ b/newswires/client/src/Item.tsx
@@ -13,6 +13,7 @@ import {
 	useGeneratedHtmlId,
 } from '@elastic/eui';
 import { useEffect, useState } from 'react';
+import { pandaFetch } from './panda-session';
 import { type WireData, WireDataSchema } from './sharedTypes';
 import { useSearch } from './useSearch';
 import { WireDetail } from './WireDetail';
@@ -32,7 +33,7 @@ export const Item = ({ id }: { id: string }) => {
 
 	useEffect(() => {
 		// fetch item data from /api/item/:id
-		fetch(`/api/item/${id}`)
+		pandaFetch(`/api/item/${id}`)
 			.then((res) => {
 				if (res.status === 404) {
 					throw new Error('Item not found');

--- a/newswires/client/src/panda-session.ts
+++ b/newswires/client/src/panda-session.ts
@@ -1,0 +1,16 @@
+/* eslint-disable no-restricted-syntax -- this file provides the abstraction over `fetch`, so is allowed to call it directly */
+
+/**
+ * A customised version of `fetch`, that will attempt to re-auth the user on login failure.
+ */
+export const pandaFetch: typeof fetch = async (...args) => {
+	const response = await fetch(...args);
+	if (response.status !== 419)
+		// succeeded; return the response
+		return response;
+
+	// refresh the auth session
+	await fetch('/', { mode: 'no-cors', credentials: 'include' });
+	// reattempt the fetch, return the result no matter the expiry
+	return fetch(...args);
+};

--- a/newswires/client/src/useSearch.tsx
+++ b/newswires/client/src/useSearch.tsx
@@ -9,6 +9,7 @@ import {
 	useState,
 } from 'react';
 import { z } from 'zod';
+import { pandaFetch } from './panda-session';
 import type { Config, Query, WiresQueryResponse } from './sharedTypes';
 import {
 	ConfigSchema,
@@ -187,7 +188,7 @@ function reducer(state: State, action: Action): State {
 
 async function fetchResults(query: Query): Promise<WiresQueryResponse> {
 	const queryString = paramsToQuerystring(query);
-	const response = await fetch(`/api/search${queryString}`, {
+	const response = await pandaFetch(`/api/search${queryString}`, {
 		headers: {
 			Accept: 'application/json',
 		},


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Brings in panda-session so we can get automated session refreshes and keep wires users wiring for longer