### PR TITLE
try snyk without setting working directory

### DIFF
--- a/.github/workflows/snyk.yaml
+++ b/.github/workflows/snyk.yaml
@@ -9,9 +9,6 @@ on:
 jobs:
   security:
     uses: guardian/.github/.github/workflows/sbt-node-snyk.yml@main
-    defaults:
-      run:
-        working-directory: newswires
     with:
       ORG: guardian
       SKIP_NODE: false


### PR DESCRIPTION
Snyk docs say it should autodetect projects within the first few directories, so maybe we don't even need to specify the projects it should be looking at

Attempt to fix up #58 