### PR TITLE
Parameters to exclude wires categories

### DIFF
--- a/db/migrations/V7__keywords_nonpath_index.sql
+++ b/db/migrations/V7__keywords_nonpath_index.sql
@@ -1,0 +1,9 @@
+-- Supplement the existing keywords_index which uses jsonb_path_ops.
+-- jsonb_path_ops can be used by queries using @> operator,
+-- but cannot be used by they "key-exists operators" ?, ?| and ?&.
+-- We might decide to remove the jsonb_path_ops index in the future,
+-- as these are somewhat duplicated indexes, but the docs do
+-- suggest that a jsonb_path_ops index is more performant.
+
+CREATE INDEX keywords_nonpath_index ON fingerpost_wire_entry
+    USING GIN ((content -> 'keywords') jsonb_ops);

--- a/db/migrations/V8__subject_codes_index.sql
+++ b/db/migrations/V8__subject_codes_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX subject_codes_index ON fingerpost_wire_entry
+  USING GIN ((content->'subjects'->'code') jsonb_ops);

--- a/newswires/app/conf/SourceFeedSupplierMapping.scala
+++ b/newswires/app/conf/SourceFeedSupplierMapping.scala
@@ -86,7 +86,8 @@ object SourceFeedSupplierMapping {
       "PA THE TRUSSELL TRUST",
       "PA UK GOVERNMENT AND PUBLIC SECTOR",
       "PA HSL",
-      "PA JUST GROUP"
+      "PA JUST GROUP",
+      "PA BROOKE ACTION FOR WORKING HORSES AND DONKEYS"
     )
   )
 }

--- a/newswires/app/conf/SourceFeedSupplierMapping.scala
+++ b/newswires/app/conf/SourceFeedSupplierMapping.scala
@@ -84,7 +84,9 @@ object SourceFeedSupplierMapping {
       "PA ROYAL ACADEMY OF ENGINEERING",
       "PA SNAP",
       "PA THE TRUSSELL TRUST",
-      "PA UK GOVERNMENT AND PUBLIC SECTOR"
+      "PA UK GOVERNMENT AND PUBLIC SECTOR",
+      "PA HSL",
+      "PA JUST GROUP"
     )
   )
 }

--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -24,7 +24,7 @@ class QueryController(
       maybeKeywords: Option[String],
       suppliers: List[String],
       maybeBeforeId: Option[Int],
-      maybeSinceId: Option[Int],
+      maybeSinceId: Option[Int]
   ): Action[AnyContent] = apiAuthAction { request: UserRequest[AnyContent] =>
     val queryParams = SearchParams(
       text = maybeFreeTextQuery,

--- a/newswires/app/db/CustomMappers.scala
+++ b/newswires/app/db/CustomMappers.scala
@@ -1,0 +1,38 @@
+package db
+
+import scalikejdbc.Binders
+
+import java.sql.{PreparedStatement, ResultSet}
+
+object CustomMappers {
+
+  // no built-in scala->SQL binding for arrays :(
+  //
+  // https://github.com/scalikejdbc/scalikejdbc/issues/933#issuecomment-412015675
+  implicit val textArray: Binders[List[String]] = {
+    def sqlArrayToStringList(arr: java.sql.Array): List[String] =
+      arr.getArray
+        .asInstanceOf[Array[AnyRef]]
+        .map(_.asInstanceOf[String])
+        .toList
+
+    def fromResultSetIndex(resultSet: ResultSet, i: Int): List[String] =
+      sqlArrayToStringList(resultSet.getArray(i))
+
+    def fromResultSetLabel(resultSet: ResultSet, column: String): List[String] =
+      sqlArrayToStringList(resultSet.getArray(column))
+
+    def prepare(
+        list: List[String]
+    )(statement: PreparedStatement, i: Int): Unit = {
+      val array = statement.getConnection
+        .createArrayOf("text", list.map(_.asInstanceOf[AnyRef]).toArray)
+      statement.setArray(i, array)
+    }
+
+    Binders[List[String]](fromResultSetIndex)(fromResultSetLabel)(
+      prepare
+    )
+  }
+
+}

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -1,6 +1,7 @@
 package db
 
 import conf.SourceFeedSupplierMapping.sourceFeedsFromSupplier
+import play.api.Logging
 import play.api.libs.json._
 import scalikejdbc._
 
@@ -56,7 +57,9 @@ case class FingerpostWireEntry(
     content: FingerpostWire
 )
 
-object FingerpostWireEntry extends SQLSyntaxSupport[FingerpostWireEntry] {
+object FingerpostWireEntry
+    extends SQLSyntaxSupport[FingerpostWireEntry]
+    with Logging {
   implicit val format: OFormat[FingerpostWireEntry] =
     Json.format[FingerpostWireEntry]
 
@@ -78,7 +81,7 @@ object FingerpostWireEntry extends SQLSyntaxSupport[FingerpostWireEntry] {
       rs.long(fm.id),
       rs.string(fm.externalId),
       rs.zonedDateTime(fm.ingestedAt),
-      Json.parse(rs.string(fm.column("content"))).as[FingerpostWire]
+      Json.parse(rs.string(fm.content)).as[FingerpostWire]
     )
 
   private def clamp(low: Int, x: Int, high: Int): Int =
@@ -104,42 +107,86 @@ object FingerpostWireEntry extends SQLSyntaxSupport[FingerpostWireEntry] {
   }
 
   def query(
-      maybeFreeTextQuery: Option[String],
-      maybeKeywords: Option[List[String]],
-      suppliers: List[String],
+      search: SearchParams,
       maybeBeforeId: Option[Int],
       maybeSinceId: Option[Int],
       pageSize: Int = 250
   ): QueryResponse = DB readOnly { implicit session =>
     val effectivePageSize = clamp(0, pageSize, 250)
 
-    val contentCol = FingerpostWireEntry.syn.column("content")
-
     val sourceFeeds =
-      suppliers.flatMap(sourceFeedsFromSupplier(_).getOrElse(Nil))
+      search.suppliersIncl.flatMap(sourceFeedsFromSupplier(_).getOrElse(Nil))
+
+    val sourceFeedsExcl =
+      search.suppliersExcl.flatMap(sourceFeedsFromSupplier(_).getOrElse(Nil))
 
     val sourceFeedsQuery = sourceFeeds match {
       case Nil => None
-      case sourceFeeds =>
+      case _ =>
         Some(
-          sqls.joinWithOr(
-            sourceFeeds.map(sourceFeed =>
-              sqls"upper($contentCol->>'source-feed') = upper($sourceFeed)"
-            ): _*
+          sqls.in(
+            sqls"upper(${syn.content}->>'source-feed')",
+            sourceFeeds.map(feed => sqls"upper($feed)")
           )
         )
     }
 
+    val sourceFeedsExclQuery = sourceFeedsExcl match {
+      case Nil => None
+      case _ =>
+        val se = this.syntax("se")
+        val doesContainFeeds = sqls.in(
+          sqls"upper(${se.content}->>'source-feed')",
+          sourceFeedsExcl.map(feed => sqls"upper($feed)")
+        )
+        // unpleasant, but the sort of trick you need to pull
+        // because "NOT IN (...)" doesn't hit an index.
+        // https://stackoverflow.com/a/19364694
+        Some(
+          sqls"""|NOT EXISTS (
+                 |  SELECT FROM ${FingerpostWireEntry as se}
+                 |  WHERE ${syn.id} = ${se.id}
+                 |    AND $doesContainFeeds
+                 |)""".stripMargin
+        )
+    }
+
+    val keywordsQuery = search.keywordIncl match {
+      case Nil => None
+      case keywords =>
+        val keywordsJsonb = Json.toJson(keywords).toString()
+        Some(
+          sqls"""(${syn.content} -> 'keywords') @> $keywordsJsonb::jsonb"""
+        )
+    }
+
+    val keywordsExclQuery = search.keywordExcl match {
+      case Nil => None
+      case keywords =>
+        val ke = this.syntax("ke")
+        val keywordsJsonb = Json.toJson(keywords).toString()
+        val doesContainKeywords =
+          sqls"(${ke.content}->'keywords') @> $keywordsJsonb::jsonb"
+        // unpleasant, but the kind of trick you need to pull because
+        // NOT [row] @> [list] won't use the index.
+        // https://stackoverflow.com/a/19364694
+        Some(
+          sqls"""|NOT EXISTS (
+                 |  SELECT FROM ${FingerpostWireEntry as ke}
+                 |  WHERE ${syn.id} = ${ke.id}
+                 |    AND $doesContainKeywords
+                 |)""".stripMargin
+        )
+    }
+
     val commonWhereClauses = List(
-      maybeKeywords.map(keywords =>
-        sqls"""($contentCol -> 'keywords') @> ${Json
-            .toJson(keywords)
-            .toString()}::jsonb"""
-      ),
-      maybeFreeTextQuery.map(query =>
+      keywordsQuery,
+      keywordsExclQuery,
+      search.text.map(query =>
         sqls"websearch_to_tsquery('english', $query) @@ ${FingerpostWireEntry.syn.column("combined_textsearch")}"
       ),
-      sourceFeedsQuery
+      sourceFeedsQuery,
+      sourceFeedsExclQuery
     ).flatten
 
     val dataOnlyWhereClauses = List(

--- a/newswires/app/db/SearchParams.scala
+++ b/newswires/app/db/SearchParams.scala
@@ -5,5 +5,7 @@ case class SearchParams(
     keywordIncl: List[String] = Nil,
     keywordExcl: List[String] = Nil,
     suppliersIncl: List[String] = Nil,
-    suppliersExcl: List[String] = Nil
+    suppliersExcl: List[String] = Nil,
+    subjectsIncl: List[String] = Nil,
+    subjectsExcl: List[String] = Nil
 )

--- a/newswires/app/db/SearchParams.scala
+++ b/newswires/app/db/SearchParams.scala
@@ -1,0 +1,9 @@
+package db
+
+case class SearchParams(
+    text: Option[String],
+    keywordIncl: List[String] = Nil,
+    keywordExcl: List[String] = Nil,
+    suppliersIncl: List[String] = Nil,
+    suppliersExcl: List[String] = Nil
+)

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -18,7 +18,7 @@ import { useSearch } from './useSearch';
 
 function decideLabelForQueryBadge(query: Query): string {
 	const { supplier, q } = query;
-	const supplierLabel = supplier?.join(', ') ?? [];
+	const supplierLabel = supplier?.join(', ') ?? '';
 	const qLabel = q.length > 0 ? `"${q}"` : '';
 	const labels = [supplierLabel, qLabel];
 	return labels.filter((label) => label.length > 0).join(' ');

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -7,7 +7,6 @@ import {
 	EuiIcon,
 	EuiListGroup,
 	EuiListGroupItem,
-	EuiScreenReaderOnly,
 	EuiText,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -18,11 +17,10 @@ import type { Query } from './sharedTypes';
 import { useSearch } from './useSearch';
 
 function decideLabelForQueryBadge(query: Query): string {
-	const { supplier, q, subject } = query;
-	const supplierLabel = supplier.join(', ');
+	const { supplier, q } = query;
+	const supplierLabel = supplier?.join(', ') ?? [];
 	const qLabel = q.length > 0 ? `"${q}"` : '';
-	const subjectLabel = subject.join(', ');
-	const labels = [supplierLabel, qLabel, subjectLabel];
+	const labels = [supplierLabel, qLabel];
 	return labels.filter((label) => label.length > 0).join(' ');
 }
 
@@ -34,7 +32,10 @@ export const SideNav = () => {
 	const { state, config, handleEnterQuery } = useSearch();
 
 	const searchHistory = state.successfulQueryHistory;
-	const activeSuppliers = config.query.supplier;
+	const activeSuppliers = useMemo(
+		() => config.query.supplier ?? [],
+		[config.query.supplier],
+	);
 
 	const searchHistoryItems = useMemo(
 		() =>

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -48,6 +48,8 @@ export const QuerySchema = z.object({
 	supplierExcl: z.array(z.string()).optional(),
 	keywords: z.ostring(),
 	keywordsExcl: z.ostring(),
+	subjects: z.ostring(),
+	subjectsExcl: z.ostring(),
 });
 
 export type Query = z.infer<typeof QuerySchema>;

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -44,8 +44,10 @@ export type WiresQueryResponse = z.infer<typeof WiresQueryResponseSchema>;
 
 export const QuerySchema = z.object({
 	q: z.string(),
-	supplier: z.array(z.string()),
-	subject: z.array(z.string()),
+	supplier: z.array(z.string()).optional(),
+	supplierExcl: z.array(z.string()).optional(),
+	keywords: z.ostring(),
+	keywordsExcl: z.ostring(),
 });
 
 export type Query = z.infer<typeof QuerySchema>;

--- a/newswires/client/src/urlState.test.ts
+++ b/newswires/client/src/urlState.test.ts
@@ -62,14 +62,14 @@ describe('urlToConfig', () => {
 	});
 
 	it('can exclude multiple suppliers', () => {
-		const url = makeFakeLocation('/feed?q=abc&supplierExcl=PA');
+		const url = makeFakeLocation('/feed?q=abc&supplierExcl=PA&supplierExcl=AP');
 		const config = urlToConfig(url);
 		expect(config).toEqual({
 			view: 'feed',
 			query: {
 				...defaultQuery,
 				q: 'abc',
-				supplierExcl: ['PA'],
+				supplierExcl: ['PA', 'AP'],
 			},
 		});
 	});

--- a/newswires/client/src/urlState.test.ts
+++ b/newswires/client/src/urlState.test.ts
@@ -45,11 +45,9 @@ describe('urlToConfig', () => {
 		expect(config).toEqual({
 			view: 'feed',
 			query: {
+				...defaultQuery,
 				q: 'abc',
 				supplier: ['AP', 'PA'],
-				supplierExcl: [],
-				keywords: undefined,
-				keywordsExcl: undefined,
 			},
 		});
 	});
@@ -98,6 +96,36 @@ describe('urlToConfig', () => {
 				...defaultQuery,
 				q: 'abc',
 				keywordsExcl: 'Sports,Politics',
+			},
+		});
+	});
+
+	it('can pass subjects', () => {
+		const url = makeFakeLocation(
+			'/feed?q=abc&subjects=medtop%3A08000000%2Cmedtop%3A20001340',
+		);
+		const config = urlToConfig(url);
+		expect(config).toEqual({
+			view: 'feed',
+			query: {
+				...defaultQuery,
+				q: 'abc',
+				subjects: 'medtop:08000000,medtop:20001340',
+			},
+		});
+	});
+
+	it('can exclude subjects', () => {
+		const url = makeFakeLocation(
+			'/feed?q=abc&subjectsExcl=medtop%3A08000000%2Cmedtop%3A20001340',
+		);
+		const config = urlToConfig(url);
+		expect(config).toEqual({
+			view: 'feed',
+			query: {
+				...defaultQuery,
+				q: 'abc',
+				subjectsExcl: 'medtop:08000000,medtop:20001340',
 			},
 		});
 	});
@@ -185,5 +213,27 @@ describe('configToUrl', () => {
 		};
 		const url = configToUrl(config);
 		expect(url).toBe('/feed?q=abc&keywordsExcl=Sports%2CPolitics');
+	});
+
+	it('converts config with many subjects to querystring', () => {
+		const config = {
+			view: 'feed' as const,
+			query: { q: 'abc', subjects: 'medtop:08000000,medtop:20001340' },
+		};
+		const url = configToUrl(config);
+		expect(url).toBe(
+			'/feed?q=abc&subjects=medtop%3A08000000%2Cmedtop%3A20001340',
+		);
+	});
+
+	it('converts config with many excluded subjects to querystring', () => {
+		const config = {
+			view: 'feed' as const,
+			query: { q: 'abc', subjectsExcl: 'medtop:08000000,medtop:20001340' },
+		};
+		const url = configToUrl(config);
+		expect(url).toBe(
+			'/feed?q=abc&subjectsExcl=medtop%3A08000000%2Cmedtop%3A20001340',
+		);
 	});
 });

--- a/newswires/client/src/urlState.test.ts
+++ b/newswires/client/src/urlState.test.ts
@@ -44,7 +44,13 @@ describe('urlToConfig', () => {
 		const config = urlToConfig(url);
 		expect(config).toEqual({
 			view: 'feed',
-			query: { ...defaultQuery, q: 'abc', supplier: ['AP', 'PA'] },
+			query: {
+				q: 'abc',
+				supplier: ['AP', 'PA'],
+				supplierExcl: [],
+				keywords: undefined,
+				keywordsExcl: undefined,
+			},
 		});
 	});
 
@@ -54,6 +60,45 @@ describe('urlToConfig', () => {
 		expect(config).toEqual({
 			view: 'feed',
 			query: { ...defaultQuery, q: 'abc', supplier: [] },
+		});
+	});
+
+	it('can exclude multiple suppliers', () => {
+		const url = makeFakeLocation('/feed?q=abc&supplierExcl=PA');
+		const config = urlToConfig(url);
+		expect(config).toEqual({
+			view: 'feed',
+			query: {
+				...defaultQuery,
+				q: 'abc',
+				supplierExcl: ['PA'],
+			},
+		});
+	});
+
+	it('can pass keywords', () => {
+		const url = makeFakeLocation('/feed?q=abc&keywords=Sports%2CPolitics');
+		const config = urlToConfig(url);
+		expect(config).toEqual({
+			view: 'feed',
+			query: {
+				...defaultQuery,
+				q: 'abc',
+				keywords: 'Sports,Politics',
+			},
+		});
+	});
+
+	it('can exclude keywords', () => {
+		const url = makeFakeLocation('/feed?q=abc&keywordsExcl=Sports%2CPolitics');
+		const config = urlToConfig(url);
+		expect(config).toEqual({
+			view: 'feed',
+			query: {
+				...defaultQuery,
+				q: 'abc',
+				keywordsExcl: 'Sports,Politics',
+			},
 		});
 	});
 });
@@ -111,5 +156,34 @@ describe('configToUrl', () => {
 		expect(url).toBe(
 			'/item/123?q=abc&supplier=AP&supplier=PA&supplier=REUTERS',
 		);
+	});
+
+	it('converts config with many excluded suppliers to querystring', () => {
+		const config = {
+			view: 'feed' as const,
+			query: { q: 'abc', supplierExcl: ['AP', 'PA', 'REUTERS'] },
+		};
+		const url = configToUrl(config);
+		expect(url).toBe(
+			'/feed?q=abc&supplierExcl=AP&supplierExcl=PA&supplierExcl=REUTERS',
+		);
+	});
+
+	it('converts config with many keywords to querystring', () => {
+		const config = {
+			view: 'feed' as const,
+			query: { q: 'abc', keywords: 'Sports,Politics' },
+		};
+		const url = configToUrl(config);
+		expect(url).toBe('/feed?q=abc&keywords=Sports%2CPolitics');
+	});
+
+	it('converts config with many excluded keywords to querystring', () => {
+		const config = {
+			view: 'feed' as const,
+			query: { q: 'abc', keywordsExcl: 'Sports,Politics' },
+		};
+		const url = configToUrl(config);
+		expect(url).toBe('/feed?q=abc&keywordsExcl=Sports%2CPolitics');
 	});
 });

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -1,6 +1,12 @@
 import type { Config, Query } from './sharedTypes';
 
-export const defaultQuery: Query = { q: '', supplier: [], supplierExcl: [] };
+export const defaultQuery: Query = {
+	q: '',
+	supplier: [],
+	supplierExcl: [],
+	keywords: undefined,
+	keywordsExcl: undefined,
+};
 
 export const defaultConfig: Config = Object.freeze({
 	view: 'home',

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -6,6 +6,8 @@ export const defaultQuery: Query = {
 	supplierExcl: [],
 	keywords: undefined,
 	keywordsExcl: undefined,
+	subjects: undefined,
+	subjectsExcl: undefined,
 };
 
 export const defaultConfig: Config = Object.freeze({
@@ -26,6 +28,8 @@ export function urlToConfig(location: {
 	const supplierExcl = urlSearchParams.getAll('supplierExcl');
 	const keywords = urlSearchParams.get('keywords') ?? undefined;
 	const keywordsExcl = urlSearchParams.get('keywordsExcl') ?? undefined;
+	const subjects = urlSearchParams.get('subjects') ?? undefined;
+	const subjectsExcl = urlSearchParams.get('subjectsExcl') ?? undefined;
 	const query: Query = {
 		q:
 			typeof queryString === 'string' || typeof queryString === 'number'
@@ -35,6 +39,8 @@ export function urlToConfig(location: {
 		supplierExcl,
 		keywords,
 		keywordsExcl,
+		subjects,
+		subjectsExcl,
 	};
 
 	if (page === 'feed') {

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -1,11 +1,6 @@
 import type { Config, Query } from './sharedTypes';
-import { QuerySchema } from './sharedTypes';
 
-export const defaultQuery: Query = {
-	q: '',
-	supplier: [],
-	subject: [],
-};
+export const defaultQuery: Query = { q: '', supplier: [], supplierExcl: [] };
 
 export const defaultConfig: Config = Object.freeze({
 	view: 'home',
@@ -20,12 +15,21 @@ export function urlToConfig(location: {
 	const page = location.pathname.slice(1);
 
 	const urlSearchParams = new URLSearchParams(location.search);
-
-	const query = QuerySchema.parse({
-		q: urlSearchParams.get('q') ?? '',
-		supplier: urlSearchParams.getAll('supplier'),
-		subject: urlSearchParams.getAll('subject'),
-	});
+	const queryString = urlSearchParams.get('q');
+	const supplier = urlSearchParams.getAll('supplier');
+	const supplierExcl = urlSearchParams.getAll('supplierExcl');
+	const keywords = urlSearchParams.get('keywords') ?? undefined;
+	const keywordsExcl = urlSearchParams.get('keywordsExcl') ?? undefined;
+	const query: Query = {
+		q:
+			typeof queryString === 'string' || typeof queryString === 'number'
+				? queryString.toString()
+				: '',
+		supplier,
+		supplierExcl,
+		keywords,
+		keywordsExcl,
+	};
 
 	if (page === 'feed') {
 		return { view: 'feed', query };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

As much as you should be able to request to see wires matching suppliers or keywords (and soon subjects), you should _also_ be able to exclude certain suppliers or keywords. 

This is trickier in the DB queries, because postgres seems reluctant or unable to use the indexes that support the positive queries for negative. Thanks to a very handy stack overflow post, there is a trick that allows you to work around this, by querying for the rows which do match the exclusion parameters, then exclude _those_ rows from the real query. Because you're only searching the DB in a positive manner, postgres seems much happier/able to use the indexes for fast querying.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
