### PR TITLE
Highlight search terms in results

### DIFF
--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -73,11 +73,12 @@ class QueryController(
     Ok(Json.toJson(results))
   }
 
-  def item(id: Int): Action[AnyContent] = AuthAction {
-    FingerpostWireEntry.get(id) match {
-      case Some(entry) => Ok(Json.toJson(entry))
-      case None        => NotFound
+  def item(id: Int, maybeFreeTextQuery: Option[String]): Action[AnyContent] =
+    AuthAction {
+      FingerpostWireEntry.get(id, maybeFreeTextQuery) match {
+        case Some(entry) => Ok(Json.toJson(entry))
+        case None        => NotFound
+      }
     }
-  }
 
 }

--- a/newswires/client/src/Item.tsx
+++ b/newswires/client/src/Item.tsx
@@ -12,14 +12,15 @@ import {
 	EuiTitle,
 	useGeneratedHtmlId,
 } from '@elastic/eui';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { pandaFetch } from './panda-session';
 import { type WireData, WireDataSchema } from './sharedTypes';
+import { paramsToQuerystring } from './urlState';
 import { useSearch } from './useSearch';
 import { WireDetail } from './WireDetail';
 
 export const Item = ({ id }: { id: string }) => {
-	const { handleDeselectItem } = useSearch();
+	const { handleDeselectItem, config } = useSearch();
 
 	const [itemData, setItemData] = useState<WireData | undefined>(undefined);
 	const [error, setError] = useState<string | undefined>(undefined);
@@ -31,9 +32,17 @@ export const Item = ({ id }: { id: string }) => {
 		prefix: 'pushedFlyoutTitle',
 	});
 
+	const maybeSearchParams = useMemo(() => {
+		const q = config.query.q;
+		if (q) {
+			return paramsToQuerystring({ q, supplier: [] });
+		}
+		return '';
+	}, [config.query.q]);
+
 	useEffect(() => {
 		// fetch item data from /api/item/:id
-		pandaFetch(`/api/item/${id}`)
+		pandaFetch(`/api/item/${id}${maybeSearchParams}`)
 			.then((res) => {
 				if (res.status === 404) {
 					throw new Error('Item not found');

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -8,6 +8,7 @@ import {
 	EuiFlexItem,
 	EuiScreenReaderLive,
 	EuiSpacer,
+	useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { Fragment, useMemo } from 'react';
@@ -21,6 +22,7 @@ export const WireDetail = ({
 	wire: WireData;
 	isShowingJson: boolean;
 }) => {
+	const theme = useEuiTheme();
 	const { byline, keywords, usage } = wire.content;
 
 	const safeBodyText = useMemo(() => {
@@ -28,6 +30,14 @@ export const WireDetail = ({
 			? sanitizeHtml(wire.content.bodyText)
 			: undefined;
 	}, [wire]);
+
+	const safeHighlightText = useMemo(() => {
+		return wire.highlight.trim().length > 0
+			? sanitizeHtml(wire.highlight)
+			: undefined;
+	}, [wire]);
+
+	const bodyTextContent = safeHighlightText ?? safeBodyText;
 
 	const nonEmptyKeywords = useMemo(
 		() => keywords?.filter((keyword) => keyword.trim().length > 0) ?? [],
@@ -54,7 +64,16 @@ export const WireDetail = ({
 
 					<EuiSpacer size="m" />
 
-					<EuiDescriptionList>
+					<EuiDescriptionList
+						css={css`
+							& mark {
+								background-color: ${theme.euiTheme.colors.highlight};
+								font-weight: bold;
+								position: relative;
+								border: 3px solid ${theme.euiTheme.colors.highlight};
+							}
+						`}
+					>
 						{byline && (
 							<>
 								<EuiDescriptionListTitle>Byline</EuiDescriptionListTitle>
@@ -87,12 +106,12 @@ export const WireDetail = ({
 								</EuiDescriptionListDescription>
 							</>
 						)}
-						{safeBodyText && (
+						{bodyTextContent && (
 							<>
 								<EuiDescriptionListTitle>Body text</EuiDescriptionListTitle>
 								<EuiDescriptionListDescription>
 									<article
-										dangerouslySetInnerHTML={{ __html: safeBodyText }}
+										dangerouslySetInnerHTML={{ __html: bodyTextContent }}
 										data-pinboard-selection-target
 									/>
 								</EuiDescriptionListDescription>

--- a/newswires/client/src/WireItemTable.tsx
+++ b/newswires/client/src/WireItemTable.tsx
@@ -13,6 +13,7 @@ import {
 	useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
+import sanitizeHtml from 'sanitize-html';
 import { formatTimestamp } from './formatTimestamp';
 import type { WireData } from './sharedTypes';
 import { useSearch } from './useSearch';
@@ -35,7 +36,10 @@ export const WireItemTable = ({ wires }: { wires: WireData[] }) => {
 	const selectedWireId = config.itemId;
 
 	return (
-		<EuiTable tableLayout="auto">
+		<EuiTable
+			tableLayout="auto"
+			responsiveBreakpoint={config.view === 'item' ? true : 'm'}
+		>
 			<EuiTableHeader
 				css={css`
 					${euiScreenReaderOnly()}
@@ -45,12 +49,13 @@ export const WireItemTable = ({ wires }: { wires: WireData[] }) => {
 				<EuiTableHeaderCell>Version Created</EuiTableHeaderCell>
 			</EuiTableHeader>
 			<EuiTableBody>
-				{wires.map(({ id, content, isFromRefresh }) => (
+				{wires.map(({ id, content, isFromRefresh, highlight }) => (
 					<WireDataRow
 						key={id}
 						id={id}
 						content={content}
 						isFromRefresh={isFromRefresh}
+						highlight={highlight}
 						selected={selectedWireId == id.toString()}
 						handleSelect={handleSelectItem}
 					/>
@@ -63,12 +68,14 @@ export const WireItemTable = ({ wires }: { wires: WireData[] }) => {
 const WireDataRow = ({
 	id,
 	content,
+	highlight,
 	selected,
 	isFromRefresh,
 	handleSelect,
 }: {
 	id: number;
 	content: WireData['content'];
+	highlight: string;
 	selected: boolean;
 	isFromRefresh: boolean;
 	handleSelect: (id: string) => void;
@@ -108,6 +115,19 @@ const WireDataRow = ({
 							<p>{content.headline}</p>
 						</EuiText>
 					)}
+					{highlight.trim().length > 0 && (
+						<EuiText
+							size="xs"
+							css={css`
+								padding-left: 5px;
+								background-color: ${theme.euiTheme.colors.highlight};
+							`}
+						>
+							<p
+								dangerouslySetInnerHTML={{ __html: sanitizeHtml(highlight) }}
+							/>
+						</EuiText>
+					)}
 				</EuiFlexGroup>
 			</EuiTableRowCell>
 			<EuiTableRowCell align="right" valign="baseline">
@@ -118,7 +138,6 @@ const WireDataRow = ({
 								<EuiText
 									size="xs"
 									css={css`
-										font-family: monospace;
 										white-space: pre;
 									`}
 									key={part}

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -31,6 +31,7 @@ export const WireDataSchema = z.object({
 	externalId: z.string(),
 	ingestedAt: z.string(),
 	content: FingerpostContentSchema,
+	highlight: z.string(),
 	isFromRefresh: z.boolean().default(false),
 });
 

--- a/newswires/conf/routes
+++ b/newswires/conf/routes
@@ -9,7 +9,7 @@ GET     /feed                       controllers.ViteController.index()
 GET     /item/*id                   controllers.ViteController.item(id: String)
 GET     /api/search                 controllers.QueryController.query(q: Option[String], keywords: Option[String], supplier: List[String], beforeId: Option[Int], sinceId: Option[Int])
 GET     /api/keywords               controllers.QueryController.keywords(inLastHours: Option[Int], limit:Option[Int])
-GET     /api/item/*id               controllers.QueryController.item(id: Int)
+GET     /api/item/*id               controllers.QueryController.item(id: Int, q: Option[String])
 
 GET     /oauthCallback              controllers.AuthController.oauthCallback()
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Add a `highlight` column, that should return a `ts_headline` for the given query, if there's a free text search as part of that query
- Display the highlight column in the main feed table, and use the highlighted `bodyText` as the markup for the main item display, if we have it.
  - nb. the highlighting is achieved by adding `<mark>` elements either side of the search terms, which means that the markup in the body text on the page won't be quite the same as the markup that we have stored in the db for the story. We should bear this in mind when working on the 'import to composer' via pinboard functionality (cc. @twrichards) though I don't think it's a huge issue. 
- Tweak the main feed table to use a 'responsive' layout whenever an item is selected, as there's reduced horizontal space but the standard responsive layout doesn't kick in because the overall page is still at a wide breakpoint.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="1057" alt="image" src="https://github.com/user-attachments/assets/7787a5d2-dd1a-4a9d-8d08-9651bb452013">


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
