### PR TITLE
add riff-raff dependency for Newswires cfn deploy on the WiresFeeds cfn deploy (plus snapshot test the riff-raff.yaml)

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -1,10 +1,12 @@
 import 'source-map-support/register';
-import { GuRoot } from '@guardian/cdk/lib/constructs/root';
 import { WiresFeeds } from '../lib/wires-feeds';
 import { Newswires } from '../lib/newswires';
+import { App } from 'aws-cdk-lib';
+import { RiffRaffYamlFile } from '@guardian/cdk/lib/riff-raff-yaml-file';
 
-const app = new GuRoot();
+const app = new App();
 
+// FIXME we should probably have a dedicated stack for the Newswires app for e.g. cost explorer purposes (as the App tag needs to be different for riff-raff etc. to differentiate)
 const stack = 'editorial-feeds';
 
 const env = {
@@ -40,3 +42,7 @@ new Newswires(app, 'Newswires-PROD', {
 	enableMonitoring: false,
 	fingerpostQueue: prodWiresFeeds.fingerpostQueue,
 });
+
+export const riffraff = new RiffRaffYamlFile(app);
+
+riffraff.synth();

--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -32,7 +32,7 @@ new Newswires(app, 'Newswires-CODE', {
 	domainName: 'newswires.code.dev-gutools.co.uk',
 	enableMonitoring: false,
 	fingerpostQueue: codeWiresFeeds.fingerpostQueue,
-});
+}).addDependency(codeWiresFeeds);
 
 new Newswires(app, 'Newswires-PROD', {
 	env,
@@ -41,8 +41,7 @@ new Newswires(app, 'Newswires-PROD', {
 	domainName: 'newswires.gutools.co.uk',
 	enableMonitoring: false,
 	fingerpostQueue: prodWiresFeeds.fingerpostQueue,
-});
+}).addDependency(prodWiresFeeds);
 
 export const riffraff = new RiffRaffYamlFile(app);
-
 riffraff.synth();

--- a/cdk/lib/__snapshots__/riffraff.test.ts.snap
+++ b/cdk/lib/__snapshots__/riffraff.test.ts.snap
@@ -65,6 +65,7 @@ deployments:
     dependencies:
       - lambda-upload-eu-west-1-editorial-feeds-ingestion-lambda
       - asg-upload-eu-west-1-editorial-feeds-newswires
+      - cfn-eu-west-1-editorial-feeds-wires-feeds
   lambda-update-eu-west-1-editorial-feeds-ingestion-lambda:
     type: aws-lambda
     stacks:

--- a/cdk/lib/__snapshots__/riffraff.test.ts.snap
+++ b/cdk/lib/__snapshots__/riffraff.test.ts.snap
@@ -1,0 +1,100 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`generated riff-raff.yaml matches the snapshot 1`] = `
+"allowedStages:
+  - CODE
+  - PROD
+deployments:
+  cfn-eu-west-1-editorial-feeds-wires-feeds:
+    type: cloud-formation
+    regions:
+      - eu-west-1
+    stacks:
+      - editorial-feeds
+    app: wires-feeds
+    contentDirectory: cdk.out
+    parameters:
+      templateStagePaths:
+        CODE: WiresFeeds-CODE.template.json
+        PROD: WiresFeeds-PROD.template.json
+  lambda-upload-eu-west-1-editorial-feeds-ingestion-lambda:
+    type: aws-lambda
+    stacks:
+      - editorial-feeds
+    regions:
+      - eu-west-1
+    app: ingestion-lambda
+    contentDirectory: ingestion-lambda
+    parameters:
+      bucketSsmLookup: true
+      lookupByTags: true
+      fileName: ingestion-lambda.zip
+    actions:
+      - uploadLambda
+  asg-upload-eu-west-1-editorial-feeds-newswires:
+    type: autoscaling
+    actions:
+      - uploadArtifacts
+    regions:
+      - eu-west-1
+    stacks:
+      - editorial-feeds
+    app: newswires
+    parameters:
+      bucketSsmLookup: true
+      prefixApp: true
+    contentDirectory: newswires
+  cfn-eu-west-1-editorial-feeds-newswires:
+    type: cloud-formation
+    regions:
+      - eu-west-1
+    stacks:
+      - editorial-feeds
+    app: newswires
+    contentDirectory: cdk.out
+    parameters:
+      templateStagePaths:
+        CODE: Newswires-CODE.template.json
+        PROD: Newswires-PROD.template.json
+      amiParametersToTags:
+        AMINewswires:
+          BuiltBy: amigo
+          AmigoStage: PROD
+          Recipe: editorial-tools-jammy-java17
+          Encrypted: 'true'
+    dependencies:
+      - lambda-upload-eu-west-1-editorial-feeds-ingestion-lambda
+      - asg-upload-eu-west-1-editorial-feeds-newswires
+  lambda-update-eu-west-1-editorial-feeds-ingestion-lambda:
+    type: aws-lambda
+    stacks:
+      - editorial-feeds
+    regions:
+      - eu-west-1
+    app: ingestion-lambda
+    contentDirectory: ingestion-lambda
+    parameters:
+      bucketSsmLookup: true
+      lookupByTags: true
+      fileName: ingestion-lambda.zip
+    actions:
+      - updateLambda
+    dependencies:
+      - cfn-eu-west-1-editorial-feeds-newswires
+  asg-update-eu-west-1-editorial-feeds-newswires:
+    type: autoscaling
+    actions:
+      - deploy
+    regions:
+      - eu-west-1
+    stacks:
+      - editorial-feeds
+    app: newswires
+    parameters:
+      bucketSsmLookup: true
+      prefixApp: true
+    dependencies:
+      - cfn-eu-west-1-editorial-feeds-newswires
+    contentDirectory: newswires
+"
+`;

--- a/cdk/lib/riffraff.test.ts
+++ b/cdk/lib/riffraff.test.ts
@@ -1,0 +1,10 @@
+import { riffraff } from '../bin/cdk';
+
+describe('generated riff-raff.yaml', () => {
+	it('matches the snapshot', () => {
+		// @ts-ignore
+		const outdir = riffraff.outdir; // this changes for every test execution and best not to change cdk.ts too much
+		const riffRaffYaml = riffraff.toYAML().replaceAll(outdir, 'cdk.out');
+		expect(riffRaffYaml).toMatchSnapshot();
+	});
+});


### PR DESCRIPTION
The Newswires stack references the queue exposed by the WiresFeeds stack, cdk automagically does this via cfn outputs under the hood. The generated riff-raff.yaml has no idea about this relationship but the two stacks have separate cfn deployments, which by default execute in parallel, creating a race condition.

This PR...
- first snapshot tests the generated riff-raff yaml (as that's useful in its own right)
- second, it makes use of `addDependency` (added in https://github.com/guardian/cdk/pull/2094) to add that dependency (which shows up in the test snapshot)