### PR TITLE
Jest setup for `poller-lambdas` project

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,12 @@ const generateProject = (name) => {
 	return {
 		displayName: name,
 		transform: {
-			'^.+\\.tsx?$': 'ts-jest',
+			'^.+\\.tsx?$': [
+				'ts-jest',
+				{
+					isolatedModules: true,
+				},
+			],
 		},
 		testMatch: [`<rootDir>/${name}/**/*.test.ts`],
 		setupFilesAfterEnv: [`./${name}/jest.setup.js`],
@@ -12,5 +17,5 @@ const generateProject = (name) => {
 module.exports = {
 	verbose: true,
 	testEnvironment: 'node',
-	projects: ['cdk', 'ingestion-lambda'].map(generateProject),
+	projects: ['cdk', 'ingestion-lambda', 'poller-lambdas'].map(generateProject),
 };

--- a/poller-lambdas/package.json
+++ b/poller-lambdas/package.json
@@ -7,7 +7,8 @@
 		"typecheck": "tsc -noEmit",
 		"build": "esbuild src/index.ts --bundle --minify --outfile=dist/index.js --external:@aws-sdk --external:aws-sdk --platform=node",
 		"lint": "eslint src/** --ext .ts --no-error-on-unmatched-pattern --fix",
-		"lint:ci": "eslint src/** --ext .ts --no-error-on-unmatched-pattern"
+		"lint:ci": "eslint src/** --ext .ts --no-error-on-unmatched-pattern",
+		"test": "jest --detectOpenHandles --config ../jest.config.js --selectProjects poller-lambdas"
 	},
 	"dependencies": {},
 	"devDependencies": {

--- a/poller-lambdas/src/test.test.ts
+++ b/poller-lambdas/src/test.test.ts
@@ -1,0 +1,5 @@
+describe('test', () => {
+	it('should pass', () => {
+		expect(true).toBe(true);
+	});
+});


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add config and a demo Jest test for the `poller-lambdas` project, in preparation for adding some actual tests.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
