### PR TITLE
Linting for polling lambdas

### DIFF
--- a/poller-lambdas/package.json
+++ b/poller-lambdas/package.json
@@ -5,10 +5,11 @@
 	"scripts": {
 		"dev": "tsx watch localRun.ts",
 		"typecheck": "tsc -noEmit",
-		"build": "esbuild src/index.ts --bundle --minify --outfile=dist/index.js --external:@aws-sdk --external:aws-sdk --platform=node"
+		"build": "esbuild src/index.ts --bundle --minify --outfile=dist/index.js --external:@aws-sdk --external:aws-sdk --platform=node",
+		"lint": "eslint src/** --ext .ts --no-error-on-unmatched-pattern --fix",
+		"lint:ci": "eslint src/** --ext .ts --no-error-on-unmatched-pattern"
 	},
-	"dependencies": {
-	},
+	"dependencies": {},
 	"devDependencies": {
 		"@aws-sdk/client-secrets-manager": "^3.682.0",
 		"@aws-sdk/client-sqs": "^3.682.0",

--- a/poller-lambdas/src/index.ts
+++ b/poller-lambdas/src/index.ts
@@ -1,9 +1,10 @@
-import { SQSEvent } from 'aws-lambda';
 import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs';
-import { POLLER_LAMBDA_ENV_VAR_KEYS, PollerId } from '../../shared/pollers';
-import { PollFunction } from './types';
-import EXAMPLE_long_polling from './pollers/EXAMPLE_long_polling';
-import EXAMPLE_fixed_frequency from './pollers/EXAMPLE_fixed_frequency';
+import type { SQSEvent } from 'aws-lambda';
+import type { PollerId } from '../../shared/pollers';
+import { POLLER_LAMBDA_ENV_VAR_KEYS } from '../../shared/pollers';
+import { EXAMPLE_fixed_frequency } from './pollers/EXAMPLE_fixed_frequency';
+import { EXAMPLE_long_polling } from './pollers/EXAMPLE_long_polling';
+import type { PollFunction } from './types';
 
 const getEnvironmentVariableOrCrash = (
 	key: keyof typeof POLLER_LAMBDA_ENV_VAR_KEYS,

--- a/poller-lambdas/src/pollers/EXAMPLE_fixed_frequency.ts
+++ b/poller-lambdas/src/pollers/EXAMPLE_fixed_frequency.ts
@@ -1,10 +1,11 @@
-import { FixedFrequencyPollFunction, SecretValue } from '../types';
+import type { FixedFrequencyPollFunction, SecretValue } from '../types';
 
-export default (async (secret: SecretValue) => {
+export const EXAMPLE_fixed_frequency = (async (secret: SecretValue) => {
 	console.log({
 		secretLength: secret.length,
 		pollingAt: new Date().toISOString(),
 	});
+	await new Promise((resolve) => setTimeout(resolve, 10));
 	return {
 		payloadForIngestionLambda: {},
 		idealFrequencyInSeconds: 30,

--- a/poller-lambdas/src/pollers/EXAMPLE_long_polling.ts
+++ b/poller-lambdas/src/pollers/EXAMPLE_long_polling.ts
@@ -1,6 +1,9 @@
-import { LongPollFunction, PollerInput, SecretValue } from '../types';
+import type { LongPollFunction, PollerInput, SecretValue } from '../types';
 
-export default (async (secret: SecretValue, input: PollerInput) => {
+export const EXAMPLE_long_polling = (async (
+	secret: SecretValue,
+	input: PollerInput,
+) => {
 	const previousCounterValue = parseInt(input);
 	await new Promise((resolve) => setTimeout(resolve, 30000)); // simulate long poll taking 30s
 	const newCounterValue = previousCounterValue + 1;

--- a/poller-lambdas/tsconfig.json
+++ b/poller-lambdas/tsconfig.json
@@ -1,0 +1,3 @@
+{
+	"extends": "../tsconfig.json"
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add `.tsconfig` and lint script to the `poller-lambdas` workspace and fix linting errors surfaced by this. (All changes should be no-ops.)


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
