### PR TITLE
drop now-unnecessary trigram indexes

### DIFF
--- a/db/migrations/V6__drop_trigram_indices.sql
+++ b/db/migrations/V6__drop_trigram_indices.sql
@@ -1,0 +1,13 @@
+-- These indexes were added to support some initial, pg_trgm based
+-- text searches. These have been replaces by the tsvector searches
+-- in operation now.
+
+DROP INDEX headline_trgm_index;
+
+DROP INDEX subhead_trgm_index;
+
+DROP INDEX keywords_trgm_index;
+
+DROP INDEX byline_trgm_index;
+
+DROP INDEX body_text_trgm_index;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Originally added in #19 to quickly allow some sort of text searching without setting up `tsvector` indexes... those are set up and working pretty nicely now, so these indexes should now be unused and so deletable.
