### PR TITLE
Initial AP and Reuters poller infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,6 @@ cdk.out
 
 vite.config.d.ts
 .DS_Store
-
+.vscode
+.bsp
+.metals

--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -18,11 +18,6 @@ exports[`The Newswires stack matches the snapshot 1`] = `
       "GuLambdaThrottlingAlarm",
       "GuAlarm",
       "GuAlarm",
-      "GuLambdaFunction",
-      "GuLambdaErrorPercentageAlarm",
-      "GuLambdaThrottlingAlarm",
-      "GuAlarm",
-      "GuAlarm",
       "GuGetS3ObjectsPolicy",
       "GuGetS3ObjectsPolicy",
       "GuSubnetListParameter",
@@ -355,1650 +350,6 @@ exports[`The Newswires stack matches the snapshot 1`] = `
         "TTL": 60,
       },
       "Type": "Guardian::DNS::RecordSet",
-    },
-    "EXAMPLEfixedfrequencyLambdaD9A07041": {
-      "DependsOn": [
-        "EXAMPLEfixedfrequencyLambdaServiceRoleDefaultPolicy272A9D10",
-        "EXAMPLEfixedfrequencyLambdaServiceRoleBA2F232F",
-      ],
-      "Properties": {
-        "Architectures": [
-          "arm64",
-        ],
-        "Code": {
-          "S3Bucket": {
-            "Ref": "DistributionBucketName",
-          },
-          "S3Key": "editorial-feeds/TEST/EXAMPLE_fixed_frequency_poller_lambda/poller-lambdas.zip",
-        },
-        "Environment": {
-          "Variables": {
-            "APP": "EXAMPLE_fixed_frequency_poller_lambda",
-            "INGESTION_LAMBDA_QUEUE_URL": {
-              "Fn::ImportValue": "mockWiresFeeds:ExportsOutputRefMockSourceQueue20B4D8C006FBA8DA",
-            },
-            "OWN_QUEUE_URL": {
-              "Ref": "EXAMPLEfixedfrequencyLambdaQueueF55F5480",
-            },
-            "SECRET_NAME": {
-              "Fn::Join": [
-                "-",
-                [
-                  {
-                    "Fn::Select": [
-                      0,
-                      {
-                        "Fn::Split": [
-                          "-",
-                          {
-                            "Fn::Select": [
-                              6,
-                              {
-                                "Fn::Split": [
-                                  ":",
-                                  {
-                                    "Ref": "EXAMPLEfixedfrequencySecretCB2DCB8C",
-                                  },
-                                ],
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                  {
-                    "Fn::Select": [
-                      1,
-                      {
-                        "Fn::Split": [
-                          "-",
-                          {
-                            "Fn::Select": [
-                              6,
-                              {
-                                "Fn::Split": [
-                                  ":",
-                                  {
-                                    "Ref": "EXAMPLEfixedfrequencySecretCB2DCB8C",
-                                  },
-                                ],
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              ],
-            },
-            "STACK": "editorial-feeds",
-            "STAGE": "TEST",
-          },
-        },
-        "FunctionName": "editorial-feeds-TEST-EXAMPLE_fixed_frequency_poller_lambda",
-        "Handler": "index.handlers.EXAMPLE_fixed_frequency",
-        "LoggingConfig": {
-          "LogFormat": "JSON",
-        },
-        "MemorySize": 128,
-        "RecursiveLoop": "Allow",
-        "ReservedConcurrentExecutions": 2,
-        "Role": {
-          "Fn::GetAtt": [
-            "EXAMPLEfixedfrequencyLambdaServiceRoleBA2F232F",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs20.x",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "EXAMPLE_fixed_frequency_poller_lambda",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newswires",
-          },
-          {
-            "Key": "Stack",
-            "Value": "editorial-feeds",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "Timeout": 60,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "EXAMPLEfixedfrequencyLambdaErrorPercentageAlarmForLambda1B4D14B2": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "newswiresemailalarmtopicB2906D97",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "The editorial-feeds-TEST-EXAMPLE_fixed_frequency_poller_lambda is erroring.",
-        "AlarmName": "editorial-feeds-TEST-EXAMPLE_fixed_frequency_poller_lambda_Error_Alarm",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 1,
-        "Metrics": [
-          {
-            "Expression": "100*m1/m2",
-            "Id": "expr_1",
-            "Label": {
-              "Fn::Join": [
-                "",
-                [
-                  "Error % of ",
-                  {
-                    "Ref": "EXAMPLEfixedfrequencyLambdaD9A07041",
-                  },
-                ],
-              ],
-            },
-          },
-          {
-            "Id": "m1",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "EXAMPLEfixedfrequencyLambdaD9A07041",
-                    },
-                  },
-                ],
-                "MetricName": "Errors",
-                "Namespace": "AWS/Lambda",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-          {
-            "Id": "m2",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "EXAMPLEfixedfrequencyLambdaD9A07041",
-                    },
-                  },
-                ],
-                "MetricName": "Invocations",
-                "Namespace": "AWS/Lambda",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-        ],
-        "OKActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "newswiresemailalarmtopicB2906D97",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "newswires",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newswires",
-          },
-          {
-            "Key": "Stack",
-            "Value": "editorial-feeds",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "Threshold": 0,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "EXAMPLEfixedfrequencyLambdaHaywireAlarm739FFA93": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "newswiresemailalarmtopicB2906D97",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "The editorial-feeds-TEST-EXAMPLE_fixed_frequency_poller_lambda has potentially gone haywire (has been invoked more frequently than expected).",
-        "AlarmName": "editorial-feeds-TEST-EXAMPLE_fixed_frequency_poller_lambda_Haywire_Alarm",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "Dimensions": [
-          {
-            "Name": "FunctionName",
-            "Value": "editorial-feeds-TEST-EXAMPLE_fixed_frequency_poller_lambda",
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "Invocations",
-        "Namespace": "AWS/Lambda",
-        "OKActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "newswiresemailalarmtopicB2906D97",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "Period": 300,
-        "Statistic": "Sum",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "newswires",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newswires",
-          },
-          {
-            "Key": "Stack",
-            "Value": "editorial-feeds",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "Threshold": 15,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "EXAMPLEfixedfrequencyLambdaQueueF55F5480": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "MessageRetentionPeriod": 300,
-        "QueueName": "editorial-feeds-TEST-EXAMPLE_fixed_frequency_poller_lambda_queue",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "newswires",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newswires",
-          },
-          {
-            "Key": "Stack",
-            "Value": "editorial-feeds",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "VisibilityTimeout": 60,
-      },
-      "Type": "AWS::SQS::Queue",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "EXAMPLEfixedfrequencyLambdaServiceRoleBA2F232F": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "EXAMPLE_fixed_frequency_poller_lambda",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newswires",
-          },
-          {
-            "Key": "Stack",
-            "Value": "editorial-feeds",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "EXAMPLEfixedfrequencyLambdaServiceRoleDefaultPolicy272A9D10": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                    ],
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                      "/editorial-feeds/TEST/EXAMPLE_fixed_frequency_poller_lambda/poller-lambdas.zip",
-                    ],
-                  ],
-                },
-              ],
-            },
-            {
-              "Action": "ssm:GetParametersByPath",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/TEST/editorial-feeds/EXAMPLE_fixed_frequency_poller_lambda",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "ssm:GetParameters",
-                "ssm:GetParameter",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/TEST/editorial-feeds/EXAMPLE_fixed_frequency_poller_lambda/*",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "secretsmanager:GetSecretValue",
-                "secretsmanager:DescribeSecret",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Ref": "EXAMPLEfixedfrequencySecretCB2DCB8C",
-              },
-            },
-            {
-              "Action": [
-                "sqs:ReceiveMessage",
-                "sqs:ChangeMessageVisibility",
-                "sqs:GetQueueUrl",
-                "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "EXAMPLEfixedfrequencyLambdaQueueF55F5480",
-                  "Arn",
-                ],
-              },
-            },
-            {
-              "Action": [
-                "sqs:SendMessage",
-                "sqs:GetQueueAttributes",
-                "sqs:GetQueueUrl",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "EXAMPLEfixedfrequencyLambdaQueueF55F5480",
-                  "Arn",
-                ],
-              },
-            },
-            {
-              "Action": [
-                "sqs:SendMessage",
-                "sqs:GetQueueAttributes",
-                "sqs:GetQueueUrl",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::ImportValue": "mockWiresFeeds:ExportsOutputFnGetAttMockSourceQueue20B4D8C0ArnCE5A6D0C",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "EXAMPLEfixedfrequencyLambdaServiceRoleDefaultPolicy272A9D10",
-        "Roles": [
-          {
-            "Ref": "EXAMPLEfixedfrequencyLambdaServiceRoleBA2F232F",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "EXAMPLEfixedfrequencyLambdaSqsEventSourceNewswiresEXAMPLEfixedfrequencyLambdaQueue19E585D8ADCAD8C9": {
-      "Properties": {
-        "BatchSize": 1,
-        "EventSourceArn": {
-          "Fn::GetAtt": [
-            "EXAMPLEfixedfrequencyLambdaQueueF55F5480",
-            "Arn",
-          ],
-        },
-        "FunctionName": {
-          "Ref": "EXAMPLEfixedfrequencyLambdaD9A07041",
-        },
-      },
-      "Type": "AWS::Lambda::EventSourceMapping",
-    },
-    "EXAMPLEfixedfrequencyLambdaStalledAlarm3E1E3005": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "newswiresemailalarmtopicB2906D97",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "The editorial-feeds-TEST-EXAMPLE_fixed_frequency_poller_lambda is potentially stalled (hasn't been invoked as frequently as expected).",
-        "AlarmName": "editorial-feeds-TEST-EXAMPLE_fixed_frequency_poller_lambda_Stalled_Alarm",
-        "ComparisonOperator": "LessThanThreshold",
-        "Dimensions": [
-          {
-            "Name": "FunctionName",
-            "Value": "editorial-feeds-TEST-EXAMPLE_fixed_frequency_poller_lambda",
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "Invocations",
-        "Namespace": "AWS/Lambda",
-        "OKActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "newswiresemailalarmtopicB2906D97",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "Period": 900,
-        "Statistic": "Sum",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "newswires",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newswires",
-          },
-          {
-            "Key": "Stack",
-            "Value": "editorial-feeds",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "Threshold": 30,
-        "TreatMissingData": "breaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "EXAMPLEfixedfrequencyLambdaThrottlingAlarmForLambda7B722356": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "newswiresemailalarmtopicB2906D97",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "The editorial-feeds-TEST-EXAMPLE_fixed_frequency_poller_lambda is throttling.",
-        "AlarmName": "editorial-feeds-TEST-EXAMPLE_fixed_frequency_poller_lambda_Throttling_Alarm",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "Dimensions": [
-          {
-            "Name": "FunctionName",
-            "Value": {
-              "Ref": "EXAMPLEfixedfrequencyLambdaD9A07041",
-            },
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "Throttles",
-        "Namespace": "AWS/Lambda",
-        "OKActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "newswiresemailalarmtopicB2906D97",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "Period": 60,
-        "Statistic": "Sum",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "newswires",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newswires",
-          },
-          {
-            "Key": "Stack",
-            "Value": "editorial-feeds",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "Threshold": 0,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "EXAMPLEfixedfrequencySecretCB2DCB8C": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "Description": "Secret for the EXAMPLE_fixed_frequency poller lambda",
-        "GenerateSecretString": {},
-        "Name": "/TEST/editorial-feeds/newswires/EXAMPLE_fixed_frequency_poller_lambda",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "newswires",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newswires",
-          },
-          {
-            "Key": "Stack",
-            "Value": "editorial-feeds",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-      },
-      "Type": "AWS::SecretsManager::Secret",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "EXAMPLElongpollingLambdaDC443D98": {
-      "DependsOn": [
-        "EXAMPLElongpollingLambdaServiceRoleDefaultPolicy72E70E87",
-        "EXAMPLElongpollingLambdaServiceRoleF2C4DC08",
-      ],
-      "Properties": {
-        "Architectures": [
-          "arm64",
-        ],
-        "Code": {
-          "S3Bucket": {
-            "Ref": "DistributionBucketName",
-          },
-          "S3Key": "editorial-feeds/TEST/EXAMPLE_long_polling_poller_lambda/poller-lambdas.zip",
-        },
-        "Environment": {
-          "Variables": {
-            "APP": "EXAMPLE_long_polling_poller_lambda",
-            "INGESTION_LAMBDA_QUEUE_URL": {
-              "Fn::ImportValue": "mockWiresFeeds:ExportsOutputRefMockSourceQueue20B4D8C006FBA8DA",
-            },
-            "OWN_QUEUE_URL": {
-              "Ref": "EXAMPLElongpollingLambdaQueue0E2C8DED",
-            },
-            "SECRET_NAME": {
-              "Fn::Join": [
-                "-",
-                [
-                  {
-                    "Fn::Select": [
-                      0,
-                      {
-                        "Fn::Split": [
-                          "-",
-                          {
-                            "Fn::Select": [
-                              6,
-                              {
-                                "Fn::Split": [
-                                  ":",
-                                  {
-                                    "Ref": "EXAMPLElongpollingSecret702B1E98",
-                                  },
-                                ],
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                  {
-                    "Fn::Select": [
-                      1,
-                      {
-                        "Fn::Split": [
-                          "-",
-                          {
-                            "Fn::Select": [
-                              6,
-                              {
-                                "Fn::Split": [
-                                  ":",
-                                  {
-                                    "Ref": "EXAMPLElongpollingSecret702B1E98",
-                                  },
-                                ],
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                ],
-              ],
-            },
-            "STACK": "editorial-feeds",
-            "STAGE": "TEST",
-          },
-        },
-        "FunctionName": "editorial-feeds-TEST-EXAMPLE_long_polling_poller_lambda",
-        "Handler": "index.handlers.EXAMPLE_long_polling",
-        "LoggingConfig": {
-          "LogFormat": "JSON",
-        },
-        "MemorySize": 128,
-        "RecursiveLoop": "Allow",
-        "ReservedConcurrentExecutions": 2,
-        "Role": {
-          "Fn::GetAtt": [
-            "EXAMPLElongpollingLambdaServiceRoleF2C4DC08",
-            "Arn",
-          ],
-        },
-        "Runtime": "nodejs20.x",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "EXAMPLE_long_polling_poller_lambda",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newswires",
-          },
-          {
-            "Key": "Stack",
-            "Value": "editorial-feeds",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "Timeout": 60,
-      },
-      "Type": "AWS::Lambda::Function",
-    },
-    "EXAMPLElongpollingLambdaErrorPercentageAlarmForLambda3358F222": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "newswiresemailalarmtopicB2906D97",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "The editorial-feeds-TEST-EXAMPLE_long_polling_poller_lambda is erroring.",
-        "AlarmName": "editorial-feeds-TEST-EXAMPLE_long_polling_poller_lambda_Error_Alarm",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "EvaluationPeriods": 1,
-        "Metrics": [
-          {
-            "Expression": "100*m1/m2",
-            "Id": "expr_1",
-            "Label": {
-              "Fn::Join": [
-                "",
-                [
-                  "Error % of ",
-                  {
-                    "Ref": "EXAMPLElongpollingLambdaDC443D98",
-                  },
-                ],
-              ],
-            },
-          },
-          {
-            "Id": "m1",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "EXAMPLElongpollingLambdaDC443D98",
-                    },
-                  },
-                ],
-                "MetricName": "Errors",
-                "Namespace": "AWS/Lambda",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-          {
-            "Id": "m2",
-            "MetricStat": {
-              "Metric": {
-                "Dimensions": [
-                  {
-                    "Name": "FunctionName",
-                    "Value": {
-                      "Ref": "EXAMPLElongpollingLambdaDC443D98",
-                    },
-                  },
-                ],
-                "MetricName": "Invocations",
-                "Namespace": "AWS/Lambda",
-              },
-              "Period": 60,
-              "Stat": "Sum",
-            },
-            "ReturnData": false,
-          },
-        ],
-        "OKActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "newswiresemailalarmtopicB2906D97",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "newswires",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newswires",
-          },
-          {
-            "Key": "Stack",
-            "Value": "editorial-feeds",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "Threshold": 0,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "EXAMPLElongpollingLambdaHaywireAlarmFB9A2851": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "newswiresemailalarmtopicB2906D97",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "The editorial-feeds-TEST-EXAMPLE_long_polling_poller_lambda has potentially gone haywire (has been invoked more frequently than expected).",
-        "AlarmName": "editorial-feeds-TEST-EXAMPLE_long_polling_poller_lambda_Haywire_Alarm",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "Dimensions": [
-          {
-            "Name": "FunctionName",
-            "Value": "editorial-feeds-TEST-EXAMPLE_long_polling_poller_lambda",
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "Invocations",
-        "Namespace": "AWS/Lambda",
-        "OKActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "newswiresemailalarmtopicB2906D97",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "Period": 60,
-        "Statistic": "Sum",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "newswires",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newswires",
-          },
-          {
-            "Key": "Stack",
-            "Value": "editorial-feeds",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "Threshold": 60,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "EXAMPLElongpollingLambdaQueue0E2C8DED": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "MessageRetentionPeriod": 300,
-        "QueueName": "editorial-feeds-TEST-EXAMPLE_long_polling_poller_lambda_queue",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "newswires",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newswires",
-          },
-          {
-            "Key": "Stack",
-            "Value": "editorial-feeds",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "VisibilityTimeout": 60,
-      },
-      "Type": "AWS::SQS::Queue",
-      "UpdateReplacePolicy": "Delete",
-    },
-    "EXAMPLElongpollingLambdaServiceRoleDefaultPolicy72E70E87": {
-      "Properties": {
-        "PolicyDocument": {
-          "Statement": [
-            {
-              "Action": [
-                "s3:GetObject*",
-                "s3:GetBucket*",
-                "s3:List*",
-              ],
-              "Effect": "Allow",
-              "Resource": [
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                    ],
-                  ],
-                },
-                {
-                  "Fn::Join": [
-                    "",
-                    [
-                      "arn:",
-                      {
-                        "Ref": "AWS::Partition",
-                      },
-                      ":s3:::",
-                      {
-                        "Ref": "DistributionBucketName",
-                      },
-                      "/editorial-feeds/TEST/EXAMPLE_long_polling_poller_lambda/poller-lambdas.zip",
-                    ],
-                  ],
-                },
-              ],
-            },
-            {
-              "Action": "ssm:GetParametersByPath",
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/TEST/editorial-feeds/EXAMPLE_long_polling_poller_lambda",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "ssm:GetParameters",
-                "ssm:GetParameter",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::Join": [
-                  "",
-                  [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
-                    {
-                      "Ref": "AWS::AccountId",
-                    },
-                    ":parameter/TEST/editorial-feeds/EXAMPLE_long_polling_poller_lambda/*",
-                  ],
-                ],
-              },
-            },
-            {
-              "Action": [
-                "secretsmanager:GetSecretValue",
-                "secretsmanager:DescribeSecret",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Ref": "EXAMPLElongpollingSecret702B1E98",
-              },
-            },
-            {
-              "Action": [
-                "sqs:ReceiveMessage",
-                "sqs:ChangeMessageVisibility",
-                "sqs:GetQueueUrl",
-                "sqs:DeleteMessage",
-                "sqs:GetQueueAttributes",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "EXAMPLElongpollingLambdaQueue0E2C8DED",
-                  "Arn",
-                ],
-              },
-            },
-            {
-              "Action": [
-                "sqs:SendMessage",
-                "sqs:GetQueueAttributes",
-                "sqs:GetQueueUrl",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::GetAtt": [
-                  "EXAMPLElongpollingLambdaQueue0E2C8DED",
-                  "Arn",
-                ],
-              },
-            },
-            {
-              "Action": [
-                "sqs:SendMessage",
-                "sqs:GetQueueAttributes",
-                "sqs:GetQueueUrl",
-              ],
-              "Effect": "Allow",
-              "Resource": {
-                "Fn::ImportValue": "mockWiresFeeds:ExportsOutputFnGetAttMockSourceQueue20B4D8C0ArnCE5A6D0C",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "PolicyName": "EXAMPLElongpollingLambdaServiceRoleDefaultPolicy72E70E87",
-        "Roles": [
-          {
-            "Ref": "EXAMPLElongpollingLambdaServiceRoleF2C4DC08",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Policy",
-    },
-    "EXAMPLElongpollingLambdaServiceRoleF2C4DC08": {
-      "Properties": {
-        "AssumeRolePolicyDocument": {
-          "Statement": [
-            {
-              "Action": "sts:AssumeRole",
-              "Effect": "Allow",
-              "Principal": {
-                "Service": "lambda.amazonaws.com",
-              },
-            },
-          ],
-          "Version": "2012-10-17",
-        },
-        "ManagedPolicyArns": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:",
-                {
-                  "Ref": "AWS::Partition",
-                },
-                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-              ],
-            ],
-          },
-        ],
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "EXAMPLE_long_polling_poller_lambda",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newswires",
-          },
-          {
-            "Key": "Stack",
-            "Value": "editorial-feeds",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-      },
-      "Type": "AWS::IAM::Role",
-    },
-    "EXAMPLElongpollingLambdaSqsEventSourceNewswiresEXAMPLElongpollingLambdaQueue7E62ACD815B2FCD9": {
-      "Properties": {
-        "BatchSize": 1,
-        "EventSourceArn": {
-          "Fn::GetAtt": [
-            "EXAMPLElongpollingLambdaQueue0E2C8DED",
-            "Arn",
-          ],
-        },
-        "FunctionName": {
-          "Ref": "EXAMPLElongpollingLambdaDC443D98",
-        },
-      },
-      "Type": "AWS::Lambda::EventSourceMapping",
-    },
-    "EXAMPLElongpollingLambdaStalledAlarm6F0BABB6": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "newswiresemailalarmtopicB2906D97",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "The editorial-feeds-TEST-EXAMPLE_long_polling_poller_lambda is potentially stalled (hasn't been invoked as frequently as expected).",
-        "AlarmName": "editorial-feeds-TEST-EXAMPLE_long_polling_poller_lambda_Stalled_Alarm",
-        "ComparisonOperator": "LessThanThreshold",
-        "Dimensions": [
-          {
-            "Name": "FunctionName",
-            "Value": "editorial-feeds-TEST-EXAMPLE_long_polling_poller_lambda",
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "Invocations",
-        "Namespace": "AWS/Lambda",
-        "OKActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "newswiresemailalarmtopicB2906D97",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "Period": 180,
-        "Statistic": "Sum",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "newswires",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newswires",
-          },
-          {
-            "Key": "Stack",
-            "Value": "editorial-feeds",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "Threshold": 1,
-        "TreatMissingData": "breaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "EXAMPLElongpollingLambdaThrottlingAlarmForLambda289EA080": {
-      "Properties": {
-        "ActionsEnabled": true,
-        "AlarmActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "newswiresemailalarmtopicB2906D97",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "AlarmDescription": "The editorial-feeds-TEST-EXAMPLE_long_polling_poller_lambda is throttling.",
-        "AlarmName": "editorial-feeds-TEST-EXAMPLE_long_polling_poller_lambda_Throttling_Alarm",
-        "ComparisonOperator": "GreaterThanThreshold",
-        "Dimensions": [
-          {
-            "Name": "FunctionName",
-            "Value": {
-              "Ref": "EXAMPLElongpollingLambdaDC443D98",
-            },
-          },
-        ],
-        "EvaluationPeriods": 1,
-        "MetricName": "Throttles",
-        "Namespace": "AWS/Lambda",
-        "OKActions": [
-          {
-            "Fn::Join": [
-              "",
-              [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
-                {
-                  "Ref": "AWS::AccountId",
-                },
-                ":",
-                {
-                  "Fn::GetAtt": [
-                    "newswiresemailalarmtopicB2906D97",
-                    "TopicName",
-                  ],
-                },
-              ],
-            ],
-          },
-        ],
-        "Period": 60,
-        "Statistic": "Sum",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "newswires",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newswires",
-          },
-          {
-            "Key": "Stack",
-            "Value": "editorial-feeds",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-        "Threshold": 0,
-        "TreatMissingData": "notBreaching",
-      },
-      "Type": "AWS::CloudWatch::Alarm",
-    },
-    "EXAMPLElongpollingSecret702B1E98": {
-      "DeletionPolicy": "Delete",
-      "Properties": {
-        "Description": "Secret for the EXAMPLE_long_polling poller lambda",
-        "GenerateSecretString": {},
-        "Name": "/TEST/editorial-feeds/newswires/EXAMPLE_long_polling_poller_lambda",
-        "Tags": [
-          {
-            "Key": "App",
-            "Value": "newswires",
-          },
-          {
-            "Key": "gu:cdk:version",
-            "Value": "TEST",
-          },
-          {
-            "Key": "gu:repo",
-            "Value": "guardian/newswires",
-          },
-          {
-            "Key": "Stack",
-            "Value": "editorial-feeds",
-          },
-          {
-            "Key": "Stage",
-            "Value": "TEST",
-          },
-        ],
-      },
-      "Type": "AWS::SecretsManager::Secret",
-      "UpdateReplacePolicy": "Delete",
     },
     "GetDistributablePolicyNewswires3D555C70": {
       "Properties": {
@@ -3867,6 +2218,828 @@ dpkg -i /newswires/newswires.deb",
         ],
       },
       "Type": "AWS::SNS::Topic",
+    },
+    "reutersLambda21FE513B": {
+      "DependsOn": [
+        "reutersLambdaServiceRoleDefaultPolicy86486920",
+        "reutersLambdaServiceRoleB1396562",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "editorial-feeds/TEST/reuters_poller_lambda/poller-lambdas.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "reuters_poller_lambda",
+            "INGESTION_LAMBDA_QUEUE_URL": {
+              "Fn::ImportValue": "mockWiresFeeds:ExportsOutputRefMockSourceQueue20B4D8C006FBA8DA",
+            },
+            "OWN_QUEUE_URL": {
+              "Ref": "reutersLambdaQueue7636161A",
+            },
+            "SECRET_NAME": {
+              "Fn::Join": [
+                "-",
+                [
+                  {
+                    "Fn::Select": [
+                      0,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "reutersSecretA9E37489",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    "Fn::Select": [
+                      1,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "reutersSecretA9E37489",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+            "STACK": "editorial-feeds",
+            "STAGE": "TEST",
+          },
+        },
+        "FunctionName": "editorial-feeds-TEST-reuters_poller_lambda",
+        "Handler": "index.handlers.reuters",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
+        "MemorySize": 128,
+        "RecursiveLoop": "Allow",
+        "ReservedConcurrentExecutions": 2,
+        "Role": {
+          "Fn::GetAtt": [
+            "reutersLambdaServiceRoleB1396562",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "reuters_poller_lambda",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 60,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "reutersLambdaErrorPercentageAlarmForLambdaA449406D": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "newswiresemailalarmtopicB2906D97",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "The editorial-feeds-TEST-reuters_poller_lambda is erroring.",
+        "AlarmName": "editorial-feeds-TEST-reuters_poller_lambda_Error_Alarm",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": {
+              "Fn::Join": [
+                "",
+                [
+                  "Error % of ",
+                  {
+                    "Ref": "reutersLambda21FE513B",
+                  },
+                ],
+              ],
+            },
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "reutersLambda21FE513B",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "reutersLambda21FE513B",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "newswiresemailalarmtopicB2906D97",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newswires",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "reutersLambdaHaywireAlarm583979E8": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "newswiresemailalarmtopicB2906D97",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "The editorial-feeds-TEST-reuters_poller_lambda has potentially gone haywire (has been invoked more frequently than expected).",
+        "AlarmName": "editorial-feeds-TEST-reuters_poller_lambda_Haywire_Alarm",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": "editorial-feeds-TEST-reuters_poller_lambda",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Namespace": "AWS/Lambda",
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "newswiresemailalarmtopicB2906D97",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "Period": 300,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newswires",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Threshold": 7.5,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "reutersLambdaQueue7636161A": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "MessageRetentionPeriod": 300,
+        "QueueName": "editorial-feeds-TEST-reuters_poller_lambda_queue",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newswires",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VisibilityTimeout": 60,
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "reutersLambdaServiceRoleB1396562": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "reuters_poller_lambda",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "reutersLambdaServiceRoleDefaultPolicy86486920": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/editorial-feeds/TEST/reuters_poller_lambda/poller-lambdas.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/editorial-feeds/reuters_poller_lambda",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/editorial-feeds/reuters_poller_lambda/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "reutersSecretA9E37489",
+              },
+            },
+            {
+              "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueUrl",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "reutersLambdaQueue7636161A",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "reutersLambdaQueue7636161A",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::ImportValue": "mockWiresFeeds:ExportsOutputFnGetAttMockSourceQueue20B4D8C0ArnCE5A6D0C",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "reutersLambdaServiceRoleDefaultPolicy86486920",
+        "Roles": [
+          {
+            "Ref": "reutersLambdaServiceRoleB1396562",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "reutersLambdaSqsEventSourceNewswiresreutersLambdaQueue461D5765E7006B8A": {
+      "Properties": {
+        "BatchSize": 1,
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "reutersLambdaQueue7636161A",
+            "Arn",
+          ],
+        },
+        "FunctionName": {
+          "Ref": "reutersLambda21FE513B",
+        },
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
+    },
+    "reutersLambdaStalledAlarm9A0557EB": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "newswiresemailalarmtopicB2906D97",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "The editorial-feeds-TEST-reuters_poller_lambda is potentially stalled (hasn't been invoked as frequently as expected).",
+        "AlarmName": "editorial-feeds-TEST-reuters_poller_lambda_Stalled_Alarm",
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": "editorial-feeds-TEST-reuters_poller_lambda",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Namespace": "AWS/Lambda",
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "newswiresemailalarmtopicB2906D97",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "Period": 900,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newswires",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Threshold": 15,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "reutersLambdaThrottlingAlarmForLambdaE74C58AB": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "newswiresemailalarmtopicB2906D97",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "The editorial-feeds-TEST-reuters_poller_lambda is throttling.",
+        "AlarmName": "editorial-feeds-TEST-reuters_poller_lambda_Throttling_Alarm",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "reutersLambda21FE513B",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Throttles",
+        "Namespace": "AWS/Lambda",
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "newswiresemailalarmtopicB2906D97",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newswires",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "reutersSecretA9E37489": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Description": "Secret for the reuters poller lambda",
+        "GenerateSecretString": {},
+        "Name": "/TEST/editorial-feeds/newswires/reuters_poller_lambda",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newswires",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
     },
   },
 }

--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -18,6 +18,11 @@ exports[`The Newswires stack matches the snapshot 1`] = `
       "GuLambdaThrottlingAlarm",
       "GuAlarm",
       "GuAlarm",
+      "GuLambdaFunction",
+      "GuLambdaErrorPercentageAlarm",
+      "GuLambdaThrottlingAlarm",
+      "GuAlarm",
+      "GuAlarm",
       "GuGetS3ObjectsPolicy",
       "GuGetS3ObjectsPolicy",
       "GuSubnetListParameter",
@@ -1988,6 +1993,828 @@ exports[`The Newswires stack matches the snapshot 1`] = `
         "ToPort": 9000,
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
+    },
+    "apPollerLambdaCA07C49A": {
+      "DependsOn": [
+        "apPollerLambdaServiceRoleDefaultPolicy1EF8D631",
+        "apPollerLambdaServiceRole1992B661",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "editorial-feeds/TEST/apPoller_poller_lambda/poller-lambdas.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "apPoller_poller_lambda",
+            "INGESTION_LAMBDA_QUEUE_URL": {
+              "Fn::ImportValue": "mockWiresFeeds:ExportsOutputRefMockSourceQueue20B4D8C006FBA8DA",
+            },
+            "OWN_QUEUE_URL": {
+              "Ref": "apPollerLambdaQueueCEBF3221",
+            },
+            "SECRET_NAME": {
+              "Fn::Join": [
+                "-",
+                [
+                  {
+                    "Fn::Select": [
+                      0,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "apPollerSecret4DA8E7BD",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  {
+                    "Fn::Select": [
+                      1,
+                      {
+                        "Fn::Split": [
+                          "-",
+                          {
+                            "Fn::Select": [
+                              6,
+                              {
+                                "Fn::Split": [
+                                  ":",
+                                  {
+                                    "Ref": "apPollerSecret4DA8E7BD",
+                                  },
+                                ],
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                ],
+              ],
+            },
+            "STACK": "editorial-feeds",
+            "STAGE": "TEST",
+          },
+        },
+        "FunctionName": "editorial-feeds-TEST-apPoller_poller_lambda",
+        "Handler": "index.handlers.apPoller",
+        "LoggingConfig": {
+          "LogFormat": "JSON",
+        },
+        "MemorySize": 128,
+        "RecursiveLoop": "Allow",
+        "ReservedConcurrentExecutions": 2,
+        "Role": {
+          "Fn::GetAtt": [
+            "apPollerLambdaServiceRole1992B661",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "apPoller_poller_lambda",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 60,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "apPollerLambdaErrorPercentageAlarmForLambda18550835": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "newswiresemailalarmtopicB2906D97",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "The editorial-feeds-TEST-apPoller_poller_lambda is erroring.",
+        "AlarmName": "editorial-feeds-TEST-apPoller_poller_lambda_Error_Alarm",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "EvaluationPeriods": 1,
+        "Metrics": [
+          {
+            "Expression": "100*m1/m2",
+            "Id": "expr_1",
+            "Label": {
+              "Fn::Join": [
+                "",
+                [
+                  "Error % of ",
+                  {
+                    "Ref": "apPollerLambdaCA07C49A",
+                  },
+                ],
+              ],
+            },
+          },
+          {
+            "Id": "m1",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "apPollerLambdaCA07C49A",
+                    },
+                  },
+                ],
+                "MetricName": "Errors",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+          {
+            "Id": "m2",
+            "MetricStat": {
+              "Metric": {
+                "Dimensions": [
+                  {
+                    "Name": "FunctionName",
+                    "Value": {
+                      "Ref": "apPollerLambdaCA07C49A",
+                    },
+                  },
+                ],
+                "MetricName": "Invocations",
+                "Namespace": "AWS/Lambda",
+              },
+              "Period": 60,
+              "Stat": "Sum",
+            },
+            "ReturnData": false,
+          },
+        ],
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "newswiresemailalarmtopicB2906D97",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newswires",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "apPollerLambdaHaywireAlarm8A959E3F": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "newswiresemailalarmtopicB2906D97",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "The editorial-feeds-TEST-apPoller_poller_lambda has potentially gone haywire (has been invoked more frequently than expected).",
+        "AlarmName": "editorial-feeds-TEST-apPoller_poller_lambda_Haywire_Alarm",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": "editorial-feeds-TEST-apPoller_poller_lambda",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Namespace": "AWS/Lambda",
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "newswiresemailalarmtopicB2906D97",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newswires",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Threshold": 60,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "apPollerLambdaQueueCEBF3221": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "MessageRetentionPeriod": 300,
+        "QueueName": "editorial-feeds-TEST-apPoller_poller_lambda_queue",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newswires",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "VisibilityTimeout": 60,
+      },
+      "Type": "AWS::SQS::Queue",
+      "UpdateReplacePolicy": "Delete",
+    },
+    "apPollerLambdaServiceRole1992B661": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "apPoller_poller_lambda",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "apPollerLambdaServiceRoleDefaultPolicy1EF8D631": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/editorial-feeds/TEST/apPoller_poller_lambda/poller-lambdas.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/editorial-feeds/apPoller_poller_lambda",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/editorial-feeds/apPoller_poller_lambda/*",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:GetSecretValue",
+                "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "apPollerSecret4DA8E7BD",
+              },
+            },
+            {
+              "Action": [
+                "sqs:ReceiveMessage",
+                "sqs:ChangeMessageVisibility",
+                "sqs:GetQueueUrl",
+                "sqs:DeleteMessage",
+                "sqs:GetQueueAttributes",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "apPollerLambdaQueueCEBF3221",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "apPollerLambdaQueueCEBF3221",
+                  "Arn",
+                ],
+              },
+            },
+            {
+              "Action": [
+                "sqs:SendMessage",
+                "sqs:GetQueueAttributes",
+                "sqs:GetQueueUrl",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::ImportValue": "mockWiresFeeds:ExportsOutputFnGetAttMockSourceQueue20B4D8C0ArnCE5A6D0C",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "apPollerLambdaServiceRoleDefaultPolicy1EF8D631",
+        "Roles": [
+          {
+            "Ref": "apPollerLambdaServiceRole1992B661",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
+    },
+    "apPollerLambdaSqsEventSourceNewswiresapPollerLambdaQueue911BC96A52716070": {
+      "Properties": {
+        "BatchSize": 1,
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "apPollerLambdaQueueCEBF3221",
+            "Arn",
+          ],
+        },
+        "FunctionName": {
+          "Ref": "apPollerLambdaCA07C49A",
+        },
+      },
+      "Type": "AWS::Lambda::EventSourceMapping",
+    },
+    "apPollerLambdaStalledAlarm5E199779": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "newswiresemailalarmtopicB2906D97",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "The editorial-feeds-TEST-apPoller_poller_lambda is potentially stalled (hasn't been invoked as frequently as expected).",
+        "AlarmName": "editorial-feeds-TEST-apPoller_poller_lambda_Stalled_Alarm",
+        "ComparisonOperator": "LessThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": "editorial-feeds-TEST-apPoller_poller_lambda",
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Invocations",
+        "Namespace": "AWS/Lambda",
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "newswiresemailalarmtopicB2906D97",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "Period": 180,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newswires",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Threshold": 1,
+        "TreatMissingData": "breaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "apPollerLambdaThrottlingAlarmForLambda9B677431": {
+      "Properties": {
+        "ActionsEnabled": true,
+        "AlarmActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "newswiresemailalarmtopicB2906D97",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "AlarmDescription": "The editorial-feeds-TEST-apPoller_poller_lambda is throttling.",
+        "AlarmName": "editorial-feeds-TEST-apPoller_poller_lambda_Throttling_Alarm",
+        "ComparisonOperator": "GreaterThanThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": {
+              "Ref": "apPollerLambdaCA07C49A",
+            },
+          },
+        ],
+        "EvaluationPeriods": 1,
+        "MetricName": "Throttles",
+        "Namespace": "AWS/Lambda",
+        "OKActions": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:aws:sns:",
+                {
+                  "Ref": "AWS::Region",
+                },
+                ":",
+                {
+                  "Ref": "AWS::AccountId",
+                },
+                ":",
+                {
+                  "Fn::GetAtt": [
+                    "newswiresemailalarmtopicB2906D97",
+                    "TopicName",
+                  ],
+                },
+              ],
+            ],
+          },
+        ],
+        "Period": 60,
+        "Statistic": "Sum",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newswires",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Threshold": 0,
+        "TreatMissingData": "notBreaching",
+      },
+      "Type": "AWS::CloudWatch::Alarm",
+    },
+    "apPollerSecret4DA8E7BD": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "Description": "Secret for the apPoller poller lambda",
+        "GenerateSecretString": {},
+        "Name": "/TEST/editorial-feeds/newswires/apPoller_poller_lambda",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newswires",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SecretsManager::Secret",
+      "UpdateReplacePolicy": "Delete",
     },
     "editorialfeedsTESTnewswires01BC2EBA": {
       "DependsOn": [

--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -438,7 +438,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
           },
         },
         "FunctionName": "editorial-feeds-TEST-EXAMPLE_fixed_frequency_poller_lambda",
-        "Handler": "index.EXAMPLE_fixed_frequency",
+        "Handler": "index.handlers.EXAMPLE_fixed_frequency",
         "LoggingConfig": {
           "LogFormat": "JSON",
         },
@@ -1260,7 +1260,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
           },
         },
         "FunctionName": "editorial-feeds-TEST-EXAMPLE_long_polling_poller_lambda",
-        "Handler": "index.EXAMPLE_long_polling",
+        "Handler": "index.handlers.EXAMPLE_long_polling",
         "LoggingConfig": {
           "LogFormat": "JSON",
         },

--- a/cdk/lib/__snapshots__/riffraff.test.ts.snap
+++ b/cdk/lib/__snapshots__/riffraff.test.ts.snap
@@ -45,6 +45,20 @@ deployments:
       fileName: poller-lambdas.zip
     actions:
       - uploadLambda
+  lambda-upload-eu-west-1-editorial-feeds-apPoller_poller_lambda:
+    type: aws-lambda
+    stacks:
+      - editorial-feeds
+    regions:
+      - eu-west-1
+    app: apPoller_poller_lambda
+    contentDirectory: poller-lambdas
+    parameters:
+      bucketSsmLookup: true
+      lookupByTags: true
+      fileName: poller-lambdas.zip
+    actions:
+      - uploadLambda
   asg-upload-eu-west-1-editorial-feeds-newswires:
     type: autoscaling
     actions:
@@ -79,6 +93,7 @@ deployments:
     dependencies:
       - lambda-upload-eu-west-1-editorial-feeds-ingestion-lambda
       - lambda-upload-eu-west-1-editorial-feeds-reuters_poller_lambda
+      - lambda-upload-eu-west-1-editorial-feeds-apPoller_poller_lambda
       - asg-upload-eu-west-1-editorial-feeds-newswires
       - cfn-eu-west-1-editorial-feeds-wires-feeds
   lambda-update-eu-west-1-editorial-feeds-ingestion-lambda:
@@ -104,6 +119,22 @@ deployments:
     regions:
       - eu-west-1
     app: reuters_poller_lambda
+    contentDirectory: poller-lambdas
+    parameters:
+      bucketSsmLookup: true
+      lookupByTags: true
+      fileName: poller-lambdas.zip
+    actions:
+      - updateLambda
+    dependencies:
+      - cfn-eu-west-1-editorial-feeds-newswires
+  lambda-update-eu-west-1-editorial-feeds-apPoller_poller_lambda:
+    type: aws-lambda
+    stacks:
+      - editorial-feeds
+    regions:
+      - eu-west-1
+    app: apPoller_poller_lambda
     contentDirectory: poller-lambdas
     parameters:
       bucketSsmLookup: true

--- a/cdk/lib/__snapshots__/riffraff.test.ts.snap
+++ b/cdk/lib/__snapshots__/riffraff.test.ts.snap
@@ -31,27 +31,13 @@ deployments:
       fileName: ingestion-lambda.zip
     actions:
       - uploadLambda
-  lambda-upload-eu-west-1-editorial-feeds-EXAMPLE_long_polling_poller_lambda:
+  lambda-upload-eu-west-1-editorial-feeds-reuters_poller_lambda:
     type: aws-lambda
     stacks:
       - editorial-feeds
     regions:
       - eu-west-1
-    app: EXAMPLE_long_polling_poller_lambda
-    contentDirectory: poller-lambdas
-    parameters:
-      bucketSsmLookup: true
-      lookupByTags: true
-      fileName: poller-lambdas.zip
-    actions:
-      - uploadLambda
-  lambda-upload-eu-west-1-editorial-feeds-EXAMPLE_fixed_frequency_poller_lambda:
-    type: aws-lambda
-    stacks:
-      - editorial-feeds
-    regions:
-      - eu-west-1
-    app: EXAMPLE_fixed_frequency_poller_lambda
+    app: reuters_poller_lambda
     contentDirectory: poller-lambdas
     parameters:
       bucketSsmLookup: true
@@ -92,10 +78,7 @@ deployments:
           Encrypted: 'true'
     dependencies:
       - lambda-upload-eu-west-1-editorial-feeds-ingestion-lambda
-      - >-
-        lambda-upload-eu-west-1-editorial-feeds-EXAMPLE_long_polling_poller_lambda
-      - >-
-        lambda-upload-eu-west-1-editorial-feeds-EXAMPLE_fixed_frequency_poller_lambda
+      - lambda-upload-eu-west-1-editorial-feeds-reuters_poller_lambda
       - asg-upload-eu-west-1-editorial-feeds-newswires
       - cfn-eu-west-1-editorial-feeds-wires-feeds
   lambda-update-eu-west-1-editorial-feeds-ingestion-lambda:
@@ -114,29 +97,13 @@ deployments:
       - updateLambda
     dependencies:
       - cfn-eu-west-1-editorial-feeds-newswires
-  lambda-update-eu-west-1-editorial-feeds-EXAMPLE_long_polling_poller_lambda:
+  lambda-update-eu-west-1-editorial-feeds-reuters_poller_lambda:
     type: aws-lambda
     stacks:
       - editorial-feeds
     regions:
       - eu-west-1
-    app: EXAMPLE_long_polling_poller_lambda
-    contentDirectory: poller-lambdas
-    parameters:
-      bucketSsmLookup: true
-      lookupByTags: true
-      fileName: poller-lambdas.zip
-    actions:
-      - updateLambda
-    dependencies:
-      - cfn-eu-west-1-editorial-feeds-newswires
-  lambda-update-eu-west-1-editorial-feeds-EXAMPLE_fixed_frequency_poller_lambda:
-    type: aws-lambda
-    stacks:
-      - editorial-feeds
-    regions:
-      - eu-west-1
-    app: EXAMPLE_fixed_frequency_poller_lambda
+    app: reuters_poller_lambda
     contentDirectory: poller-lambdas
     parameters:
       bucketSsmLookup: true

--- a/cdk/lib/constructs/pollerLambda.ts
+++ b/cdk/lib/constructs/pollerLambda.ts
@@ -98,7 +98,7 @@ export class PollerLambda {
 			},
 			memorySize: pollerConfig.overrideLambdaMemoryMB ?? 128,
 			timeout,
-			handler: `index.${pollerId}`, // see programmatically generated exports in poller-lambdas/src/index.ts
+			handler: `index.handlers.${pollerId}`, // see programmatically generated exports in poller-lambdas/src/index.ts
 			fileName: `poller-lambdas.zip`, // shared zip for all the poller-lambdas
 		});
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,21 @@
 			"cdk.out",
 			".eslintrc.js",
 			"jest.config.js"
-		]
+		],
+		"rules": {
+			"@typescript-eslint/no-unused-vars": [
+				"error",
+				{
+					"args": "all",
+					"argsIgnorePattern": "^_",
+					"caughtErrors": "all",
+					"caughtErrorsIgnorePattern": "^_",
+					"destructuredArrayIgnorePattern": "^_",
+					"varsIgnorePattern": "^_",
+					"ignoreRestSiblings": true
+				}
+			]
+		}
 	},
 	"dependencies": {
 		"zod": "3.23.8"

--- a/poller-lambdas/localRun.ts
+++ b/poller-lambdas/localRun.ts
@@ -8,7 +8,7 @@ import {
 	POLLERS_CONFIG,
 } from '../shared/pollers';
 import { sqs } from './src/aws';
-import handlers from './src/index';
+import { handlers } from './src/index';
 import type { HandlerInputSqsPayload } from './src/types';
 
 const fakeInvoke = async (

--- a/poller-lambdas/src/index.ts
+++ b/poller-lambdas/src/index.ts
@@ -5,6 +5,7 @@ import type { PollerId } from '../../shared/pollers';
 import { POLLER_LAMBDA_ENV_VAR_KEYS } from '../../shared/pollers';
 import { queueNextInvocation, secretsManager, sqs } from './aws';
 import { getEnvironmentVariableOrCrash } from './config';
+import { apPoller } from './pollers/ap/apPoller';
 import { reutersPoller } from './pollers/reuters/reutersPoller';
 import type { HandlerInputSqsPayload, PollFunction } from './types';
 import { isFixedFrequencyPollOutput } from './types';
@@ -102,6 +103,7 @@ export const handlers = {
 	// EXAMPLE_long_polling: pollerWrapper(EXAMPLE_long_polling),
 	// EXAMPLE_fixed_frequency: pollerWrapper(EXAMPLE_fixed_frequency),
 	reuters: pollerWrapper(reutersPoller),
+	apPoller: pollerWrapper(apPoller),
 } satisfies Record<
 	PollerId,
 	(sqsEvent: HandlerInputSqsPayload) => Promise<void>

--- a/poller-lambdas/src/index.ts
+++ b/poller-lambdas/src/index.ts
@@ -5,8 +5,7 @@ import type { PollerId } from '../../shared/pollers';
 import { POLLER_LAMBDA_ENV_VAR_KEYS } from '../../shared/pollers';
 import { queueNextInvocation, secretsManager, sqs } from './aws';
 import { getEnvironmentVariableOrCrash } from './config';
-import { EXAMPLE_fixed_frequency } from './pollers/EXAMPLE_fixed_frequency';
-import { EXAMPLE_long_polling } from './pollers/EXAMPLE_long_polling';
+import { reutersPoller } from './pollers/reuters/reutersPoller';
 import type { HandlerInputSqsPayload, PollFunction } from './types';
 import { isFixedFrequencyPollOutput } from './types';
 
@@ -100,8 +99,9 @@ const pollerWrapper =
 	};
 
 export const handlers = {
-	EXAMPLE_long_polling: pollerWrapper(EXAMPLE_long_polling),
-	EXAMPLE_fixed_frequency: pollerWrapper(EXAMPLE_fixed_frequency),
+	// EXAMPLE_long_polling: pollerWrapper(EXAMPLE_long_polling),
+	// EXAMPLE_fixed_frequency: pollerWrapper(EXAMPLE_fixed_frequency),
+	reuters: pollerWrapper(reutersPoller),
 } satisfies Record<
 	PollerId,
 	(sqsEvent: HandlerInputSqsPayload) => Promise<void>

--- a/poller-lambdas/src/index.ts
+++ b/poller-lambdas/src/index.ts
@@ -99,8 +99,7 @@ const pollerWrapper =
 		}
 	};
 
-// eslint-disable-next-line import/no-default-export -- we need this to expose the pollers as named handlers but the shape verified with 'satisfies' keyword
-export default {
+export const handlers = {
 	EXAMPLE_long_polling: pollerWrapper(EXAMPLE_long_polling),
 	EXAMPLE_fixed_frequency: pollerWrapper(EXAMPLE_fixed_frequency),
 } satisfies Record<

--- a/poller-lambdas/src/pollers/ap/apPoller.ts
+++ b/poller-lambdas/src/pollers/ap/apPoller.ts
@@ -1,0 +1,10 @@
+import type { LongPollFunction, PollerInput, SecretValue } from '../../types';
+
+export const apPoller = (async (_secret: SecretValue, _input: PollerInput) => {
+	console.log('AP poller running');
+	await new Promise((resolve) => setTimeout(resolve, 15000));
+	return {
+		payloadForIngestionLambda: [],
+		valueForNextPoll: '',
+	};
+}) satisfies LongPollFunction;

--- a/poller-lambdas/src/pollers/reuters/reutersPoller.ts
+++ b/poller-lambdas/src/pollers/reuters/reutersPoller.ts
@@ -1,0 +1,18 @@
+import type {
+	FixedFrequencyPollFunction,
+	PollerInput,
+	SecretValue,
+} from '../../types';
+
+export const reutersPoller = (async (
+	_secret: SecretValue,
+	_input: PollerInput,
+) => {
+	console.log('Reuters poller running');
+	await new Promise((resolve) => setTimeout(resolve, 1000));
+	return {
+		payloadForIngestionLambda: [],
+		valueForNextPoll: '',
+		idealFrequencyInSeconds: 30,
+	};
+}) satisfies FixedFrequencyPollFunction;

--- a/shared/pollers.ts
+++ b/shared/pollers.ts
@@ -24,6 +24,7 @@ export type PollerConfig = PollerLambdaProps & {
 export type PollerId = keyof typeof POLLERS_CONFIG;
 
 export const POLLERS_CONFIG = {
-	EXAMPLE_long_polling: {},
-	EXAMPLE_fixed_frequency: { idealFrequencyInSeconds: 30 },
+	// EXAMPLE_long_polling: {},
+	// EXAMPLE_fixed_frequency: { idealFrequencyInSeconds: 30 },
+	reuters: { idealFrequencyInSeconds: 60 },
 } as const satisfies Record<string, PollerConfig>; // used to generate lambda etc. per agency, with config mapped

--- a/shared/pollers.ts
+++ b/shared/pollers.ts
@@ -27,4 +27,5 @@ export const POLLERS_CONFIG = {
 	// EXAMPLE_long_polling: {},
 	// EXAMPLE_fixed_frequency: { idealFrequencyInSeconds: 30 },
 	reuters: { idealFrequencyInSeconds: 60 },
+	apPoller: {},
 } as const satisfies Record<string, PollerConfig>; // used to generate lambda etc. per agency, with config mapped


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Add minimal definition of Reuters and AP poller lambdas, using the patterns added in #83:
  - d878e2fee6628a1d19cfddd77db51d9a47fe5a23
  - 9c2816cf2899e729b64518ce26a7858f80af7696 
- Fixes the poller lambdas `index.ts` export, so that the lambdas can find the right function to run: 548ac91cf23b539513170e0183e263ff84b2fbb4

Getting this merged into `main` will make the branch deployable to CODE again, and the actual business logic for the two pollers can then be added at a later point.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Successful deployment to CODE.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
