### PR TITLE
add `Popout as ticker` button to search results

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -32,6 +32,8 @@ export function App() {
 	const { view, query, itemId: selectedItemId } = config;
 	const { successfulQueryHistory, status } = state;
 
+	const isPoppedOut = !!window.opener;
+
 	return (
 		<EuiProvider colorMode="light">
 			<EuiPageTemplate
@@ -54,23 +56,25 @@ export function App() {
 					max-height: 100vh;
 				`}
 			>
-				<EuiHeader position="fixed">
-					<EuiHeaderSectionItem>
-						<EuiTitle size={'s'}>
-							<h1>Newswires</h1>
-						</EuiTitle>
-						<EuiSpacer size={'s'} />
-						<SideNav />
-					</EuiHeaderSectionItem>
-					<EuiHeaderSectionItem>
-						<SearchBox
-							initialQuery={query}
-							searchHistory={successfulQueryHistory}
-							update={handleEnterQuery}
-							incremental={true}
-						/>
-					</EuiHeaderSectionItem>
-				</EuiHeader>
+				{!isPoppedOut && (
+					<EuiHeader position="fixed">
+						<EuiHeaderSectionItem>
+							<EuiTitle size={'s'}>
+								<h1>Newswires</h1>
+							</EuiTitle>
+							<EuiSpacer size={'s'} />
+							<SideNav />
+						</EuiHeaderSectionItem>
+						<EuiHeaderSectionItem>
+							<SearchBox
+								initialQuery={query}
+								searchHistory={successfulQueryHistory}
+								update={handleEnterQuery}
+								incremental={true}
+							/>
+						</EuiHeaderSectionItem>
+					</EuiHeader>
+				)}
 				{status !== 'error' && (
 					<>
 						<EuiShowFor sizes={['xs', 's']}>

--- a/newswires/client/src/WireItemTable.tsx
+++ b/newswires/client/src/WireItemTable.tsx
@@ -1,6 +1,8 @@
 import {
+	EuiButton,
 	EuiFlexGroup,
 	euiScreenReaderOnly,
+	EuiSpacer,
 	EuiTable,
 	EuiTableBody,
 	EuiTableHeader,
@@ -22,8 +24,33 @@ export const WireItemTable = ({ wires }: { wires: WireData[] }) => {
 
 	const selectedWireId = config.itemId;
 
+	const isPoppedOut = !!window.opener;
+
 	return (
 		<div>
+			<EuiFlexGroup
+				justifyContent={'center'}
+				css={css`
+					position: sticky;
+					top: 45px;
+				`}
+			>
+				{!isPoppedOut && (
+					<EuiButton
+						iconType={'popout'}
+						onClick={() =>
+							window.open(
+								window.location.href,
+								'_blank',
+								'popout=true,width=400,height=800,top=200,location=no,menubar=no,toolbar=no',
+							)
+						}
+					>
+						Popout as ticker
+					</EuiButton>
+				)}
+			</EuiFlexGroup>
+			<EuiSpacer size="l" />
 			<EuiTable tableLayout="auto">
 				<EuiTableHeader
 					css={css`

--- a/newswires/client/src/icons.ts
+++ b/newswires/client/src/icons.ts
@@ -22,6 +22,7 @@ import { icon as link } from '@elastic/eui/es/components/icon/assets/link';
 import { icon as menu } from '@elastic/eui/es/components/icon/assets/menu';
 import { icon as menuLeft } from '@elastic/eui/es/components/icon/assets/menuLeft';
 import { icon as menuRight } from '@elastic/eui/es/components/icon/assets/menuRight';
+import { icon as popout } from '@elastic/eui/es/components/icon/assets/popout';
 import { icon as refresh } from '@elastic/eui/es/components/icon/assets/refresh';
 import { icon as returnKey } from '@elastic/eui/es/components/icon/assets/return_key';
 import { icon as search } from '@elastic/eui/es/components/icon/assets/search';
@@ -55,4 +56,5 @@ appendIconComponentCache({
 	heart,
 	link,
 	copyClipboard,
+	popout,
 });


### PR DESCRIPTION
Popout tickers are a useful part of the current wires solution, so this PR adds a basic implementation.

## What does this change?
Here we piggy back on the fact newswires works nicely at mobile breakpoints already, and:

- add a new `Popout as ticker` (sticky) button at the top of search results with uses `window.open` (with the `popout=true`) option to (re)open itself in a small popup window (easy thanks to persistent URLs)
- given opening a popup populates the `window.opener` property we can detect whether we're open in a popup and hide the heading bar and the `Popout as ticker` button for more streamlined view.

This solution requires very little extra maintenance (when compared with dedicated components for pop-out ticker).

In future, it would be good to also offer tickers within the main window, perhaps docked to the bottom (a bit like drafting multiple emails in gmail).

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
![ticker](https://github.com/user-attachments/assets/78af4cfa-3273-4fe8-aae4-1290179005f0)


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
