### PR TITLE
Undock side nav on smaller screens

### DIFF
--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -3,8 +3,6 @@ import {
 	EuiBadgeGroup,
 	EuiCollapsibleNav,
 	EuiCollapsibleNavGroup,
-	EuiFlexGroup,
-	EuiFlexItem,
 	EuiHeaderSectionItemButton,
 	EuiIcon,
 	EuiListGroup,
@@ -12,6 +10,7 @@ import {
 	EuiSwitch,
 	EuiText,
 	useEuiTheme,
+	useIsWithinMinBreakpoint,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useCallback, useMemo, useState } from 'react';
@@ -43,6 +42,7 @@ function bucketName(bucketId: string): string | undefined {
 export const SideNav = () => {
 	const [navIsOpen, setNavIsOpen] = useState<boolean>(false);
 	const theme = useEuiTheme();
+	const isOnLargerScreen = useIsWithinMinBreakpoint('m');
 
 	const { state, config, handleEnterQuery, toggleAutoUpdate } = useSearch();
 
@@ -128,7 +128,7 @@ export const SideNav = () => {
 		<>
 			<EuiCollapsibleNav
 				isOpen={navIsOpen}
-				isDocked={true}
+				isDocked={isOnLargerScreen}
 				size={300}
 				button={
 					<EuiHeaderSectionItemButton


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Undock on medium; also fixes the issue where clicking overlay outside of the menu would _both_ close the menu _and_ propagate the click to the layer below.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
