### PR TITLE
Add ingestor data validation

### DIFF
--- a/ingestion-lambda/localRun.ts
+++ b/ingestion-lambda/localRun.ts
@@ -1,5 +1,6 @@
 import type { SQSEvent, SQSRecord } from 'aws-lambda';
 import { LoremIpsum } from 'lorem-ipsum';
+import type { IngestorInputBody } from '../shared/types';
 import { main } from './src/handler';
 
 const lorem = new LoremIpsum({});
@@ -33,7 +34,10 @@ function recursivelyScheduleEvent() {
 	);
 }
 
-function createDummyFeedEntry() {
+function createDummyFeedEntry(): {
+	externalId: string;
+	body: IngestorInputBody;
+} {
 	const usn = Math.random().toString(36).substring(7);
 	const firstVersion = new Date().toISOString();
 	const versionCreated = new Date().toISOString();

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
 				"cdk",
 				"ingestion-lambda"
 			],
+			"dependencies": {
+				"zod": "3.23.8"
+			},
 			"devDependencies": {
 				"@guardian/eslint-config-typescript": "8.0.0",
 				"@guardian/prettier": "5.0.0",
@@ -10455,6 +10458,15 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/zod": {
+			"version": "3.23.8",
+			"resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
+			"integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/colinhacks"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -44,5 +44,8 @@
 			".eslintrc.js",
 			"jest.config.js"
 		]
+	},
+	"dependencies": {
+		"zod": "3.23.8"
 	}
 }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,5 +1,18 @@
 import { z } from 'zod';
 
+const OptionalStringOrArrayAsArrayOfStrings = z
+	.union([z.string(), z.array(z.string())])
+	.optional()
+	.transform((val) => {
+		if (Array.isArray(val)) {
+			return val;
+		}
+		if (val === undefined) {
+			return [];
+		}
+		return [val];
+	});
+
 const FingerpostFeedPayloadSchema = z.object({
 	uri: z.string().optional(),
 	'source-feed': z.string().optional(),
@@ -19,14 +32,14 @@ const FingerpostFeedPayloadSchema = z.object({
 	priority: z.string().optional(), // 1-5 in all records
 	subjects: z
 		.object({
-			code: z.string().optional(),
+			code: OptionalStringOrArrayAsArrayOfStrings,
 		})
 		.optional(),
 	mediaCatCodes: z.string().optional(),
-	keywords: z.union([z.string(), z.array(z.string())]).optional(),
+	keywords: OptionalStringOrArrayAsArrayOfStrings,
 	organisation: z
 		.object({
-			symbols: z.union([z.string(), z.array(z.string())]).optional(),
+			symbols: OptionalStringOrArrayAsArrayOfStrings,
 		})
 		.optional(), // {"symbols": ""} {"symbols": [""]} in all records
 	tabVtxt: z.string().optional(), // always 'X' or null

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,0 +1,47 @@
+type FingerpostFeedPayload = {
+	uri?: string;
+	'source-feed'?: string;
+	usn?: string;
+	version?: string;
+	type?: string; // this is 'text' in every entry we have in the CODE db on 1st Nov 2024 (175553 entries at time of checking)
+	format?: string; // "GOA-WIRES-NINJS" in all records
+	mimeType?: string; // application/ninjs+json
+	firstVersion?: string;
+	versionCreated?: string;
+	dateTimeSent?: string; // more than 1/2 of the time identical to versionCreated
+	originalUrn?: string; // almost all entries have a string here, but not very unique (181803 values, only 53988 unique values)
+	slug?: string; // fp set this
+	headline?: string;
+	subhead?: string;
+	byline?: string;
+	priority?: string; // 1-5 in all records
+	subjects?: {
+		code?: string;
+	};
+	mediaCatCodes?: string;
+	keywords?: string | string[];
+	organisation?: {
+		symbols?: string;
+	}; // {"symbols": ""} {"symbols": [""]} in all records
+	tabVtxt?: string; // always 'X' or null
+	status?: string; //  always one of: "" "usable" "canceled" "embargoed" "withheld"
+	usage?: string;
+	ednote?: string;
+	abstract?: string; // only present in REUTERS and AAP items
+	language?: string;
+	location?: string; // just plain string
+	body_text?: string;
+	copyrightHolder?: string;
+	copyrightNotice?: string;
+};
+
+export type IngestorInputBody = FingerpostFeedPayload & {
+	originalContentText?: string;
+};
+
+/**
+ * Data structure produced by the ingestion lambda and saved to the database as JSONB in the `content` column.
+ */
+export type WireEntryContent = Omit<IngestorInputBody, 'keywords'> & {
+	keywords: string[];
+};

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -7,7 +7,7 @@ const OptionalStringOrArrayAsArrayOfStrings = z
 		if (Array.isArray(val)) {
 			return val;
 		}
-		if (val === undefined) {
+		if (val === undefined || val.trim() === '') {
 			return [];
 		}
 		return [val];


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add Zod schemas and types that describe the expected shape of payloads to the ingestion lambda. Use the schemas to validate the payload of the SQS messages which feed the lambda.

This is a preparatory step for adding our own data sources which will feed the ingestion lambda, which will help us to make sure we're writing what we expect to read.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Deploy to CODE, ingestion still works

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
