### PR TITLE
Reuters poller business logic

### DIFF
--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -48,8 +48,10 @@ case class FingerpostWire(
     language: Option[String],
     usage: Option[String],
     location: Option[String],
-    bodyText: Option[String],
-    ednote: Option[String]
+    ednote: Option[String],
+    mediaCatCodes: Option[String],
+    `abstract`: Option[String],
+    bodyText: Option[String]
 )
 object FingerpostWire {
   // rename a couple of fields

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -48,7 +48,7 @@ export const WireDetail = ({
 		<Fragment>
 			{isShowingJson ? (
 				<EuiCodeBlock language="json">
-					{JSON.stringify(wire.content, null, 2)}
+					{JSON.stringify(wire, null, 2)}
 				</EuiCodeBlock>
 			) : (
 				<>

--- a/poller-lambdas/src/pollers/reuters/auth.ts
+++ b/poller-lambdas/src/pollers/reuters/auth.ts
@@ -1,0 +1,39 @@
+import { z } from 'zod';
+
+const AuthSchema = z.object({
+	access_token: z.string(),
+	expires_in: z.number(),
+	token_type: z.string(),
+});
+
+const scopes =
+	'https://api.thomsonreuters.com/auth/reutersconnect.contentapi.read https://api.thomsonreuters.com/auth/reutersconnect.contentapi.write';
+const authUrl = 'https://auth.thomsonreuters.com/oauth/token';
+const grantType = 'client_credentials';
+const audience = '7a14b6a2-73b8-4ab2-a610-80fb9f40f769';
+
+export async function auth(
+	clientId: string,
+	clientSecret: string,
+): Promise<string> {
+	const req = new Request(authUrl, {
+		method: 'POST',
+		headers: {
+			'content-type': 'application/x-www-form-urlencoded',
+		},
+		body: `grant_type=${grantType}&client_id=${clientId}&client_secret=${clientSecret}&audience=${audience}&scope=${encodeURIComponent(scopes)}`,
+	});
+	try {
+		console.log('Requesting new auth token from Reuters');
+		const response = await fetch(req);
+		const data = (await response.json()) as unknown;
+		const { access_token, expires_in } = AuthSchema.parse(data);
+		console.log(
+			`Received new auth token from Reuters, expires in ${expires_in} seconds`,
+		);
+		return access_token;
+	} catch (error) {
+		console.error(error);
+		throw new Error('Failed to get auth token from Reuters');
+	}
+}

--- a/poller-lambdas/src/pollers/reuters/reutersPoller.ts
+++ b/poller-lambdas/src/pollers/reuters/reutersPoller.ts
@@ -1,18 +1,256 @@
+import { parse } from 'node-html-parser';
+import { z } from 'zod';
+import type { IngestorInputBody } from '../../../../shared/types';
 import type {
 	FixedFrequencyPollFunction,
 	PollerInput,
 	SecretValue,
 } from '../../types';
+import { auth } from './auth';
+
+/**
+ * usn: unique story number. this is the same identifier as the guid
+ * version: The version of the news object which is identified by the uri property
+ * versionProcessed: timestamp when this version was processed in our internal systems
+ * versionedGuid: The globally unique identifier of the target item (guid) which also includes the version identifier
+ */
+const textItemsSearchQuery = `query NewTextItemsSearch {
+search(filter: { mediaTypes: TEXT }) {
+	pageInfo {
+		endCursor
+		hasNextPage
+	}
+	items {
+		caption
+		headLine
+		uri
+		usn
+		versionedGuid
+	}
+}
+}`;
+
+const NullishToStringOrUndefinedSchema = z
+	.string()
+	.nullish()
+	.transform((x) => x ?? undefined);
+
+const SearchDataSchema = z.object({
+	data: z.object({
+		search: z.object({
+			items: z.array(
+				z.object({
+					caption: NullishToStringOrUndefinedSchema,
+					headLine: NullishToStringOrUndefinedSchema,
+					uri: NullishToStringOrUndefinedSchema,
+					usn: NullishToStringOrUndefinedSchema,
+					versionedGuid: NullishToStringOrUndefinedSchema,
+				}),
+			),
+		}),
+	}),
+});
+
+/**
+ * PF: As far as I can tell this should include basically everything that's in the NewsML download,
+ * so we shouldn't need to fetch that as well.
+ */
+function itemQuery(itemId: string) {
+	return `query ItemDetailQuery {
+item(id: "${itemId}") {
+    byLine
+    copyrightNotice
+    versionCreated
+    fragment
+    headLine
+    versionedGuid
+    uri
+    language
+    type
+    profile
+    slug
+    usageTerms
+    usageTermsRole
+    version
+    credit
+    firstCreated
+    productLabel
+    pubStatus
+    urgency
+    usn
+    position
+    intro
+    bodyXhtml
+    bodyXhtmlRich
+    subject {
+        code
+        name
+        rel
+    }
+}}`;
+}
+
+const ReutersItemSchema = z.object({
+	byLine: NullishToStringOrUndefinedSchema,
+	copyrightNotice: NullishToStringOrUndefinedSchema,
+	versionCreated: NullishToStringOrUndefinedSchema,
+	fragment: NullishToStringOrUndefinedSchema,
+	headLine: NullishToStringOrUndefinedSchema,
+	versionedGuid: z.string(),
+	uri: NullishToStringOrUndefinedSchema,
+	language: NullishToStringOrUndefinedSchema,
+	type: NullishToStringOrUndefinedSchema,
+	profile: NullishToStringOrUndefinedSchema,
+	slug: NullishToStringOrUndefinedSchema,
+	usageTerms: NullishToStringOrUndefinedSchema,
+	usageTermsRole: NullishToStringOrUndefinedSchema,
+	version: NullishToStringOrUndefinedSchema,
+	credit: NullishToStringOrUndefinedSchema,
+	firstCreated: NullishToStringOrUndefinedSchema,
+	productLabel: NullishToStringOrUndefinedSchema,
+	pubStatus: NullishToStringOrUndefinedSchema,
+	urgency: z
+		.number()
+		.nullish()
+		.transform((x) => x ?? undefined),
+	usn: NullishToStringOrUndefinedSchema,
+	position: NullishToStringOrUndefinedSchema,
+	bodyXhtml: NullishToStringOrUndefinedSchema,
+	bodyXhtmlRich: NullishToStringOrUndefinedSchema,
+	subject: z.array(
+		z.object({
+			code: NullishToStringOrUndefinedSchema,
+			name: NullishToStringOrUndefinedSchema,
+			rel: NullishToStringOrUndefinedSchema,
+		}),
+	),
+});
+
+const itemResponseSchema = z.object({
+	data: z.object({
+		item: ReutersItemSchema,
+	}),
+});
+
+function itemResponseToIngestionLambdaInput(
+	item: z.infer<typeof ReutersItemSchema>,
+): IngestorInputBody {
+	const { bodyXhtmlRich, bodyXhtml } = item;
+	const bodyHtml = parse(bodyXhtmlRich ?? bodyXhtml ?? '').querySelector(
+		'body',
+	)?.innerHTML;
+	return {
+		originalContentText: item.bodyXhtmlRich,
+		uri: item.uri,
+		'source-feed': 'Reuters-Newswires',
+		usn: item.usn,
+		version: item.version,
+		type: item.type,
+		format: 'TODO',
+		mimeType: 'TODO',
+		firstVersion: item.firstCreated,
+		versionCreated: item.versionCreated,
+		dateTimeSent: item.versionCreated,
+		originalUrn: item.versionedGuid,
+		slug: item.slug,
+		headline: item.headLine,
+		byline: item.byLine,
+		priority: item.urgency?.toString() ?? '',
+		subjects: {
+			code: item.subject
+				.map((subject) => subject.code)
+				.filter((_): _ is string => _ !== undefined),
+		},
+		mediaCatCodes: '',
+		keywords: [],
+		organisation: { symbols: [] },
+		tabVtxt: 'X',
+		status: item.pubStatus,
+		usage: item.usageTerms,
+		ednote: '',
+		abstract: item.fragment,
+		body_text: bodyHtml,
+		copyrightNotice: item.copyrightNotice,
+		language: item.language,
+	};
+}
+
+const SecretValueSchema = z.object({
+	CLIENT_ID: z.string(),
+	CLIENT_SECRET: z.string(),
+	ACCESS_TOKEN: z.string().optional(),
+});
 
 export const reutersPoller = (async (
-	_secret: SecretValue,
-	_input: PollerInput,
+	secret: SecretValue,
+	input: PollerInput,
 ) => {
-	console.log('Reuters poller running');
-	await new Promise((resolve) => setTimeout(resolve, 1000));
+	const parsedSecret = SecretValueSchema.safeParse(JSON.parse(secret));
+	if (!parsedSecret.success) {
+		throw new Error('Failed to parse secret value for Reuters poller');
+	}
+	const { CLIENT_ID, CLIENT_SECRET, ACCESS_TOKEN } = parsedSecret.data;
+
+	let accessToken = ACCESS_TOKEN ?? (await auth(CLIENT_ID, CLIENT_SECRET));
+
+	async function fetchWithReauth(query: string) {
+		let searchResponse = await fetch(
+			'https://api.reutersconnect.com/content/graphql',
+			{
+				method: 'POST',
+				headers: {
+					'Content-Type': 'application/json',
+					Authorization: `Bearer ${accessToken}`,
+				},
+				body: JSON.stringify({
+					query: query,
+				}),
+			},
+		);
+		if (searchResponse.status === 401 || searchResponse.status === 419) {
+			const newAccessToken = await auth(CLIENT_ID, CLIENT_SECRET);
+			accessToken = newAccessToken;
+			searchResponse = await fetch(
+				'https://api.reutersconnect.com/content/graphql',
+				{
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+						Authorization: `Bearer ${accessToken}`,
+					},
+					body: JSON.stringify({
+						query: textItemsSearchQuery,
+					}),
+				},
+			);
+		}
+		return (await searchResponse.json()) as unknown;
+	}
+
+	const searchData = SearchDataSchema.parse(
+		await fetchWithReauth(textItemsSearchQuery),
+	);
+
+	const itemsToFetch = searchData.data.search.items
+		.map((item) => item.versionedGuid)
+		.filter((guid): guid is string => guid !== undefined);
+
+	const itemResponses = await Promise.all(
+		itemsToFetch.map(async (itemId) =>
+			itemResponseSchema.parse(await fetchWithReauth(itemQuery(itemId))),
+		),
+	);
+
 	return {
-		payloadForIngestionLambda: [],
-		valueForNextPoll: '',
-		idealFrequencyInSeconds: 30,
+		payloadForIngestionLambda: itemResponses.map((response) => ({
+			externalId: response.data.item.versionedGuid,
+			body: itemResponseToIngestionLambdaInput(response.data.item),
+		})),
+		valueForNextPoll: input,
+		idealFrequencyInSeconds: 60,
+		newSecretValue:
+			accessToken === ACCESS_TOKEN
+				? undefined
+				: JSON.stringify({ ...parsedSecret.data, ACCESS_TOKEN: accessToken }),
 	};
 }) satisfies FixedFrequencyPollFunction;

--- a/scripts/get-reuters-item.sh
+++ b/scripts/get-reuters-item.sh
@@ -1,0 +1,106 @@
+#!/bin/bash
+
+# Configuration
+SCOPES="https://api.thomsonreuters.com/auth/reutersconnect.contentapi.read https://api.thomsonreuters.com/auth/reutersconnect.contentapi.write"
+AUTH_URL="https://auth.thomsonreuters.com/oauth/token"
+GRANT_TYPE="client_credentials"
+AUDIENCE="7a14b6a2-73b8-4ab2-a610-80fb9f40f769"
+
+# Check if item ID is provided
+if [ -z "$1" ]; then
+    echo "Please provide an item id"
+    exit 1
+fi
+
+ITEM_ID="$1"
+
+CREDENTIALS=$(
+aws secretsmanager get-secret-value \
+    --region eu-west-1 \
+    --profile editorial-feeds \
+    --secret-id /CODE/editorial-feeds/newswires/reuters_poller_lambda \
+    --query SecretString \
+    --output text
+)
+CLIENT_ID=$(echo "$CREDENTIALS" | jq -r '.CLIENT_ID')
+CLIENT_SECRET=$(echo "$CREDENTIALS" | jq -r '.CLIENT_SECRET')
+
+if [ -z "$CLIENT_ID" ] || [ -z "$CLIENT_SECRET" ]; then
+    echo "Failed to retrieve credentials from AWS Secrets Manager; check you have valid credentials stored"
+    exit 1
+fi
+
+# Create GraphQL query
+QUERY=$(cat <<EOF
+query ItemDetailQuery {
+  item(id: "${ITEM_ID}") {
+    byLine
+    copyrightNotice
+    versionCreated
+    fragment
+    headLine
+    versionedGuid
+    uri
+    language
+    type
+    profile
+    slug
+    usageTerms
+    usageTermsRole
+    version
+    credit
+    firstCreated
+    productLabel
+    pubStatus
+    urgency
+    usn
+    position
+    intro
+    bodyXhtml
+    bodyXhtmlRich
+    subject {
+        code
+        name
+        rel
+    }
+  }
+}
+EOF
+)
+
+# Get auth token
+AUTH_RESPONSE=$(curl -s -X POST "$AUTH_URL" \
+    -H "Content-Type: application/x-www-form-urlencoded" \
+    --data-urlencode "grant_type=$GRANT_TYPE" \
+    --data-urlencode "client_id=$CLIENT_ID" \
+    --data-urlencode "client_secret=$CLIENT_SECRET" \
+    --data-urlencode "audience=$AUDIENCE" \
+    -d "scope=$SCOPES")
+
+ACCESS_TOKEN=$(echo "$AUTH_RESPONSE" | jq -r '.access_token')
+
+if [ -z "$ACCESS_TOKEN" ]; then
+    echo "Failed to get auth token from Reuters"
+    echo "Response: $AUTH_RESPONSE"
+    exit 1
+fi
+
+# Make GraphQL request
+echo "Fetching content..."
+
+REQUEST_PAYLOAD="{\"query\": $(echo "$QUERY" | jq -sR)}"
+
+# Make the request and store the response
+RESPONSE=$(curl -s -v -X POST "https://api.reutersconnect.com/content/graphql" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $ACCESS_TOKEN" \
+    -d "$REQUEST_PAYLOAD")
+
+# Check if we got a response
+if [ -z "$RESPONSE" ]; then
+    echo "No response received from the GraphQL endpoint"
+    exit 1
+fi
+
+# Try to parse the response as JSON and output it
+echo "$RESPONSE" | jq '.' || echo "Raw response (invalid JSON): $RESPONSE"

--- a/shared/pollers.ts
+++ b/shared/pollers.ts
@@ -23,9 +23,11 @@ export type PollerConfig = PollerLambdaProps & {
 
 export type PollerId = keyof typeof POLLERS_CONFIG;
 
+export const REUTERS_POLLING_FREQUENCY_IN_SECONDS = 60;
+
 export const POLLERS_CONFIG = {
 	// EXAMPLE_long_polling: {},
 	// EXAMPLE_fixed_frequency: { idealFrequencyInSeconds: 30 },
-	reuters: { idealFrequencyInSeconds: 60 },
+	reuters: { idealFrequencyInSeconds: REUTERS_POLLING_FREQUENCY_IN_SECONDS },
 	apPoller: {},
 } as const satisfies Record<string, PollerConfig>; // used to generate lambda etc. per agency, with config mapped


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

First pass at business logic for Reuters feed.

### Steps:

#### 1. Auth

  * Read auth token from Secrets
  * If the auth token fails, try to request a new one to use for subsequent calls using the client id and secret from Secrets

#### 2. Request feed via search for the last `n*1.2` seconds, where `n` is the frequency at which the poller runs.

  * nb. as per our conversation with Reuters' API team there is not currently a supported method for getting 'only new items since last poll', so this is my suggested heuristic for getting new stories, though it's not foolproof
  * this means there will be overlap between any two consecutive queries, but currently opting to rely on the ingestion lambda to deduplicate stories unless this proves problematic for performance or other reasons

#### 3. Pass the most recent auth token back

The poller lambda wrapper, as of #99, will check this value and update the Secret value if needed.

---

The implementation of (1) adds a little complexity and mutation that it would be nice to avoid, but the API guidelines suggest we shouldn't request new access tokens too often, so we should respect that. It could be refactored so that e.g. `fetchWithReauth` and `fetchAllPages` were defined outside the scope of the main function, and had `accessToken` passed as an argument, but on reflection it felt to me as though declaring `accessToken` via `let` makes it more explicit a) that it can mutate, and b) which functions can mutate it. I'm open to other perspectives though.

### Script

Also adds a script to help get raw item data from the Reuters API, to help with debugging.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Run locally
- [x] Deploy to CODE, see that Reuters stories are being processed as expected.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
