### PR TITLE
Put search in side nav

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -13,7 +13,6 @@ import {
 import { css } from '@emotion/react';
 import { Feed } from './Feed';
 import { Item } from './Item';
-import { SearchBox } from './SearchBox';
 import { SideNav } from './SideNav';
 import { defaultQuery } from './urlState';
 import { useSearch } from './useSearch';
@@ -29,8 +28,8 @@ export function App() {
 		handlePreviousItem,
 	} = useSearch();
 
-	const { view, query, itemId: selectedItemId } = config;
-	const { successfulQueryHistory, status } = state;
+	const { view, itemId: selectedItemId } = config;
+	const { status } = state;
 
 	const isPoppedOut = !!window.opener;
 
@@ -64,14 +63,6 @@ export function App() {
 							</EuiTitle>
 							<EuiSpacer size={'s'} />
 							<SideNav />
-						</EuiHeaderSectionItem>
-						<EuiHeaderSectionItem>
-							<SearchBox
-								initialQuery={query}
-								searchHistory={successfulQueryHistory}
-								update={handleEnterQuery}
-								incremental={true}
-							/>
 						</EuiHeaderSectionItem>
 					</EuiHeader>
 				)}

--- a/newswires/client/src/SearchBox.tsx
+++ b/newswires/client/src/SearchBox.tsx
@@ -1,9 +1,9 @@
-import { EuiFieldSearch, EuiForm } from '@elastic/eui';
+import { EuiFieldSearch } from '@elastic/eui';
 import { useMemo, useState } from 'react';
 import { debounce } from './debounce';
 import { useSearch } from './useSearch';
 
-export function SearchBox({ incremental = false }: { incremental?: boolean }) {
+export function SearchBox() {
 	const { config, handleEnterQuery } = useSearch();
 	const [freeTextQuery, setFreeTextQuery] = useState<string>(config.query.q);
 
@@ -13,24 +13,15 @@ export function SearchBox({ incremental = false }: { incremental?: boolean }) {
 	);
 
 	return (
-		<EuiForm
-			onSubmit={(e) => {
-				e.preventDefault();
-				handleEnterQuery({ ...config.query, q: freeTextQuery });
+		<EuiFieldSearch
+			value={freeTextQuery}
+			onChange={(e) => {
+				const newQuery = e.target.value;
+				setFreeTextQuery(newQuery);
+				debouncedUpdate({ ...config.query, q: newQuery });
 			}}
-		>
-			<EuiFieldSearch
-				value={freeTextQuery}
-				onChange={(e) => {
-					const newQuery = e.target.value;
-					setFreeTextQuery(newQuery);
-					if (incremental) {
-						debouncedUpdate({ ...config.query, q: newQuery });
-					}
-				}}
-				aria-label="search wires"
-				style={{ borderRadius: '0', border: 'none' }}
-			/>
-		</EuiForm>
+			aria-label="search wires"
+			style={{ borderRadius: '0', border: 'none' }}
+		/>
 	);
 }

--- a/newswires/client/src/SearchBox.tsx
+++ b/newswires/client/src/SearchBox.tsx
@@ -1,29 +1,22 @@
-import { EuiFieldSearch } from '@elastic/eui';
+import { EuiFieldSearch, EuiForm } from '@elastic/eui';
 import { useMemo, useState } from 'react';
 import { debounce } from './debounce';
-import type { Query } from './sharedTypes';
-import { type SearchHistory, useSearch } from './useSearch';
+import { useSearch } from './useSearch';
 
-export function SearchBox({
-	initialQuery,
-	update,
-	incremental = false,
-}: {
-	initialQuery: Query;
-	update: (query: Query) => void;
-	searchHistory: SearchHistory;
-	incremental?: boolean;
-}) {
-	const { config } = useSearch();
-	const [freeTextQuery, setFreeTextQuery] = useState<string>(initialQuery.q);
+export function SearchBox({ incremental = false }: { incremental?: boolean }) {
+	const { config, handleEnterQuery } = useSearch();
+	const [freeTextQuery, setFreeTextQuery] = useState<string>(config.query.q);
 
-	const debouncedUpdate = useMemo(() => debounce(update, 750), [update]);
+	const debouncedUpdate = useMemo(
+		() => debounce(handleEnterQuery, 750),
+		[handleEnterQuery],
+	);
 
 	return (
-		<form
+		<EuiForm
 			onSubmit={(e) => {
 				e.preventDefault();
-				update({ ...config.query, q: freeTextQuery });
+				handleEnterQuery({ ...config.query, q: freeTextQuery });
 			}}
 		>
 			<EuiFieldSearch
@@ -36,7 +29,8 @@ export function SearchBox({
 					}
 				}}
 				aria-label="search wires"
+				style={{ borderRadius: '0', border: 'none' }}
 			/>
-		</form>
+		</EuiForm>
 	);
 }

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -107,7 +107,7 @@ export const SideNav = () => {
 				}
 				onClose={() => setNavIsOpen(false)}
 			>
-				<SearchBox incremental={true} />
+				<SearchBox />
 				<EuiCollapsibleNavGroup title={'Suppliers'}>
 					<EuiListGroup
 						maxWidth="none"

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -7,10 +7,12 @@ import {
 	EuiIcon,
 	EuiListGroup,
 	EuiListGroupItem,
+	EuiScreenReaderOnly,
 	EuiText,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useCallback, useMemo, useState } from 'react';
+import { SearchBox } from './SearchBox';
 import { brandColours } from './sharedStyles';
 import type { Query } from './sharedTypes';
 import { useSearch } from './useSearch';
@@ -105,6 +107,7 @@ export const SideNav = () => {
 				}
 				onClose={() => setNavIsOpen(false)}
 			>
+				<SearchBox incremental={true} />
 				<EuiCollapsibleNavGroup title={'Suppliers'}>
 					<EuiListGroup
 						maxWidth="none"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Move search bar to side nav
- Refactor `SearchBox` component so that it consumes global values from `useSearch` directly, rather than having them passed as children.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="433" alt="image" src="https://github.com/user-attachments/assets/ccd28e77-ab48-48e6-88d3-bfd4076742e0">


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
