### PR TITLE
Pollers can update their own secrets

### DIFF
--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -2532,6 +2532,16 @@ exports[`The Newswires stack matches the snapshot 1`] = `
             },
             {
               "Action": [
+                "secretsmanager:PutSecretValue",
+                "secretsmanager:UpdateSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "apPollerSecret4DA8E7BD",
+              },
+            },
+            {
+              "Action": [
                 "sqs:ReceiveMessage",
                 "sqs:ChangeMessageVisibility",
                 "sqs:GetQueueUrl",
@@ -3576,6 +3586,16 @@ dpkg -i /newswires/newswires.deb",
               "Action": [
                 "secretsmanager:GetSecretValue",
                 "secretsmanager:DescribeSecret",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Ref": "reutersSecretA9E37489",
+              },
+            },
+            {
+              "Action": [
+                "secretsmanager:PutSecretValue",
+                "secretsmanager:UpdateSecret",
               ],
               "Effect": "Allow",
               "Resource": {

--- a/cdk/lib/constructs/pollerLambda.ts
+++ b/cdk/lib/constructs/pollerLambda.ts
@@ -103,6 +103,7 @@ export class PollerLambda {
 		});
 
 		secret.grantRead(lambda);
+		secret.grantWrite(lambda);
 
 		// wire up lambda to process its own queue
 		lambda.addEventSource(new SqsEventSource(lambdaQueue, { batchSize: 1 }));

--- a/poller-lambdas/src/types.ts
+++ b/poller-lambdas/src/types.ts
@@ -7,6 +7,7 @@ export type PollerInput = string;
 export interface CorePollerOutput {
 	payloadForIngestionLambda: IngestorPayload[] | IngestorPayload;
 	valueForNextPoll: PollerInput;
+	newSecretValue?: SecretValue;
 }
 export type LongPollOutput = CorePollerOutput;
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add a mechanism allowing a poller lambda to update its own secret.

This will be used in the upcoming #92 PR, to store an auth token in the secret that can be re-used across multiple lambda runs while it's still valid.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
