### PR TITLE
Add pinboard selection target

### DIFF
--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -91,7 +91,10 @@ export const WireDetail = ({
 							<>
 								<EuiDescriptionListTitle>Body text</EuiDescriptionListTitle>
 								<EuiDescriptionListDescription>
-									<article dangerouslySetInnerHTML={{ __html: safeBodyText }} />
+									<article
+										dangerouslySetInnerHTML={{ __html: safeBodyText }}
+										data-pinboard-selection-target
+									/>
 								</EuiDescriptionListDescription>
 							</>
 						)}


### PR DESCRIPTION
Add data attribute to allow Pinboard to identify the body text of an item for snippet selection.