### PR TITLE
Newswires UI: fix toggle auto-update

### DIFF
--- a/newswires/client/src/context/SearchReducer.test.ts
+++ b/newswires/client/src/context/SearchReducer.test.ts
@@ -9,6 +9,28 @@ describe('SearchReducer', () => {
 		autoUpdate: true,
 	};
 
+	const successState: State = {
+		...initialState,
+		status: 'success',
+		queryData: { results: [sampleWireData] },
+	};
+
+	const offlineState: State = {
+		status: 'offline',
+		queryData: { results: [sampleWireData] },
+		successfulQueryHistory: [],
+		error: 'Network error',
+		autoUpdate: true,
+	};
+
+	const errorState: State = {
+		status: 'error',
+		queryData: { results: [sampleWireData] },
+		successfulQueryHistory: [],
+		error: 'Fetch error',
+		autoUpdate: true,
+	};
+
 	it('should handle FETCH_SUCCESS action in loading state', () => {
 		const action: Action = {
 			type: 'FETCH_SUCCESS',
@@ -26,185 +48,92 @@ describe('SearchReducer', () => {
 		expect(newState.error).toBeUndefined();
 	});
 
-	it('should handle FETCH_ERROR action in loading state', () => {
-		const action: Action = {
-			type: 'FETCH_ERROR',
-			error: 'Fetch failed',
-		};
+	[
+		{
+			state: {
+				...initialState,
+				autoUpdate: true,
+			},
+			expectedAutoUpdateValue: false,
+		},
+		{
+			state: {
+				...successState,
+				autoUpdate: true,
+			},
+			expectedAutoUpdateValue: false,
+		},
+	].forEach(({ state, expectedAutoUpdateValue }) => {
+		it(`should handle TOGGLE_AUTO_UPDATE action in ${state.status} state`, () => {
+			const action: Action = {
+				type: 'TOGGLE_AUTO_UPDATE',
+			};
 
-		const newState = SearchReducer(initialState, action);
+			const newState = SearchReducer(state, action);
 
-		expect(newState.status).toBe('error');
-		expect(newState.error).toEqual(action.error);
-	});
-
-	it('should handle UPDATE_RESULTS action in success state', () => {
-		const state: State = {
-			...initialState,
-			status: 'success',
-			queryData: { results: [{ ...sampleWireData, id: 1 }] },
-		};
-
-		const action: Action = {
-			type: 'UPDATE_RESULTS',
-			data: { results: [{ ...sampleWireData, id: 2 }] },
-		};
-
-		const newState = SearchReducer(state, action);
-
-		expect(newState.status).toBe('success');
-		expect(newState.queryData?.results).toHaveLength(2);
-		expect(newState.queryData?.results).toContainEqual({
-			...sampleWireData,
-			id: 2,
-			isFromRefresh: true,
-		});
-		expect(newState.queryData?.results).toContainEqual({
-			...sampleWireData,
-			id: 1,
+			expect(newState.autoUpdate).toBe(expectedAutoUpdateValue);
 		});
 	});
 
-	it('should handle ENTER_QUERY action in success state', () => {
-		const state: State = {
-			...initialState,
-			status: 'success',
-			queryData: { results: [sampleWireData] },
-		};
+	[successState, offlineState, errorState].forEach((state) => {
+		it(`should handle UPDATE_RESULTS action in ${state.status} state`, () => {
+			const action: Action = {
+				type: 'UPDATE_RESULTS',
+				data: { results: [{ ...sampleWireData, id: 2 }] },
+			};
 
-		const action: Action = {
-			type: 'ENTER_QUERY',
-		};
+			const newState = SearchReducer(state, action);
 
-		const newState = SearchReducer(state, action);
-
-		expect(newState.status).toBe('loading');
-	});
-
-	it('should handle TOGGLE_AUTO_UPDATE action in success state', () => {
-		const state: State = {
-			...initialState,
-			status: 'success',
-			queryData: { results: [sampleWireData] },
-		};
-
-		const action: Action = {
-			type: 'TOGGLE_AUTO_UPDATE',
-		};
-
-		const newState = SearchReducer(state, action);
-
-		expect(newState.autoUpdate).toBe(false);
-	});
-
-	it('should handle FETCH_ERROR action in success state', () => {
-		const state: State = {
-			...initialState,
-			status: 'success',
-			queryData: { results: [sampleWireData] },
-		};
-
-		const action: Action = {
-			type: 'FETCH_ERROR',
-			error: 'Fetch failed',
-		};
-
-		const newState = SearchReducer(state, action);
-
-		expect(newState.status).toBe('offline');
-		expect(newState.error).toEqual(action.error);
-	});
-
-	it('should handle UPDATE_RESULTS action in offline state', () => {
-		const state: State = {
-			status: 'offline',
-			queryData: { results: [{ ...sampleWireData, id: 1 }] },
-			successfulQueryHistory: [],
-			error: 'Network error',
-			autoUpdate: true,
-		};
-
-		const action: Action = {
-			type: 'UPDATE_RESULTS',
-			data: { results: [{ ...sampleWireData, id: 2 }] },
-		};
-
-		const newState = SearchReducer(state, action);
-
-		expect(newState.status).toBe('success');
-		expect(newState.queryData?.results).toHaveLength(2);
-		expect(newState.queryData?.results).toContainEqual({
-			...sampleWireData,
-			id: 2,
-			isFromRefresh: true,
-		});
-		expect(newState.queryData?.results).toContainEqual({
-			...sampleWireData,
-			id: 1,
+			expect(newState.status).toBe('success');
+			expect(newState.queryData?.results).toHaveLength(2);
+			expect(newState.queryData?.results).toContainEqual({
+				...sampleWireData,
+				id: 2,
+				isFromRefresh: true,
+			});
+			expect(newState.queryData?.results).toContainEqual({
+				...sampleWireData,
+				id: 1,
+			});
 		});
 	});
 
-	it('should handle UPDATE_RESULTS action in error state', () => {
-		const state: State = {
-			status: 'error',
-			queryData: { results: [{ ...sampleWireData, id: 1 }] },
-			successfulQueryHistory: [],
-			error: 'Fetch error',
-			autoUpdate: true,
-		};
+	[
+		{ state: initialState, expectedStatus: 'error' },
+		{ state: successState, expectedStatus: 'offline' },
+	].forEach(({ state, expectedStatus }) => {
+		it(`should handle FETCH_ERROR action in ${state.status} state`, () => {
+			const action: Action = {
+				type: 'FETCH_ERROR',
+				error: 'Fetch failed',
+			};
 
-		const action: Action = {
-			type: 'UPDATE_RESULTS',
-			data: { results: [{ ...sampleWireData, id: 2 }] },
-		};
+			const newState = SearchReducer(state, action);
 
-		const newState = SearchReducer(state, action);
-
-		expect(newState.status).toBe('success');
-		expect(newState.queryData?.results).toHaveLength(2);
-		expect(newState.queryData?.results).toContainEqual({
-			...sampleWireData,
-			id: 2,
-			isFromRefresh: true,
-		});
-		expect(newState.queryData?.results).toContainEqual({
-			...sampleWireData,
-			id: 1,
+			expect(newState.status).toBe(expectedStatus);
+			expect(newState.error).toEqual(action.error);
 		});
 	});
 
 	it('should handle RETRY action in error state', () => {
-		const state: State = {
-			status: 'error',
-			successfulQueryHistory: [],
-			error: 'Fetch error',
-			autoUpdate: true,
-		};
-
 		const action: Action = {
 			type: 'RETRY',
 		};
 
-		const newState = SearchReducer(state, action);
+		const newState = SearchReducer(errorState, action);
 
 		expect(newState.status).toBe('loading');
 	});
 
-	it('should handle ENTER_QUERY action in error state', () => {
-		const state: State = {
-			status: 'error',
-			queryData: undefined,
-			successfulQueryHistory: [],
-			error: 'Fetch error',
-			autoUpdate: true,
-		};
+	[successState, offlineState, errorState].forEach((state) => {
+		it(`should handle ENTER_QUERY action in ${state.status} state`, () => {
+			const action: Action = {
+				type: 'ENTER_QUERY',
+			};
 
-		const action: Action = {
-			type: 'ENTER_QUERY',
-		};
+			const newState = SearchReducer(state, action);
 
-		const newState = SearchReducer(state, action);
-
-		expect(newState.status).toBe('loading');
+			expect(newState.status).toBe('loading');
+		});
 	});
 });

--- a/newswires/client/src/context/SearchReducer.ts
+++ b/newswires/client/src/context/SearchReducer.ts
@@ -50,49 +50,50 @@ function getUpdatedHistory(
 }
 
 export const SearchReducer = (state: State, action: Action): State => {
-	switch (state.status) {
-		case 'loading':
-			switch (action.type) {
-				case 'FETCH_SUCCESS':
+	switch (action.type) {
+		case 'FETCH_SUCCESS':
+			return {
+				...state,
+				queryData: action.data,
+				successfulQueryHistory: getUpdatedHistory(
+					state.successfulQueryHistory,
+					action.query,
+					action.data.results.length,
+				),
+				status: 'success',
+				error: undefined,
+			};
+		case 'TOGGLE_AUTO_UPDATE':
+			return {
+				...state,
+				autoUpdate: !state.autoUpdate,
+			};
+		case 'UPDATE_RESULTS':
+			switch (state.status) {
+				case 'success':
 					return {
 						...state,
-						queryData: action.data,
-						successfulQueryHistory: getUpdatedHistory(
-							state.successfulQueryHistory,
-							action.query,
-							action.data.results.length,
-						),
-						status: 'success',
-						error: undefined,
+						queryData: mergeQueryData(state.queryData, action.data),
 					};
-
-				case 'FETCH_ERROR':
+				case 'offline':
+				case 'error':
+					return {
+						...state,
+						status: 'success',
+						queryData: mergeQueryData(state.queryData, action.data),
+					};
+				default:
+					return state;
+			}
+		case 'FETCH_ERROR':
+			switch (state.status) {
+				case 'loading':
 					return {
 						...state,
 						error: action.error,
 						status: 'error',
 					};
-				default:
-					return state;
-			}
-		case 'success':
-			switch (action.type) {
-				case 'UPDATE_RESULTS':
-					return {
-						...state,
-						queryData: mergeQueryData(state.queryData, action.data),
-					};
-				case 'ENTER_QUERY':
-					return {
-						...state,
-						status: 'loading',
-					};
-				case 'TOGGLE_AUTO_UPDATE':
-					return {
-						...state,
-						autoUpdate: !state.autoUpdate,
-					};
-				case 'FETCH_ERROR':
+				case 'success':
 					return {
 						...state,
 						error: action.error,
@@ -101,31 +102,9 @@ export const SearchReducer = (state: State, action: Action): State => {
 				default:
 					return state;
 			}
-		case 'offline':
-			switch (action.type) {
-				case 'UPDATE_RESULTS':
-					return {
-						...state,
-						status: 'success',
-						queryData: mergeQueryData(state.queryData, action.data),
-					};
-				default:
-					return state;
-			}
-		case 'error':
-			switch (action.type) {
-				case 'UPDATE_RESULTS':
-					return {
-						...state,
-						status: 'success',
-						queryData: mergeQueryData(state.queryData, action.data),
-					};
-				case 'RETRY':
-					return {
-						...state,
-						status: 'loading',
-					};
-				case 'ENTER_QUERY':
+		case 'RETRY':
+			switch (state.status) {
+				case 'error':
 					return {
 						...state,
 						status: 'loading',
@@ -133,6 +112,11 @@ export const SearchReducer = (state: State, action: Action): State => {
 				default:
 					return state;
 			}
+		case 'ENTER_QUERY':
+			return {
+				...state,
+				status: 'loading',
+			};
 		default:
 			return state;
 	}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Enable toggle auto-update regardless of the search status.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
