### PR TITLE
Switch db instance storage type to gp3

### DIFF
--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -1319,7 +1319,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
         "Port": "5432",
         "PubliclyAccessible": false,
         "StorageEncrypted": true,
-        "StorageType": "gp2",
+        "StorageType": "gp3",
         "Tags": [
           {
             "Key": "App",

--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -1291,6 +1291,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
         "EnableIAMDatabaseAuthentication": true,
         "Engine": "postgres",
         "EngineVersion": "16.4",
+        "Iops": 3000,
         "MasterUserPassword": {
           "Fn::Join": [
             "",
@@ -1319,6 +1320,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
         "Port": "5432",
         "PubliclyAccessible": false,
         "StorageEncrypted": true,
+        "StorageThroughput": 125,
         "StorageType": "gp3",
         "Tags": [
           {

--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -68,6 +68,8 @@ export class Newswires extends GuStack {
 				// version: PostgresEngineVersion.VER_16, // FIXME temporary, until VER_16 defaults to 16.4
 			}),
 			storageType: StorageType.GP3,
+			iops: 3000, // the default for gp3 - not required but nice to declare
+			storageThroughput: 125, // the default for gp3
 			autoMinorVersionUpgrade: false, // FIXME temporary, until rds defaults version 16 to 16.4
 		});
 

--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -22,6 +22,7 @@ import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
 import {
 	DatabaseInstanceEngine,
 	PostgresEngineVersion,
+	StorageType,
 } from 'aws-cdk-lib/aws-rds';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import type { Queue } from 'aws-cdk-lib/aws-sqs';
@@ -66,6 +67,7 @@ export class Newswires extends GuStack {
 				version: PostgresEngineVersion.of('16.4', '16'),
 				// version: PostgresEngineVersion.VER_16, // FIXME temporary, until VER_16 defaults to 16.4
 			}),
+			storageType: StorageType.GP3,
 			autoMinorVersionUpgrade: false, // FIXME temporary, until rds defaults version 16 to 16.4
 		});
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

gp2 has low baseline performance and relies on bursting to keep up with demand. gp3 has a baseline performance equal to gp2's max burst and is cheaper.

If this isn't sufficient, or if increased future usage means we need to scale up, we can look at provisioning the IOPS while on gp3, or moving again to io1 or io2 for further configuration.
