### PR TITLE
Add two racing codes to no sports bucket

### DIFF
--- a/newswires/app/conf/SearchBuckets.scala
+++ b/newswires/app/conf/SearchBuckets.scala
@@ -30,6 +30,8 @@ object Subjects {
     "iptccat:SCN",
     "iptccat:GXX", // maybe, or maybe advertising "Tequila brand announces partnership with Fulham Football Club"
     "iptccat:RFC",
+    "ipccat:RDR",
+    "ipccat:RRR",
     "a1312cat:s",
     "MCC:SPO",
     "N2:TEN"


### PR DESCRIPTION
I haven't been able to find documentation of these codes, but they look like they only carry horse racing content.