### PR TITLE
Display fingerpost supplier on the feed

### DIFF
--- a/newswires/app/conf/SourceFeedSupplierMapping.scala
+++ b/newswires/app/conf/SourceFeedSupplierMapping.scala
@@ -4,6 +4,15 @@ object SourceFeedSupplierMapping {
   def sourceFeedsFromSupplier(supplierName: String): Option[List[String]] =
     lookup.get(supplierName.toUpperCase())
 
+  def supplierFromSourceFeed(sourceFeed: String): Option[String] =
+    lookup
+      .find { case (_, sourceFeeds) =>
+        sourceFeeds.contains(sourceFeed)
+      }
+      .map { case (supplier, _) =>
+        supplier
+      }
+
   private val lookup = Map(
     "REUTERS" -> List("REUTERS"),
     "AAP" -> List("AAP"),

--- a/newswires/client/src/WireItemTable.tsx
+++ b/newswires/client/src/WireItemTable.tsx
@@ -49,10 +49,11 @@ export const WireItemTable = ({ wires }: { wires: WireData[] }) => {
 				<EuiTableHeaderCell>Version Created</EuiTableHeaderCell>
 			</EuiTableHeader>
 			<EuiTableBody>
-				{wires.map(({ id, content, isFromRefresh, highlight }) => (
+				{wires.map(({ id, supplier, content, isFromRefresh, highlight }) => (
 					<WireDataRow
 						key={id}
 						id={id}
+						supplier={supplier}
 						content={content}
 						isFromRefresh={isFromRefresh}
 						highlight={highlight}
@@ -67,6 +68,7 @@ export const WireItemTable = ({ wires }: { wires: WireData[] }) => {
 
 const WireDataRow = ({
 	id,
+	supplier,
 	content,
 	highlight,
 	selected,
@@ -74,6 +76,7 @@ const WireDataRow = ({
 	handleSelect,
 }: {
 	id: number;
+	supplier: string;
 	content: WireData['content'];
 	highlight: string;
 	selected: boolean;
@@ -107,7 +110,8 @@ const WireDataRow = ({
 				<EuiFlexGroup direction="column" gutterSize="xs">
 					<EuiTitle size="xxs">
 						<h3>
-							{hasSlug ? content.slug : (content.headline ?? 'No headline')}
+							{hasSlug ? content.slug : (content.headline ?? 'No headline')} [
+							{supplier}]
 						</h3>
 					</EuiTitle>
 					{hasSlug && (

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -28,6 +28,7 @@ const FingerpostContentSchema = z
 
 export const WireDataSchema = z.object({
 	id: z.number(),
+	supplier: z.string(),
 	externalId: z.string(),
 	ingestedAt: z.string(),
 	content: FingerpostContentSchema,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Display the supplier in the feed to identify the source of each item.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

**Given** the feed items have been populated in the database
**When** going to the main feed page
**Then** the supplier should be displayed for each feed item

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Displaying the feed supplier for each feed item allows users to identify the source of each item and compare items coming from Fingerpost with items ingested directly from the supplier.

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
