### PR TITLE
Newswires-UI: add offline banner when data update fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 !.eslintrc.js
 node_modules
 dist
+out
+coverage
 
 .idea
 

--- a/newswires/client/package-lock.json
+++ b/newswires/client/package-lock.json
@@ -23,6 +23,7 @@
 				"@eslint/js": "^9.9.0",
 				"@guardian/eslint-config": "9.0.0",
 				"@guardian/prettier": "^8.0.1",
+				"@testing-library/react": "^16.1.0",
 				"@types/react": "^18.3.3",
 				"@types/react-dom": "^18.3.0",
 				"@types/sanitize-html": "^2.13.0",
@@ -35,6 +36,7 @@
 				"eslint-plugin-react-refresh": "^0.4.9",
 				"globals": "^15.9.0",
 				"jest": "29.7.0",
+				"jest-environment-jsdom": "^29.7.0",
 				"prettier": "^3.3.3",
 				"ts-jest": "29.2.4",
 				"typescript": "^5.5.3",
@@ -2568,6 +2570,193 @@
 				"@sinonjs/commons": "^3.0.0"
 			}
 		},
+		"node_modules/@testing-library/dom": {
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
+			"integrity": "sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.10.4",
+				"@babel/runtime": "^7.12.5",
+				"@types/aria-query": "^5.0.1",
+				"aria-query": "5.3.0",
+				"chalk": "^4.1.0",
+				"dom-accessibility-api": "^0.5.9",
+				"lz-string": "^1.5.0",
+				"pretty-format": "^27.0.2"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/ansi-styles": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"color-convert": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/chalk": {
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-styles": "^4.1.0",
+				"supports-color": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/chalk?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/color-convert": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"color-name": "~1.1.4"
+			},
+			"engines": {
+				"node": ">=7.0.0"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/color-name": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@testing-library/dom/node_modules/has-flag": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/pretty-format": {
+			"version": "27.5.1",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+			"integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"ansi-regex": "^5.0.1",
+				"ansi-styles": "^5.0.0",
+				"react-is": "^17.0.1"
+			},
+			"engines": {
+				"node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/pretty-format/node_modules/ansi-styles": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+			"integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
+			}
+		},
+		"node_modules/@testing-library/dom/node_modules/react-is": {
+			"version": "17.0.2",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+			"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
+		"node_modules/@testing-library/dom/node_modules/supports-color": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"dependencies": {
+				"has-flag": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/@testing-library/react": {
+			"version": "16.1.0",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.1.0.tgz",
+			"integrity": "sha512-Q2ToPvg0KsVL0ohND9A3zLJWcOXXcO8IDu3fj11KhNt0UlCWyFyvnCIBkd12tidB2lkiVRG8VFqdhcqhqnAQtg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/runtime": "^7.12.5"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@testing-library/dom": "^10.0.0",
+				"@types/react": "^18.0.0 || ^19.0.0",
+				"@types/react-dom": "^18.0.0 || ^19.0.0",
+				"react": "^18.0.0 || ^19.0.0",
+				"react-dom": "^18.0.0 || ^19.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@types/react": {
+					"optional": true
+				},
+				"@types/react-dom": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/@tootallnate/once": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10"
+			}
+		},
+		"node_modules/@types/aria-query": {
+			"version": "5.0.4",
+			"resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+			"integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/@types/babel__core": {
 			"version": "7.20.5",
 			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2672,6 +2861,31 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/istanbul-lib-report": "*"
+			}
+		},
+		"node_modules/@types/jsdom": {
+			"version": "20.0.1",
+			"resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+			"integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/tough-cookie": "*",
+				"parse5": "^7.0.0"
+			}
+		},
+		"node_modules/@types/jsdom/node_modules/parse5": {
+			"version": "7.2.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+			"integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^4.5.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
 		"node_modules/@types/json5": {
@@ -2780,6 +2994,13 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
 			"integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@types/tough-cookie": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+			"integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3066,6 +3287,14 @@
 				"vite": "^4.2.0 || ^5.0.0"
 			}
 		},
+		"node_modules/abab": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+			"integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+			"deprecated": "Use your platform's native atob() and btoa() methods instead",
+			"dev": true,
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/acorn": {
 			"version": "8.12.1",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.1.tgz",
@@ -3079,6 +3308,17 @@
 				"node": ">=0.4.0"
 			}
 		},
+		"node_modules/acorn-globals": {
+			"version": "7.0.1",
+			"resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+			"integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.1.0",
+				"acorn-walk": "^8.0.2"
+			}
+		},
 		"node_modules/acorn-jsx": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -3087,6 +3327,32 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+			}
+		},
+		"node_modules/acorn-walk": {
+			"version": "8.3.4",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+			"integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"acorn": "^8.11.0"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/agent-base": {
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6.0.0"
 			}
 		},
 		"node_modules/ajv": {
@@ -3187,6 +3453,17 @@
 			},
 			"engines": {
 				"node": ">=10"
+			}
+		},
+		"node_modules/aria-query": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+			"integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"peer": true,
+			"dependencies": {
+				"dequal": "^2.0.3"
 			}
 		},
 		"node_modules/array-buffer-byte-length": {
@@ -3351,6 +3628,13 @@
 			"version": "3.2.6",
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
 			"integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3958,6 +4242,19 @@
 			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
 			"license": "MIT"
 		},
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/comma-separated-tokens": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
@@ -4128,11 +4425,53 @@
 				"tiny-invariant": "^1.0.6"
 			}
 		},
+		"node_modules/cssom": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+			"integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/cssstyle": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+			"integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"cssom": "~0.3.6"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/cssstyle/node_modules/cssom": {
+			"version": "0.3.8",
+			"resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+			"integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/csstype": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
 			"integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
 			"license": "MIT"
+		},
+		"node_modules/data-urls": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+			"integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abab": "^2.0.6",
+				"whatwg-mimetype": "^3.0.0",
+				"whatwg-url": "^11.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/data-view-buffer": {
 			"version": "1.0.1",
@@ -4205,6 +4544,13 @@
 				}
 			}
 		},
+		"node_modules/decimal.js": {
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.4.3.tgz",
+			"integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/dedent": {
 			"version": "1.5.3",
 			"resolved": "https://registry.npmjs.org/dedent/-/dedent-1.5.3.tgz",
@@ -4272,6 +4618,27 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
@@ -4310,6 +4677,14 @@
 				"node": ">=6.0.0"
 			}
 		},
+		"node_modules/dom-accessibility-api": {
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+			"integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true
+		},
 		"node_modules/dom-serializer": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
@@ -4335,6 +4710,20 @@
 				}
 			],
 			"license": "BSD-2-Clause"
+		},
+		"node_modules/domexception": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+			"integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+			"deprecated": "Use your platform's native DOMException instead",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"webidl-conversions": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
 		},
 		"node_modules/domhandler": {
 			"version": "5.0.3",
@@ -4674,6 +5063,39 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/escodegen": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+			"integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"dependencies": {
+				"esprima": "^4.0.1",
+				"estraverse": "^5.2.0",
+				"esutils": "^2.0.2"
+			},
+			"bin": {
+				"escodegen": "bin/escodegen.js",
+				"esgenerate": "bin/esgenerate.js"
+			},
+			"engines": {
+				"node": ">=6.0"
+			},
+			"optionalDependencies": {
+				"source-map": "~0.6.1"
+			}
+		},
+		"node_modules/escodegen/node_modules/source-map": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"optional": true,
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/eslint": {
@@ -5516,6 +5938,21 @@
 				"is-callable": "^1.1.3"
 			}
 		},
+		"node_modules/form-data": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
+			"integrity": "sha512-tzN8e4TX8+kkxGPK8D5u0FNmjPUjw3lwC9lSLxxoB/+GtsJG91CO8bSWy73APlgAZzZbXEYZJuxjkHH2w+Ezhw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/fs-extra": {
 			"version": "11.2.0",
 			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
@@ -6017,6 +6454,19 @@
 				"react-is": "^16.7.0"
 			}
 		},
+		"node_modules/html-encoding-sniffer": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+			"integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"whatwg-encoding": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/html-escaper": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -6052,6 +6502,35 @@
 				"entities": "^4.4.0"
 			}
 		},
+		"node_modules/http-proxy-agent": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+			"integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@tootallnate/once": "2",
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/https-proxy-agent": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"agent-base": "6",
+				"debug": "4"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
 		"node_modules/human-signals": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -6060,6 +6539,19 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=10.17.0"
+			}
+		},
+		"node_modules/iconv-lite": {
+			"version": "0.6.3",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+			"integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/ignore": {
@@ -6541,6 +7033,13 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/is-potential-custom-element-name": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/is-regex": {
 			"version": "1.1.4",
@@ -7528,6 +8027,34 @@
 			},
 			"engines": {
 				"node": ">=8"
+			}
+		},
+		"node_modules/jest-environment-jsdom": {
+			"version": "29.7.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+			"integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "^29.7.0",
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/jsdom": "^20.0.0",
+				"@types/node": "*",
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"jsdom": "^20.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			},
+			"peerDependencies": {
+				"canvas": "^2.5.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/jest-environment-node": {
@@ -8649,6 +9176,65 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
+		"node_modules/jsdom": {
+			"version": "20.0.3",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+			"integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abab": "^2.0.6",
+				"acorn": "^8.8.1",
+				"acorn-globals": "^7.0.0",
+				"cssom": "^0.5.0",
+				"cssstyle": "^2.3.0",
+				"data-urls": "^3.0.2",
+				"decimal.js": "^10.4.2",
+				"domexception": "^4.0.0",
+				"escodegen": "^2.0.0",
+				"form-data": "^4.0.0",
+				"html-encoding-sniffer": "^3.0.0",
+				"http-proxy-agent": "^5.0.0",
+				"https-proxy-agent": "^5.0.1",
+				"is-potential-custom-element-name": "^1.0.1",
+				"nwsapi": "^2.2.2",
+				"parse5": "^7.1.1",
+				"saxes": "^6.0.0",
+				"symbol-tree": "^3.2.4",
+				"tough-cookie": "^4.1.2",
+				"w3c-xmlserializer": "^4.0.0",
+				"webidl-conversions": "^7.0.0",
+				"whatwg-encoding": "^2.0.0",
+				"whatwg-mimetype": "^3.0.0",
+				"whatwg-url": "^11.0.0",
+				"ws": "^8.11.0",
+				"xml-name-validator": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			},
+			"peerDependencies": {
+				"canvas": "^2.5.0"
+			},
+			"peerDependenciesMeta": {
+				"canvas": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/jsdom/node_modules/parse5": {
+			"version": "7.2.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.2.1.tgz",
+			"integrity": "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"entities": "^4.5.0"
+			},
+			"funding": {
+				"url": "https://github.com/inikulin/parse5?sponsor=1"
+			}
+		},
 		"node_modules/jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -8837,6 +9423,17 @@
 				"yallist": "^3.0.2"
 			}
 		},
+		"node_modules/lz-string": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+			"integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+			"dev": true,
+			"license": "MIT",
+			"peer": true,
+			"bin": {
+				"lz-string": "bin/bin.js"
+			}
+		},
 		"node_modules/make-dir": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
@@ -8964,6 +9561,29 @@
 				"node": ">=8.6"
 			}
 		},
+		"node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/mimic-fn": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
@@ -9088,6 +9708,13 @@
 			"engines": {
 				"node": "*"
 			}
+		},
+		"node_modules/nwsapi": {
+			"version": "2.2.16",
+			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.16.tgz",
+			"integrity": "sha512-F1I/bimDpj3ncaNDhfyMWuFqmQDBwDB0Fogc2qpL3BWvkQteFD/8BzWuIRl83rq0DXfm8SGt/HFhLXZyljTXcQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
@@ -9649,6 +10276,19 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/psl": {
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+			"integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.3.1"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/lupomontero"
 			}
 		},
 		"node_modules/punycode": {
@@ -10379,6 +11019,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/safer-buffer": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/sanitize-html": {
 			"version": "2.13.0",
 			"resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.13.0.tgz",
@@ -10403,6 +11050,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/saxes": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"xmlchars": "^2.2.0"
+			},
+			"engines": {
+				"node": ">=v12.22.7"
 			}
 		},
 		"node_modules/scheduler": {
@@ -10828,6 +11488,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/symbol-tree": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/synckit": {
 			"version": "0.9.1",
 			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.9.1.tgz",
@@ -10920,6 +11587,45 @@
 			},
 			"engines": {
 				"node": ">=8.0"
+			}
+		},
+		"node_modules/tough-cookie": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+			"integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"psl": "^1.1.33",
+				"punycode": "^2.1.1",
+				"universalify": "^0.2.0",
+				"url-parse": "^1.5.3"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/tough-cookie/node_modules/universalify": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+			"integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.0.0"
+			}
+		},
+		"node_modules/tr46": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+			"integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"punycode": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/trim-trailing-lines": {
@@ -11800,6 +12506,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/w3c-xmlserializer": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+			"integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"xml-name-validator": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=14"
+			}
+		},
 		"node_modules/walker": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -11817,6 +12536,53 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/webidl-conversions": {
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/whatwg-encoding": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+			"integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"iconv-lite": "0.6.3"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/whatwg-mimetype": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+			"integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/whatwg-url": {
+			"version": "11.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+			"integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tr46": "^3.0.0",
+				"webidl-conversions": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/which": {
@@ -12002,6 +12768,45 @@
 			"engines": {
 				"node": "^12.13.0 || ^14.15.0 || >=16.0.0"
 			}
+		},
+		"node_modules/ws": {
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
+			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
+			}
+		},
+		"node_modules/xml-name-validator": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+			"integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/xmlchars": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/xtend": {
 			"version": "4.0.2",

--- a/newswires/client/package.json
+++ b/newswires/client/package.json
@@ -30,6 +30,7 @@
 		"@eslint/js": "^9.9.0",
 		"@guardian/eslint-config": "9.0.0",
 		"@guardian/prettier": "^8.0.1",
+		"@testing-library/react": "^16.1.0",
 		"@types/react": "^18.3.3",
 		"@types/react-dom": "^18.3.0",
 		"@types/sanitize-html": "^2.13.0",
@@ -42,6 +43,7 @@
 		"eslint-plugin-react-refresh": "^0.4.9",
 		"globals": "^15.9.0",
 		"jest": "29.7.0",
+		"jest-environment-jsdom": "^29.7.0",
 		"prettier": "^3.3.3",
 		"ts-jest": "29.2.4",
 		"typescript": "^5.5.3",
@@ -50,8 +52,9 @@
 		"vite-plugin-checker": "^0.7.2"
 	},
 	"jest": {
+		"testEnvironment": "jsdom",
 		"testMatch": [
-			"<rootDir>/src/**/*.test.ts"
+			"<rootDir>/src/**/*.test.{ts,tsx}"
 		],
 		"transform": {
 			"^.+\\.tsx?$": "ts-jest"

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -103,7 +103,6 @@ export function App() {
 							border-radius: 0;
 							background: #fdf6d8;
 						`}
-						onClose={() => {}}
 					>
 						<p>
 							The application is no longer retrieving updates. Data

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -1,8 +1,6 @@
 import {
 	EuiButton,
 	EuiEmptyPrompt,
-	EuiFlexGroup,
-	EuiFlexItem,
 	EuiHeader,
 	EuiHeaderSection,
 	EuiHeaderSectionItem,
@@ -10,16 +8,15 @@ import {
 	EuiProvider,
 	EuiResizableContainer,
 	EuiShowFor,
-	EuiSpacer,
-	EuiSwitch,
 	EuiTitle,
+	EuiToast,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
+import { useSearch } from './context/SearchContext.tsx';
 import { Feed } from './Feed';
 import { Item } from './Item';
 import { SideNav } from './SideNav';
 import { configToUrl, defaultQuery } from './urlState';
-import { useSearch } from './useSearch';
 
 export function App() {
 	const {
@@ -30,7 +27,6 @@ export function App() {
 		handleDeselectItem,
 		handleNextItem,
 		handlePreviousItem,
-		toggleAutoUpdate,
 	} = useSearch();
 
 	const { view, itemId: selectedItemId } = config;
@@ -99,42 +95,63 @@ export function App() {
 						</EuiHeaderSectionItem>
 					</EuiHeader>
 				)}
-				{status !== 'error' && (
-					<>
-						<EuiShowFor sizes={['xs', 's']}>
-							{view === 'item' ? <Item id={selectedItemId} /> : <Feed />}
-						</EuiShowFor>
-						<EuiShowFor sizes={['m', 'l', 'xl']}>
-							{view === 'item' ? (
-								<EuiResizableContainer className="eui-fullHeight">
-									{(EuiResizablePanel, EuiResizableButton) => (
-										<>
-											<EuiResizablePanel
-												minSize="25%"
-												initialSize={100}
-												className="eui-yScroll"
-											>
-												<Feed />
-											</EuiResizablePanel>
-											<EuiResizableButton />
-											<EuiResizablePanel
-												minSize="30%"
-												initialSize={100}
-												className="eui-yScroll"
-											>
-												<Item id={selectedItemId} />
-											</EuiResizablePanel>
-										</>
-									)}
-								</EuiResizableContainer>
-							) : (
-								<Feed />
-							)}
-						</EuiShowFor>
-					</>
+				{status === 'offline' && (
+					<EuiToast
+						title="You Are Currently Offline"
+						iconType="warning"
+						css={css`
+							border-radius: 0;
+							background: #fdf6d8;
+						`}
+						onClose={() => {}}
+					>
+						<p>
+							The application is no longer retrieving updates. Data
+							synchronization will resume once connectivity is restored.
+						</p>
+					</EuiToast>
 				)}
+				{status !== 'error' &&
+					state.queryData &&
+					state.queryData.results.length > 0 && (
+						<>
+							<EuiShowFor sizes={['xs', 's']}>
+								{view === 'item' ? <Item id={selectedItemId} /> : <Feed />}
+							</EuiShowFor>
+							<EuiShowFor sizes={['m', 'l', 'xl']}>
+								{view === 'item' ? (
+									<EuiResizableContainer className="eui-fullHeight">
+										{(EuiResizablePanel, EuiResizableButton) => (
+											<>
+												<EuiResizablePanel
+													minSize="25%"
+													initialSize={100}
+													className="eui-yScroll"
+												>
+													<Feed />
+												</EuiResizablePanel>
+												<EuiResizableButton />
+												<EuiResizablePanel
+													minSize="30%"
+													initialSize={100}
+													className="eui-yScroll"
+												>
+													<Item id={selectedItemId} />
+												</EuiResizablePanel>
+											</>
+										)}
+									</EuiResizableContainer>
+								) : (
+									<Feed />
+								)}
+							</EuiShowFor>
+						</>
+					)}
 				{status == 'error' && (
 					<EuiEmptyPrompt
+						css={css`
+							background: white;
+						`}
 						actions={[
 							<EuiButton onClick={handleRetry} key="retry" iconType={'refresh'}>
 								Retry

--- a/newswires/client/src/Feed.tsx
+++ b/newswires/client/src/Feed.tsx
@@ -1,5 +1,5 @@
 import { EuiEmptyPrompt, EuiLoadingLogo, EuiPageTemplate } from '@elastic/eui';
-import { useSearch } from './useSearch';
+import { useSearch } from './context/SearchContext.tsx';
 import { WireItemTable } from './WireItemTable';
 
 export const Feed = () => {
@@ -15,18 +15,20 @@ export const Feed = () => {
 					title={<h2>Loading Wires</h2>}
 				/>
 			)}
-			{status == 'success' && queryData.results.length === 0 && (
-				<EuiEmptyPrompt
-					body={<p>Try a different search term</p>}
-					color="subdued"
-					layout="horizontal"
-					title={<h2>No results match your search criteria</h2>}
-					titleSize="s"
-				/>
-			)}
-			{status == 'success' && queryData.results.length > 0 && (
-				<WireItemTable wires={queryData.results} />
-			)}
+			{(status == 'success' || status == 'offline') &&
+				queryData.results.length === 0 && (
+					<EuiEmptyPrompt
+						body={<p>Try a different search term</p>}
+						color="subdued"
+						layout="horizontal"
+						title={<h2>No results match your search criteria</h2>}
+						titleSize="s"
+					/>
+				)}
+			{(status == 'success' || status == 'offline') &&
+				queryData.results.length > 0 && (
+					<WireItemTable wires={queryData.results} />
+				)}
 		</EuiPageTemplate.Section>
 	);
 };

--- a/newswires/client/src/Item.tsx
+++ b/newswires/client/src/Item.tsx
@@ -13,10 +13,10 @@ import {
 	useGeneratedHtmlId,
 } from '@elastic/eui';
 import { useEffect, useMemo, useState } from 'react';
+import { useSearch } from './context/SearchContext.tsx';
 import { pandaFetch } from './panda-session';
 import { type WireData, WireDataSchema } from './sharedTypes';
 import { paramsToQuerystring } from './urlState';
-import { useSearch } from './useSearch';
 import { WireDetail } from './WireDetail';
 
 export const Item = ({ id }: { id: string }) => {

--- a/newswires/client/src/SearchBox.tsx
+++ b/newswires/client/src/SearchBox.tsx
@@ -1,7 +1,7 @@
 import { EuiFieldSearch } from '@elastic/eui';
 import { useMemo, useState } from 'react';
+import { useSearch } from './context/SearchContext.tsx';
 import { debounce } from './debounce';
-import { useSearch } from './useSearch';
 
 export function SearchBox() {
 	const { config, handleEnterQuery } = useSearch();

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -14,10 +14,10 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useCallback, useMemo, useState } from 'react';
+import { useSearch } from './context/SearchContext.tsx';
 import { SearchBox } from './SearchBox';
 import { brandColours } from './sharedStyles';
 import type { Query } from './sharedTypes';
-import { useSearch } from './useSearch';
 
 function decideLabelForQueryBadge(query: Query): string {
 	const { supplier, q, bucket } = query;
@@ -265,7 +265,7 @@ const SingleSearchAsListOfBadges = ({
 };
 
 const SearchQueryBadges = ({ query }: { query: Query }) => {
-	const { handleEnterQuery } = useSearch();
+	const { handleEnterQuery } = searchContext();
 	const { q, subject } = query;
 
 	if (q.length === 0 && subject.length === 0) {

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -265,7 +265,7 @@ const SingleSearchAsListOfBadges = ({
 };
 
 const SearchQueryBadges = ({ query }: { query: Query }) => {
-	const { handleEnterQuery } = searchContext();
+	const { handleEnterQuery } = useSearch();
 	const { q, subject } = query;
 
 	if (q.length === 0 && subject.length === 0) {

--- a/newswires/client/src/WireItemTable.tsx
+++ b/newswires/client/src/WireItemTable.tsx
@@ -14,9 +14,9 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import sanitizeHtml from 'sanitize-html';
+import { useSearch } from './context/SearchContext.tsx';
 import { formatTimestamp } from './formatTimestamp';
 import type { WireData } from './sharedTypes';
-import { useSearch } from './useSearch';
 
 const fadeOutBackground = css`
 	animation: fadeOut ease-out 15s;

--- a/newswires/client/src/context/SearchContext.test.tsx
+++ b/newswires/client/src/context/SearchContext.test.tsx
@@ -1,5 +1,6 @@
 import { act, render } from '@testing-library/react';
 import type React from 'react';
+import { flushPendingPromises } from '../tests/testHelpers.ts';
 import type { SearchContextShape } from './SearchContext.tsx';
 import { SearchContextProvider, useSearch } from './SearchContext.tsx';
 
@@ -16,15 +17,6 @@ global.fetch = jest.fn(() =>
 ) as jest.Mock;
 
 describe('SearchContext', () => {
-	/**
-	 * Flushes pending promises by resolving the current microtask queue.
-	 * Useful in unit tests to ensure all async operations and state updates have completed.
-	 */
-	const flushPendingPromises = async () =>
-		act(async () => {
-			await Promise.resolve();
-		});
-
 	const renderWithContext = async () => {
 		const contextRef = { current: null as SearchContextShape | null };
 

--- a/newswires/client/src/context/SearchContext.test.tsx
+++ b/newswires/client/src/context/SearchContext.test.tsx
@@ -1,0 +1,103 @@
+import { act, render } from '@testing-library/react';
+import type React from 'react';
+import type { SearchContextShape } from './SearchContext.tsx';
+import { SearchContextProvider, useSearch } from './SearchContext.tsx';
+
+jest.useFakeTimers();
+
+global.fetch = jest.fn(() =>
+	Promise.resolve({
+		json: () =>
+			Promise.resolve({
+				results: [],
+			}),
+		ok: () => true,
+	}),
+) as jest.Mock;
+
+describe('SearchContext', () => {
+	/**
+	 * Flushes pending promises by resolving the current microtask queue.
+	 * Useful in unit tests to ensure all async operations and state updates have completed.
+	 */
+	const flushPendingPromises = async () =>
+		act(async () => {
+			await Promise.resolve();
+		});
+
+	const renderWithContext = async () => {
+		const contextRef = { current: null as SearchContextShape | null };
+
+		const TestComponent: React.FC = () => {
+			contextRef.current = useSearch();
+			return null;
+		};
+
+		act(() => {
+			render(
+				<SearchContextProvider>
+					<TestComponent />
+				</SearchContextProvider>,
+			);
+		});
+
+		await flushPendingPromises();
+
+		return contextRef;
+	};
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should fetch data and initialise the state', async () => {
+		const contextRef = await renderWithContext();
+
+		if (!contextRef.current) {
+			throw new Error('Context ref was null after render.');
+		}
+
+		expect(contextRef.current.state).toEqual({
+			autoUpdate: true,
+			status: 'success',
+			queryData: {
+				results: [],
+			},
+			successfulQueryHistory: [],
+		});
+	});
+
+	it('should toggle the auto update flag', async () => {
+		const contextRef = await renderWithContext();
+
+		if (!contextRef.current) {
+			throw new Error('Context ref was null after render.');
+		}
+
+		expect(contextRef.current.state.autoUpdate).toBe(true);
+
+		act(() => {
+			contextRef.current?.toggleAutoUpdate();
+		});
+
+		expect(contextRef.current.state.autoUpdate).toBe(false);
+	});
+
+	it('should trigger periodic fetch calls', async () => {
+		const contextRef = await renderWithContext();
+
+		if (!contextRef.current) {
+			throw new Error('Context ref was null after render.');
+		}
+
+		expect(global.fetch).toHaveBeenCalledTimes(1);
+
+		act(() => {
+			jest.advanceTimersByTime(6000);
+		});
+
+		await flushPendingPromises();
+
+		expect(global.fetch).toHaveBeenCalledTimes(2);
+	});
+});

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -15,8 +15,8 @@ import {
 	WiresQueryResponseSchema,
 } from '../sharedTypes.ts';
 import { configToUrl, defaultConfig, urlToConfig } from '../urlState.ts';
-import { SearchReducer } from './SearchReducer.ts';
 import { fetchResults } from './fetchResults.ts';
+import { SearchReducer } from './SearchReducer.ts';
 
 const SearchHistorySchema = z.array(
 	z.object({
@@ -108,6 +108,7 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 	const [currentConfig, setConfig] = useState<Config>(
 		urlToConfig(window.location),
 	);
+
 	const [state, dispatch] = useReducer(SearchReducer, {
 		error: undefined,
 		queryData: undefined,

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -1,4 +1,3 @@
-import { isEqual as deepIsEqual } from 'lodash';
 import type { Context, PropsWithChildren } from 'react';
 import {
 	createContext,
@@ -9,20 +8,15 @@ import {
 	useState,
 } from 'react';
 import { z } from 'zod';
-import { pandaFetch } from './panda-session';
-import type { Config, Query, WiresQueryResponse } from './sharedTypes';
+import type { Config, Query } from '../sharedTypes.ts';
 import {
 	ConfigSchema,
 	QuerySchema,
 	WiresQueryResponseSchema,
-} from './sharedTypes';
-import {
-	configToUrl,
-	defaultConfig,
-	defaultQuery,
-	paramsToQuerystring,
-	urlToConfig,
-} from './urlState';
+} from '../sharedTypes.ts';
+import { configToUrl, defaultConfig, urlToConfig } from '../urlState.ts';
+import { SearchReducer } from './SearchReducer.ts';
+import { fetchResults } from './fetchResults.ts';
 
 const SearchHistorySchema = z.array(
 	z.object({
@@ -63,10 +57,17 @@ const StateSchema = z.discriminatedUnion('status', [
 		successfulQueryHistory: SearchHistorySchema,
 		autoUpdate: z.boolean().default(true),
 	}),
+	z.object({
+		status: z.literal('offline'),
+		error: z.string(),
+		queryData: WiresQueryResponseSchema,
+		successfulQueryHistory: SearchHistorySchema,
+		autoUpdate: z.boolean().default(true),
+	}),
 ]);
 
 // Infer State Type
-type State = z.infer<typeof StateSchema>;
+export type State = z.infer<typeof StateSchema>;
 
 // Action Schema
 const ActionSchema = z.discriminatedUnion('type', [
@@ -87,152 +88,7 @@ const ActionSchema = z.discriminatedUnion('type', [
 ]);
 
 // Infer Action Type
-type Action = z.infer<typeof ActionSchema>;
-
-function mergeQueryData(
-	existing: WiresQueryResponse | undefined,
-	newData: WiresQueryResponse,
-): WiresQueryResponse {
-	const mergedResults = existing
-		? [
-				...newData.results
-					.filter(
-						(newItem) =>
-							!existing.results
-								.map((existing) => existing.id)
-								.includes(newItem.id),
-					)
-					.map((newItem) => ({ ...newItem, isFromRefresh: true })),
-				...existing.results.map((existingItem) => ({
-					...existingItem,
-				})),
-			]
-		: newData.results;
-	return {
-		...newData,
-		results: mergedResults,
-	};
-}
-
-function getUpdatedHistory(
-	previousHistory: SearchHistory,
-	newQuery: Query,
-	newResultsCount: number,
-): SearchHistory {
-	if (deepIsEqual(newQuery, defaultQuery)) {
-		return previousHistory;
-	}
-	if (Object.keys(newQuery).length === 1 && newQuery.q.length === 0) {
-		return previousHistory;
-	}
-	const previousHistoryWithoutMatchingQueries = previousHistory.filter(
-		({ query }) => !deepIsEqual(query, newQuery),
-	);
-	return [
-		{ query: newQuery, resultsCount: newResultsCount },
-		...previousHistoryWithoutMatchingQueries,
-	];
-}
-
-function reducer(state: State, action: Action): State {
-	switch (state.status) {
-		case 'loading':
-			switch (action.type) {
-				case 'FETCH_SUCCESS':
-					return {
-						...state,
-						queryData: action.data,
-						successfulQueryHistory: getUpdatedHistory(
-							state.successfulQueryHistory,
-							action.query,
-							action.data.results.length,
-						),
-						status: 'success',
-						error: undefined,
-					};
-
-				case 'FETCH_ERROR':
-					return {
-						...state,
-						error: action.error,
-						status: 'error',
-					};
-				default:
-					return state;
-			}
-		case 'success':
-			switch (action.type) {
-				case 'UPDATE_RESULTS':
-					return {
-						...state,
-						queryData: mergeQueryData(state.queryData, action.data),
-					};
-				case 'ENTER_QUERY':
-					return {
-						...state,
-						status: 'loading',
-					};
-				case 'TOGGLE_AUTO_UPDATE':
-					return {
-						...state,
-						autoUpdate: !state.autoUpdate,
-					};
-				default:
-					return state;
-			}
-		case 'error':
-			switch (action.type) {
-				case 'RETRY':
-					return {
-						...state,
-						status: 'loading',
-					};
-				case 'ENTER_QUERY':
-					return {
-						...state,
-						status: 'loading',
-					};
-				default:
-					return state;
-			}
-		default:
-			return state;
-	}
-}
-
-async function fetchResults(
-	query: Query,
-	sinceId: string | undefined = undefined,
-): Promise<WiresQueryResponse> {
-	const queryToSerialise = sinceId
-		? { ...query, sinceId: sinceId.toString() }
-		: query;
-	const queryString = paramsToQuerystring(queryToSerialise);
-	const response = await pandaFetch(`/api/search${queryString}`, {
-		headers: {
-			Accept: 'application/json',
-		},
-	});
-	try {
-		const data = (await response.json()) as unknown;
-		if (!response.ok) {
-			throw new Error(
-				// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- this is the expected shape from Play but you never know
-				(data as { error: { exception: { description: string } } }).error
-					.exception.description ?? 'Unknown error',
-			);
-		}
-		const parseResult = WiresQueryResponseSchema.safeParse(data);
-		if (parseResult.success) {
-			return parseResult.data;
-		}
-		throw new Error(
-			`Received invalid data from server: ${JSON.stringify(parseResult.error)}`,
-		);
-	} catch (e) {
-		throw new Error(e instanceof Error ? e.message : 'Unknown error');
-	}
-}
+export type Action = z.infer<typeof ActionSchema>;
 
 export type SearchContextShape = {
 	config: Config;
@@ -252,7 +108,7 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 	const [currentConfig, setConfig] = useState<Config>(
 		urlToConfig(window.location),
 	);
-	const [state, dispatch] = useReducer(reducer, {
+	const [state, dispatch] = useReducer(SearchReducer, {
 		error: undefined,
 		queryData: undefined,
 		successfulQueryHistory: [],
@@ -310,7 +166,7 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 				});
 		}
 
-		if (state.status === 'success') {
+		if (state.status === 'success' || state.status === 'offline') {
 			pollingInterval = setInterval(() => {
 				if (state.autoUpdate) {
 					fetchResults(

--- a/newswires/client/src/context/SearchReducer.test.ts
+++ b/newswires/client/src/context/SearchReducer.test.ts
@@ -1,3 +1,210 @@
+import { sampleWireData } from '../tests/fixtures/wireData.ts';
+import type { Action, State } from './SearchContext.tsx';
+import { SearchReducer } from './SearchReducer';
+
 describe('SearchReducer', () => {
-	it('should fetch data and initialise the state', async () => {});
+	const initialState: State = {
+		status: 'loading',
+		successfulQueryHistory: [],
+		autoUpdate: true,
+	};
+
+	it('should handle FETCH_SUCCESS action in loading state', () => {
+		const action: Action = {
+			type: 'FETCH_SUCCESS',
+			data: { results: [sampleWireData] },
+			query: { q: 'test' },
+		};
+
+		const newState = SearchReducer(initialState, action);
+
+		expect(newState.status).toBe('success');
+		expect(newState.queryData).toEqual(action.data);
+		expect(newState.successfulQueryHistory).toEqual([
+			{ query: action.query, resultsCount: 1 },
+		]);
+		expect(newState.error).toBeUndefined();
+	});
+
+	it('should handle FETCH_ERROR action in loading state', () => {
+		const action: Action = {
+			type: 'FETCH_ERROR',
+			error: 'Fetch failed',
+		};
+
+		const newState = SearchReducer(initialState, action);
+
+		expect(newState.status).toBe('error');
+		expect(newState.error).toEqual(action.error);
+	});
+
+	it('should handle UPDATE_RESULTS action in success state', () => {
+		const state: State = {
+			...initialState,
+			status: 'success',
+			queryData: { results: [{ ...sampleWireData, id: 1 }] },
+		};
+
+		const action: Action = {
+			type: 'UPDATE_RESULTS',
+			data: { results: [{ ...sampleWireData, id: 2 }] },
+		};
+
+		const newState = SearchReducer(state, action);
+
+		expect(newState.status).toBe('success');
+		expect(newState.queryData?.results).toHaveLength(2);
+		expect(newState.queryData?.results).toContainEqual({
+			...sampleWireData,
+			id: 2,
+			isFromRefresh: true,
+		});
+		expect(newState.queryData?.results).toContainEqual({
+			...sampleWireData,
+			id: 1,
+		});
+	});
+
+	it('should handle ENTER_QUERY action in success state', () => {
+		const state: State = {
+			...initialState,
+			status: 'success',
+			queryData: { results: [sampleWireData] },
+		};
+
+		const action: Action = {
+			type: 'ENTER_QUERY',
+		};
+
+		const newState = SearchReducer(state, action);
+
+		expect(newState.status).toBe('loading');
+	});
+
+	it('should handle TOGGLE_AUTO_UPDATE action in success state', () => {
+		const state: State = {
+			...initialState,
+			status: 'success',
+			queryData: { results: [sampleWireData] },
+		};
+
+		const action: Action = {
+			type: 'TOGGLE_AUTO_UPDATE',
+		};
+
+		const newState = SearchReducer(state, action);
+
+		expect(newState.autoUpdate).toBe(false);
+	});
+
+	it('should handle FETCH_ERROR action in success state', () => {
+		const state: State = {
+			...initialState,
+			status: 'success',
+			queryData: { results: [sampleWireData] },
+		};
+
+		const action: Action = {
+			type: 'FETCH_ERROR',
+			error: 'Fetch failed',
+		};
+
+		const newState = SearchReducer(state, action);
+
+		expect(newState.status).toBe('offline');
+		expect(newState.error).toEqual(action.error);
+	});
+
+	it('should handle UPDATE_RESULTS action in offline state', () => {
+		const state: State = {
+			status: 'offline',
+			queryData: { results: [{ ...sampleWireData, id: 1 }] },
+			successfulQueryHistory: [],
+			error: 'Network error',
+			autoUpdate: true,
+		};
+
+		const action: Action = {
+			type: 'UPDATE_RESULTS',
+			data: { results: [{ ...sampleWireData, id: 2 }] },
+		};
+
+		const newState = SearchReducer(state, action);
+
+		expect(newState.status).toBe('success');
+		expect(newState.queryData?.results).toHaveLength(2);
+		expect(newState.queryData?.results).toContainEqual({
+			...sampleWireData,
+			id: 2,
+			isFromRefresh: true,
+		});
+		expect(newState.queryData?.results).toContainEqual({
+			...sampleWireData,
+			id: 1,
+		});
+	});
+
+	it('should handle UPDATE_RESULTS action in error state', () => {
+		const state: State = {
+			status: 'error',
+			queryData: { results: [{ ...sampleWireData, id: 1 }] },
+			successfulQueryHistory: [],
+			error: 'Fetch error',
+			autoUpdate: true,
+		};
+
+		const action: Action = {
+			type: 'UPDATE_RESULTS',
+			data: { results: [{ ...sampleWireData, id: 2 }] },
+		};
+
+		const newState = SearchReducer(state, action);
+
+		expect(newState.status).toBe('success');
+		expect(newState.queryData?.results).toHaveLength(2);
+		expect(newState.queryData?.results).toContainEqual({
+			...sampleWireData,
+			id: 2,
+			isFromRefresh: true,
+		});
+		expect(newState.queryData?.results).toContainEqual({
+			...sampleWireData,
+			id: 1,
+		});
+	});
+
+	it('should handle RETRY action in error state', () => {
+		const state: State = {
+			status: 'error',
+			successfulQueryHistory: [],
+			error: 'Fetch error',
+			autoUpdate: true,
+		};
+
+		const action: Action = {
+			type: 'RETRY',
+		};
+
+		const newState = SearchReducer(state, action);
+
+		expect(newState.status).toBe('loading');
+	});
+
+	it('should handle ENTER_QUERY action in error state', () => {
+		const state: State = {
+			status: 'error',
+			queryData: undefined,
+			successfulQueryHistory: [],
+			error: 'Fetch error',
+			autoUpdate: true,
+		};
+
+		const action: Action = {
+			type: 'ENTER_QUERY',
+		};
+
+		const newState = SearchReducer(state, action);
+
+		expect(newState.status).toBe('loading');
+	});
 });

--- a/newswires/client/src/context/SearchReducer.test.ts
+++ b/newswires/client/src/context/SearchReducer.test.ts
@@ -1,0 +1,3 @@
+describe('SearchReducer', () => {
+	it('should fetch data and initialise the state', async () => {});
+});

--- a/newswires/client/src/context/SearchReducer.ts
+++ b/newswires/client/src/context/SearchReducer.ts
@@ -1,0 +1,138 @@
+import { isEqual as deepIsEqual } from 'lodash';
+import type { Query, WiresQueryResponse } from '../sharedTypes.ts';
+import { defaultQuery } from '../urlState.ts';
+import type { Action, SearchHistory, State } from './SearchContext.tsx';
+
+function mergeQueryData(
+	existing: WiresQueryResponse | undefined,
+	newData: WiresQueryResponse,
+): WiresQueryResponse {
+	const mergedResults = existing
+		? [
+				...newData.results
+					.filter(
+						(newItem) =>
+							!existing.results
+								.map((existing) => existing.id)
+								.includes(newItem.id),
+					)
+					.map((newItem) => ({ ...newItem, isFromRefresh: true })),
+				...existing.results.map((existingItem) => ({
+					...existingItem,
+				})),
+			]
+		: newData.results;
+	return {
+		...newData,
+		results: mergedResults,
+	};
+}
+
+function getUpdatedHistory(
+	previousHistory: SearchHistory,
+	newQuery: Query,
+	newResultsCount: number,
+): SearchHistory {
+	if (deepIsEqual(newQuery, defaultQuery)) {
+		return previousHistory;
+	}
+	if (Object.keys(newQuery).length === 1 && newQuery.q.length === 0) {
+		return previousHistory;
+	}
+	const previousHistoryWithoutMatchingQueries = previousHistory.filter(
+		({ query }) => !deepIsEqual(query, newQuery),
+	);
+	return [
+		{ query: newQuery, resultsCount: newResultsCount },
+		...previousHistoryWithoutMatchingQueries,
+	];
+}
+
+export const SearchReducer = (state: State, action: Action): State => {
+	switch (state.status) {
+		case 'loading':
+			switch (action.type) {
+				case 'FETCH_SUCCESS':
+					return {
+						...state,
+						queryData: action.data,
+						successfulQueryHistory: getUpdatedHistory(
+							state.successfulQueryHistory,
+							action.query,
+							action.data.results.length,
+						),
+						status: 'success',
+						error: undefined,
+					};
+
+				case 'FETCH_ERROR':
+					return {
+						...state,
+						error: action.error,
+						status: 'error',
+					};
+				default:
+					return state;
+			}
+		case 'success':
+			switch (action.type) {
+				case 'UPDATE_RESULTS':
+					return {
+						...state,
+						queryData: mergeQueryData(state.queryData, action.data),
+					};
+				case 'ENTER_QUERY':
+					return {
+						...state,
+						status: 'loading',
+					};
+				case 'TOGGLE_AUTO_UPDATE':
+					return {
+						...state,
+						autoUpdate: !state.autoUpdate,
+					};
+				case 'FETCH_ERROR':
+					return {
+						...state,
+						error: action.error,
+						status: 'offline',
+					};
+				default:
+					return state;
+			}
+		case 'offline':
+			switch (action.type) {
+				case 'UPDATE_RESULTS':
+					return {
+						...state,
+						status: 'success',
+						queryData: mergeQueryData(state.queryData, action.data),
+					};
+				default:
+					return state;
+			}
+		case 'error':
+			switch (action.type) {
+				case 'UPDATE_RESULTS':
+					return {
+						...state,
+						status: 'success',
+						queryData: mergeQueryData(state.queryData, action.data),
+					};
+				case 'RETRY':
+					return {
+						...state,
+						status: 'loading',
+					};
+				case 'ENTER_QUERY':
+					return {
+						...state,
+						status: 'loading',
+					};
+				default:
+					return state;
+			}
+		default:
+			return state;
+	}
+};

--- a/newswires/client/src/context/SearchReducer.ts
+++ b/newswires/client/src/context/SearchReducer.ts
@@ -7,25 +7,26 @@ function mergeQueryData(
 	existing: WiresQueryResponse | undefined,
 	newData: WiresQueryResponse,
 ): WiresQueryResponse {
-	const mergedResults = existing
-		? [
-				...newData.results
-					.filter(
-						(newItem) =>
-							!existing.results
-								.map((existing) => existing.id)
-								.includes(newItem.id),
-					)
-					.map((newItem) => ({ ...newItem, isFromRefresh: true })),
-				...existing.results.map((existingItem) => ({
-					...existingItem,
-				})),
-			]
-		: newData.results;
-	return {
-		...newData,
-		results: mergedResults,
-	};
+	if (existing) {
+		const existingIds = new Set(existing.results.map((item) => item.id));
+
+		const mergedResults = [
+			...newData.results
+				.filter((newItem) => !existingIds.has(newItem.id))
+				.map((newItem) => ({ ...newItem, isFromRefresh: true })),
+			...existing.results,
+		];
+
+		return {
+			...newData,
+			results: mergedResults,
+		};
+	} else {
+		return {
+			...newData,
+			results: newData.results,
+		};
+	}
 }
 
 function getUpdatedHistory(

--- a/newswires/client/src/context/fetchResults.test.ts
+++ b/newswires/client/src/context/fetchResults.test.ts
@@ -1,0 +1,80 @@
+import { pandaFetch } from '../panda-session';
+import { paramsToQuerystring } from '../urlState';
+import { fetchResults } from './fetchResults.ts';
+
+jest.mock('../urlState', () => ({
+	paramsToQuerystring: jest.fn(() => '?queryString'),
+}));
+
+jest.mock('../panda-session', () => ({
+	pandaFetch: jest.fn(() =>
+		Promise.resolve({
+			json: jest.fn().mockResolvedValue({ results: [] }),
+			ok: true,
+		}),
+	),
+}));
+
+describe('fetchResults', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('should call pandaFetch with correct URL and headers', async () => {
+		const mockQuery = { q: 'value' };
+		await fetchResults(mockQuery);
+
+		expect(paramsToQuerystring).toHaveBeenCalledWith(mockQuery);
+		expect(pandaFetch).toHaveBeenCalledWith('/api/search?queryString', {
+			headers: { Accept: 'application/json' },
+		});
+	});
+
+	it('should throw an error if response is not ok', async () => {
+		(pandaFetch as jest.Mock).mockResolvedValueOnce({
+			json: jest.fn().mockResolvedValue({
+				error: { exception: { description: 'Error occurred' } },
+			}),
+			ok: false,
+		});
+
+		await expect(fetchResults({ q: 'value' })).rejects.toThrow(
+			'Error occurred',
+		);
+	});
+
+	it('should throw an error if response data is invalid', async () => {
+		(pandaFetch as jest.Mock).mockResolvedValueOnce({
+			json: jest.fn().mockResolvedValue({ invalidData: true }),
+			ok: true,
+		});
+
+		await expect(fetchResults({ q: 'value' })).rejects.toThrow(
+			'Received invalid data from server',
+		);
+	});
+
+	it('should return parsed data if response is valid', async () => {
+		const mockResponseData = {
+			results: [],
+		};
+
+		(pandaFetch as jest.Mock).mockResolvedValueOnce({
+			json: jest.fn().mockResolvedValue(mockResponseData),
+			ok: true,
+		});
+
+		const result = await fetchResults({ q: 'value' });
+		expect(result).toEqual(mockResponseData);
+	});
+
+	it('should append sinceId to the query if provided', async () => {
+		const mockQuery = { q: 'value' };
+		await fetchResults(mockQuery, '123');
+
+		expect(paramsToQuerystring).toHaveBeenCalledWith({
+			...mockQuery,
+			sinceId: '123',
+		});
+	});
+});

--- a/newswires/client/src/context/fetchResults.ts
+++ b/newswires/client/src/context/fetchResults.ts
@@ -1,0 +1,39 @@
+import { pandaFetch } from '../panda-session.ts';
+import type { Query, WiresQueryResponse } from '../sharedTypes.ts';
+import { WiresQueryResponseSchema } from '../sharedTypes.ts';
+import { paramsToQuerystring } from '../urlState.ts';
+
+export const fetchResults = async (
+	query: Query,
+	sinceId: string | undefined = undefined,
+): Promise<WiresQueryResponse> => {
+	const queryToSerialise = sinceId
+		? { ...query, sinceId: sinceId.toString() }
+		: query;
+	const queryString = paramsToQuerystring(queryToSerialise);
+	const response = await pandaFetch(`/api/search${queryString}`, {
+		headers: {
+			Accept: 'application/json',
+		},
+	});
+	try {
+		const data = (await response.json()) as unknown;
+		if (!response.ok) {
+			throw new Error(
+				// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- this is the expected shape from Play but you never know
+				(data as { error: { exception: { description: string } } }).error
+					.exception.description ?? 'Unknown error',
+			);
+		}
+
+		const parseResult = WiresQueryResponseSchema.safeParse(data);
+		if (parseResult.success) {
+			return parseResult.data;
+		}
+		throw new Error(
+			`Received invalid data from server: ${JSON.stringify(parseResult.error)}`,
+		);
+	} catch (e) {
+		throw new Error(e instanceof Error ? e.message : 'Unknown error');
+	}
+};

--- a/newswires/client/src/main.tsx
+++ b/newswires/client/src/main.tsx
@@ -2,7 +2,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { App } from './App.tsx';
 import './icons';
-import { SearchContextProvider } from './useSearch.tsx';
+import { SearchContextProvider } from './context/SearchContext.tsx';
 
 const toolsDomain = window.location.hostname.substring(
 	window.location.hostname.indexOf('.'),

--- a/newswires/client/src/tests/fixtures/wireData.ts
+++ b/newswires/client/src/tests/fixtures/wireData.ts
@@ -1,0 +1,35 @@
+import type { WireData } from '../../sharedTypes.ts';
+
+export const sampleFingerpostContent = {
+	uri: 'http://example.com',
+	sourceFeed: 'TestFeed',
+	usn: 'usn123',
+	version: 'v1',
+	status: 'active',
+	firstVersion: 'v1',
+	versionCreated: '2025-01-01T00:00:00Z',
+	dateTimeSent: '2025-01-01T00:00:00Z',
+	slug: 'sample-slug',
+	headline: 'Sample Headline',
+	subhead: 'Sample Subhead',
+	byline: 'Author Name',
+	priority: 'high',
+	subjects: {
+		code: ['subject1', 'subject2'],
+	},
+	keywords: ['keyword1', 'keyword2'],
+	language: 'en',
+	usage: 'general',
+	location: 'location1',
+	bodyText: 'Sample body text.',
+};
+
+export const sampleWireData: WireData = {
+	id: 1,
+	supplier: 'TestSupplier',
+	externalId: 'external-123',
+	ingestedAt: '2025-01-01T00:00:00Z',
+	content: sampleFingerpostContent,
+	highlight: 'Sample Highlight',
+	isFromRefresh: false,
+};

--- a/newswires/client/src/tests/testHelpers.ts
+++ b/newswires/client/src/tests/testHelpers.ts
@@ -1,0 +1,10 @@
+import { act } from '@testing-library/react';
+
+/**
+ * Flushes pending promises by resolving the current microtask queue.
+ * Useful in unit tests to ensure all async operations and state updates have completed.
+ */
+export const flushPendingPromises = async () =>
+	act(async () => {
+		await Promise.resolve();
+	});

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -51,7 +51,7 @@ export function urlToConfig(location: {
 	} else if (page.startsWith('item/') && page.split('/').length === 2) {
 		return { view: 'item', itemId: page.split('/')[1], query };
 	} else {
-		console.warn(`Page not found: "${page}", so using defaultConfig`);
+		// console.warn(`Page not found: "${page}", so using defaultConfig`);
 		return defaultConfig;
 	}
 }

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -51,7 +51,7 @@ export function urlToConfig(location: {
 	} else if (page.startsWith('item/') && page.split('/').length === 2) {
 		return { view: 'item', itemId: page.split('/')[1], query };
 	} else {
-		// console.warn(`Page not found: "${page}", so using defaultConfig`);
+		console.warn(`Page not found: "${page}", so using defaultConfig`);
 		return defaultConfig;
 	}
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add offline banner when data update fails on Newswire UI.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
