### PR TITLE
Add our own AP & Reuters feeds to API/UI

### DIFF
--- a/newswires/app/conf/SourceFeedSupplierMapping.scala
+++ b/newswires/app/conf/SourceFeedSupplierMapping.scala
@@ -15,6 +15,7 @@ object SourceFeedSupplierMapping {
 
   private val lookup = Map(
     "REUTERS" -> List("REUTERS"),
+    "GUREUTERS" -> List("Reuters-Newswires"),
     "AAP" -> List("AAP"),
     "AP" -> List(
       "ADVIS",

--- a/newswires/app/conf/SourceFeedSupplierMapping.scala
+++ b/newswires/app/conf/SourceFeedSupplierMapping.scala
@@ -62,6 +62,9 @@ object SourceFeedSupplierMapping {
       "WEATHER",
       "WORLD"
     ),
+    "GUAP" -> List( // for feeds coming from our own poller
+      "AP-Newswires"
+    ),
     "PA" -> List(
       "PA",
       "PA ACCESSWIRE",

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -48,7 +48,8 @@ case class FingerpostWire(
     language: Option[String],
     usage: Option[String],
     location: Option[String],
-    bodyText: Option[String]
+    bodyText: Option[String],
+    ednote: Option[String]
 )
 object FingerpostWire {
   // rename a couple of fields

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -28,7 +28,7 @@ function decideLabelForQueryBadge(query: Query): string {
 	return labels.filter((label) => label.length > 0).join(' ');
 }
 
-const recognisedSuppliers = ['REUTERS', 'AP', 'AAP', 'PA'];
+const recognisedSuppliers = ['REUTERS', 'AP', 'AAP', 'PA', 'GuAP'];
 const buckets = [
 	{ id: 'no-sports', name: 'No Sports' },
 	{ id: 'pa-home', name: 'PA Home' },

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -15,7 +15,7 @@ import {
 import { css } from '@emotion/react';
 import { useCallback, useMemo, useState } from 'react';
 import { SearchBox } from './SearchBox';
-import { brandColours } from './sharedStyles';
+import { AAPBrand, APBrand, PABrand, reutersBrand } from './sharedStyles';
 import type { Query } from './sharedTypes';
 import { useSearch } from './useSearch';
 
@@ -28,7 +28,36 @@ function decideLabelForQueryBadge(query: Query): string {
 	return labels.filter((label) => label.length > 0).join(' ');
 }
 
-const recognisedSuppliers = ['REUTERS', 'AP', 'AAP', 'PA', 'GuAP'];
+const supplierData: Record<
+	string,
+	{
+		label: string;
+		colour: string;
+	}
+> = {
+	REUTERS: { label: 'Reuters', colour: reutersBrand },
+	AP: {
+		label: 'AP',
+		colour: APBrand,
+	},
+	AAP: {
+		label: 'AAP',
+		colour: AAPBrand,
+	},
+	PA: {
+		label: 'PA',
+		colour: PABrand,
+	},
+	GuAP: {
+		label: 'AP (Gu)',
+		colour: APBrand,
+	},
+	GuReuters: {
+		label: 'Reuters (Gu)',
+		colour: reutersBrand,
+	},
+};
+const recognisedSuppliers = Object.keys(supplierData);
 const buckets = [
 	{ id: 'no-sports', name: 'No Sports' },
 	{ id: 'pa-home', name: 'PA Home' },
@@ -98,11 +127,11 @@ export const SideNav = () => {
 				onClick: () => handleEnterQuery({ ...config.query, supplier: [] }),
 				colour: 'black',
 			},
-			...recognisedSuppliers.map((supplier) => ({
-				label: supplier,
+			...Object.entries(supplierData).map(([supplier, { label, colour }]) => ({
+				label,
 				isActive:
 					activeSuppliers.includes(supplier) || activeSuppliers.length === 0,
-				colour: brandColours.get(supplier) ?? 'black',
+				colour: colour,
 				onClick: () => toggleSupplier(supplier),
 			})),
 		],

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -23,7 +23,7 @@ export const WireDetail = ({
 	isShowingJson: boolean;
 }) => {
 	const theme = useEuiTheme();
-	const { byline, keywords, usage } = wire.content;
+	const { byline, keywords, usage, ednote } = wire.content;
 
 	const safeBodyText = useMemo(() => {
 		return wire.content.bodyText
@@ -74,6 +74,18 @@ export const WireDetail = ({
 							}
 						`}
 					>
+						{ednote && (
+							<p
+								css={css`
+									border: 1px solid;
+									padding: ${theme.euiTheme.size.s};
+									margin-bottom: ${theme.euiTheme.size.s};
+									font-weight: ${theme.euiTheme.font.weight.bold};
+								`}
+							>
+								{ednote}
+							</p>
+						)}
 						{byline && (
 							<>
 								<EuiDescriptionListTitle>Byline</EuiDescriptionListTitle>
@@ -112,6 +124,11 @@ export const WireDetail = ({
 								<EuiDescriptionListDescription>
 									<article
 										dangerouslySetInnerHTML={{ __html: bodyTextContent }}
+										css={css`
+											& p {
+												margin-bottom: ${theme.euiTheme.size.s};
+											}
+										`}
 										data-pinboard-selection-target
 									/>
 								</EuiDescriptionListDescription>

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -23,6 +23,7 @@ const FingerpostContentSchema = z
 		usage: z.string(),
 		location: z.string(),
 		bodyText: z.string(),
+		ednote: z.string(),
 	})
 	.partial();
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add a new suppliers: `GuAP` and `GuReuters`, which collects items with `source-feed: AP-Newswires` and `source-feed: Reuters-Newswires`. These are items passed to the ingestion system by the AP poller lambda added in #93, #98 and #92. These suppliers are now included in both the front end and the back end.

Also passes the `ednote` field through to the UI.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="288" alt="the 'suppliers' list in the front end, with `AP (Gu)` and `Reuters (Gu)` added to the bottom" src="https://github.com/user-attachments/assets/13418536-d1fa-4d82-bd8b-d29b3d4336c2" />


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
