### PR TITLE
Add auto-update toggle switch

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -1,20 +1,24 @@
 import {
 	EuiButton,
 	EuiEmptyPrompt,
+	EuiFlexGroup,
+	EuiFlexItem,
 	EuiHeader,
+	EuiHeaderSection,
 	EuiHeaderSectionItem,
 	EuiPageTemplate,
 	EuiProvider,
 	EuiResizableContainer,
 	EuiShowFor,
 	EuiSpacer,
+	EuiSwitch,
 	EuiTitle,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { Feed } from './Feed';
 import { Item } from './Item';
 import { SideNav } from './SideNav';
-import { defaultQuery } from './urlState';
+import { configToUrl, defaultQuery } from './urlState';
 import { useSearch } from './useSearch';
 
 export function App() {
@@ -26,6 +30,7 @@ export function App() {
 		handleDeselectItem,
 		handleNextItem,
 		handlePreviousItem,
+		toggleAutoUpdate,
 	} = useSearch();
 
 	const { view, itemId: selectedItemId } = config;
@@ -57,12 +62,40 @@ export function App() {
 			>
 				{!isPoppedOut && (
 					<EuiHeader position="fixed">
+						<EuiHeaderSection>
+							<EuiHeaderSectionItem>
+								<EuiTitle
+									size={'s'}
+									css={css`
+										padding-bottom: 3px;
+									`}
+								>
+									<h1>Newswires</h1>
+								</EuiTitle>
+							</EuiHeaderSectionItem>
+							<EuiHeaderSectionItem>
+								<SideNav />
+							</EuiHeaderSectionItem>
+						</EuiHeaderSection>
 						<EuiHeaderSectionItem>
-							<EuiTitle size={'s'}>
-								<h1>Newswires</h1>
-							</EuiTitle>
-							<EuiSpacer size={'s'} />
-							<SideNav />
+							{
+								<EuiButton
+									iconType={'popout'}
+									onClick={() =>
+										window.open(
+											configToUrl({
+												...config,
+												view: 'feed',
+												itemId: undefined,
+											}),
+											'_blank',
+											'popout=true,width=400,height=800,top=200,location=no,menubar=no,toolbar=no',
+										)
+									}
+								>
+									New ticker
+								</EuiButton>
+							}
 						</EuiHeaderSectionItem>
 					</EuiHeader>
 				)}

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -3,11 +3,15 @@ import {
 	EuiBadgeGroup,
 	EuiCollapsibleNav,
 	EuiCollapsibleNavGroup,
+	EuiFlexGroup,
+	EuiFlexItem,
 	EuiHeaderSectionItemButton,
 	EuiIcon,
 	EuiListGroup,
 	EuiListGroupItem,
+	EuiSwitch,
 	EuiText,
+	useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useCallback, useMemo, useState } from 'react';
@@ -38,8 +42,9 @@ function bucketName(bucketId: string): string | undefined {
 
 export const SideNav = () => {
 	const [navIsOpen, setNavIsOpen] = useState<boolean>(false);
+	const theme = useEuiTheme();
 
-	const { state, config, handleEnterQuery } = useSearch();
+	const { state, config, handleEnterQuery, toggleAutoUpdate } = useSearch();
 
 	const searchHistory = state.successfulQueryHistory;
 	const activeSuppliers = useMemo(
@@ -124,7 +129,7 @@ export const SideNav = () => {
 			<EuiCollapsibleNav
 				isOpen={navIsOpen}
 				isDocked={true}
-				size={240}
+				size={300}
 				button={
 					<EuiHeaderSectionItemButton
 						aria-label="Toggle main navigation"
@@ -135,92 +140,104 @@ export const SideNav = () => {
 				}
 				onClose={() => setNavIsOpen(false)}
 			>
-				<SearchBox />
-				<EuiCollapsibleNavGroup title="Buckets">
-					<EuiListGroup
-						maxWidth="none"
-						color="subdued"
-						gutterSize="none"
-						size="s"
-					>
-						{bucketItems.map(({ bucketId, label, isActive, onClick }) => {
-							return (
-								<EuiListGroupItem
-									color={isActive ? 'primary' : 'subdued'}
-									label={label}
-									key={bucketId}
-									aria-current={isActive}
-									onClick={onClick}
-									icon={
-										<div
-											css={css`
-												width: 0.5rem;
-												height: 1.5rem;
-												background-color: ${isActive
-													? '#06eeff'
-													: 'transparent'};
-											`}
-										/>
-									}
-								/>
-							);
-						})}
-					</EuiListGroup>
-				</EuiCollapsibleNavGroup>
-				<EuiCollapsibleNavGroup title={'Suppliers'}>
-					<EuiListGroup
-						maxWidth="none"
-						color="subdued"
-						gutterSize="none"
-						size="s"
-					>
-						{supplierItems.map(({ label, colour, isActive, onClick }) => {
-							return (
-								<EuiListGroupItem
-									color={isActive ? 'primary' : 'subdued'}
-									key={label}
-									label={label}
-									onClick={onClick}
-									icon={
-										<div
-											css={css`
-												width: 0.5rem;
-												height: 1.5rem;
-												background-color: ${isActive ? colour : 'transparent'};
-											`}
-										/>
-									}
-									aria-current={isActive}
-								/>
-							);
-						})}
-					</EuiListGroup>
-				</EuiCollapsibleNavGroup>
-				<EuiCollapsibleNavGroup title={'Search history'}>
-					{searchHistoryItems.length === 0 ? (
-						<EuiText size="s">{'No history yet'}</EuiText>
-					) : (
-						<EuiBadgeGroup color="subdued" gutterSize="s">
-							{searchHistoryItems.map(({ label, query, resultsCount }) => {
+				<div style={{ height: '90%', overflowY: 'auto' }}>
+					<SearchBox />
+					<EuiCollapsibleNavGroup title="Buckets">
+						<EuiListGroup
+							maxWidth="none"
+							color="subdued"
+							gutterSize="none"
+							size="s"
+						>
+							{bucketItems.map(({ bucketId, label, isActive, onClick }) => {
 								return (
-									<EuiBadge
-										key={label}
-										color="secondary"
-										onClick={() => {
-											handleEnterQuery(query);
-										}}
-										onClickAriaLabel="Apply filters"
-									>
-										{label}{' '}
-										<EuiBadge color="hollow">
-											{resultsCount === 30 ? '30+' : resultsCount}
-										</EuiBadge>
-									</EuiBadge>
+									<EuiListGroupItem
+										color={isActive ? 'primary' : 'subdued'}
+										label={label}
+										key={bucketId}
+										aria-current={isActive}
+										onClick={onClick}
+										icon={
+											<div
+												css={css`
+													width: 0.5rem;
+													height: 1.5rem;
+													background-color: ${isActive
+														? theme.euiTheme.colors.primary
+														: 'transparent'};
+												`}
+											/>
+										}
+									/>
 								);
 							})}
-						</EuiBadgeGroup>
-					)}
-				</EuiCollapsibleNavGroup>
+						</EuiListGroup>
+					</EuiCollapsibleNavGroup>
+					<EuiCollapsibleNavGroup title={'Suppliers'}>
+						<EuiListGroup
+							maxWidth="none"
+							color="subdued"
+							gutterSize="none"
+							size="s"
+						>
+							{supplierItems.map(({ label, colour, isActive, onClick }) => {
+								return (
+									<EuiListGroupItem
+										color={isActive ? 'primary' : 'subdued'}
+										key={label}
+										label={label}
+										onClick={onClick}
+										icon={
+											<div
+												css={css`
+													width: 0.5rem;
+													height: 1.5rem;
+													background-color: ${isActive
+														? colour
+														: 'transparent'};
+												`}
+											/>
+										}
+										aria-current={isActive}
+									/>
+								);
+							})}
+						</EuiListGroup>
+					</EuiCollapsibleNavGroup>
+					<EuiCollapsibleNavGroup title={'Search history'}>
+						{searchHistoryItems.length === 0 ? (
+							<EuiText size="s">{'No history yet'}</EuiText>
+						) : (
+							<EuiBadgeGroup color="subdued" gutterSize="s">
+								{searchHistoryItems.map(({ label, query, resultsCount }) => {
+									return (
+										<EuiBadge
+											key={label}
+											color="secondary"
+											onClick={() => {
+												handleEnterQuery(query);
+											}}
+											onClickAriaLabel="Apply filters"
+										>
+											{label}{' '}
+											<EuiBadge color="hollow">
+												{resultsCount === 30 ? '30+' : resultsCount}
+											</EuiBadge>
+										</EuiBadge>
+									);
+								})}
+							</EuiBadgeGroup>
+						)}
+					</EuiCollapsibleNavGroup>
+				</div>
+
+				<div style={{ padding: '20px 10px' }}>
+					<EuiSwitch
+						label="Auto-update"
+						checked={state.autoUpdate}
+						onChange={toggleAutoUpdate}
+					/>
+				</div>
 			</EuiCollapsibleNav>
 		</>
 	);

--- a/newswires/client/src/WireItemTable.tsx
+++ b/newswires/client/src/WireItemTable.tsx
@@ -1,8 +1,6 @@
 import {
-	EuiButton,
 	EuiFlexGroup,
 	euiScreenReaderOnly,
-	EuiSpacer,
 	EuiTable,
 	EuiTableBody,
 	EuiTableHeader,
@@ -19,60 +17,46 @@ import { formatTimestamp } from './formatTimestamp';
 import type { WireData } from './sharedTypes';
 import { useSearch } from './useSearch';
 
+const fadeOutBackground = css`
+	animation: fadeOut ease-out 15s;
+	@keyframes fadeOut {
+		from {
+			background-color: aliceblue;
+		}
+		to {
+			background-color: white;
+		}
+	}
+`;
+
 export const WireItemTable = ({ wires }: { wires: WireData[] }) => {
 	const { config, handleSelectItem } = useSearch();
 
 	const selectedWireId = config.itemId;
 
-	const isPoppedOut = !!window.opener;
-
 	return (
-		<div>
-			<EuiFlexGroup
-				justifyContent={'center'}
+		<EuiTable tableLayout="auto">
+			<EuiTableHeader
 				css={css`
-					position: sticky;
-					top: 45px;
+					${euiScreenReaderOnly()}
 				`}
 			>
-				{!isPoppedOut && (
-					<EuiButton
-						iconType={'popout'}
-						onClick={() =>
-							window.open(
-								window.location.href,
-								'_blank',
-								'popout=true,width=400,height=800,top=200,location=no,menubar=no,toolbar=no',
-							)
-						}
-					>
-						Popout as ticker
-					</EuiButton>
-				)}
-			</EuiFlexGroup>
-			<EuiSpacer size="l" />
-			<EuiTable tableLayout="auto">
-				<EuiTableHeader
-					css={css`
-						${euiScreenReaderOnly()}
-					`}
-				>
-					<EuiTableHeaderCell>Headline</EuiTableHeaderCell>
-					<EuiTableHeaderCell>Version Created</EuiTableHeaderCell>
-				</EuiTableHeader>
-				<EuiTableBody>
-					{wires.map(({ id, content }) => (
-						<WireDataRow
-							key={id}
-							id={id}
-							content={content}
-							selected={selectedWireId == id.toString()}
-							handleSelect={handleSelectItem}
-						/>
-					))}
-				</EuiTableBody>
-			</EuiTable>
-		</div>
+				<EuiTableHeaderCell>Headline</EuiTableHeaderCell>
+				<EuiTableHeaderCell>Version Created</EuiTableHeaderCell>
+			</EuiTableHeader>
+			<EuiTableBody>
+				{wires.map(({ id, content, isFromRefresh }) => (
+					<WireDataRow
+						key={id}
+						id={id}
+						content={content}
+						isFromRefresh={isFromRefresh}
+						selected={selectedWireId == id.toString()}
+						handleSelect={handleSelectItem}
+					/>
+				))}
+			</EuiTableBody>
+		</EuiTable>
 	);
 };
 
@@ -80,11 +64,13 @@ const WireDataRow = ({
 	id,
 	content,
 	selected,
+	isFromRefresh,
 	handleSelect,
 }: {
 	id: number;
 	content: WireData['content'];
 	selected: boolean;
+	isFromRefresh: boolean;
 	handleSelect: (id: string) => void;
 }) => {
 	const theme = useEuiTheme();
@@ -103,12 +89,11 @@ const WireDataRow = ({
 			css={css`
 				&:hover {
 					background-color: ${primaryBgColor};
+					border-left: 4px solid ${theme.euiTheme.colors.accent};
 				}
 				border-left: 4px solid
 					${selected ? theme.euiTheme.colors.primary : 'transparent'};
-				&:hover {
-					border-left: 4px solid ${theme.euiTheme.colors.accent};
-				}
+				${isFromRefresh ? fadeOutBackground : ''}
 			`}
 		>
 			<EuiTableRowCell valign="baseline">

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -31,6 +31,7 @@ export const WireDataSchema = z.object({
 	externalId: z.string(),
 	ingestedAt: z.string(),
 	content: FingerpostContentSchema,
+	isFromRefresh: z.boolean().default(false),
 });
 
 export type WireData = z.infer<typeof WireDataSchema>;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Add an 'auto update' toggle switch in the side nav
- Move the 'new ticker' button to the top bar
- And add a pass-by refactor to have it always open the new tab in 'feed' view

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="1309" alt="image" src="https://github.com/user-attachments/assets/8bf77bdd-0fed-4c41-97ca-c32ff71cbc3f">


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
