### PR TITLE
Newswires UI: fix offline banner

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -56,45 +56,6 @@ export function App() {
 					max-height: 100vh;
 				`}
 			>
-				{!isPoppedOut && (
-					<EuiHeader position="fixed">
-						<EuiHeaderSection>
-							<EuiHeaderSectionItem>
-								<EuiTitle
-									size={'s'}
-									css={css`
-										padding-bottom: 3px;
-									`}
-								>
-									<h1>Newswires</h1>
-								</EuiTitle>
-							</EuiHeaderSectionItem>
-							<EuiHeaderSectionItem>
-								<SideNav />
-							</EuiHeaderSectionItem>
-						</EuiHeaderSection>
-						<EuiHeaderSectionItem>
-							{
-								<EuiButton
-									iconType={'popout'}
-									onClick={() =>
-										window.open(
-											configToUrl({
-												...config,
-												view: 'feed',
-												itemId: undefined,
-											}),
-											'_blank',
-											'popout=true,width=400,height=800,top=200,location=no,menubar=no,toolbar=no',
-										)
-									}
-								>
-									New ticker
-								</EuiButton>
-							}
-						</EuiHeaderSectionItem>
-					</EuiHeader>
-				)}
 				{status === 'offline' && (
 					<EuiToast
 						title="You Are Currently Offline"
@@ -102,6 +63,7 @@ export function App() {
 						css={css`
 							border-radius: 0;
 							background: #fdf6d8;
+							position: fixed;
 						`}
 					>
 						<p>
@@ -110,9 +72,55 @@ export function App() {
 						</p>
 					</EuiToast>
 				)}
-				{status !== 'error' &&
-					state.queryData &&
-					state.queryData.results.length > 0 && (
+				<div
+					css={css`
+						${status === 'offline' && 'padding-top: 84px;'}
+						height: 100%;
+						${(status === 'loading' || status === 'error') &&
+						'display: flex; align-items: center;'}
+						${status === 'loading' && 'background: white;'}
+					`}
+				>
+					{!isPoppedOut && (
+						<EuiHeader position="fixed">
+							<EuiHeaderSection>
+								<EuiHeaderSectionItem>
+									<EuiTitle
+										size={'s'}
+										css={css`
+											padding-bottom: 3px;
+										`}
+									>
+										<h1>Newswires</h1>
+									</EuiTitle>
+								</EuiHeaderSectionItem>
+								<EuiHeaderSectionItem>
+									<SideNav />
+								</EuiHeaderSectionItem>
+							</EuiHeaderSection>
+							<EuiHeaderSectionItem>
+								{
+									<EuiButton
+										iconType={'popout'}
+										onClick={() =>
+											window.open(
+												configToUrl({
+													...config,
+													view: 'feed',
+													itemId: undefined,
+												}),
+												'_blank',
+												'popout=true,width=400,height=800,top=200,location=no,menubar=no,toolbar=no',
+											)
+										}
+									>
+										New ticker
+									</EuiButton>
+								}
+							</EuiHeaderSectionItem>
+						</EuiHeader>
+					)}
+					{status !== 'error' && (
 						<>
 							<EuiShowFor sizes={['xs', 's']}>
 								{view === 'item' ? <Item id={selectedItemId} /> : <Feed />}
@@ -146,27 +154,32 @@ export function App() {
 							</EuiShowFor>
 						</>
 					)}
-				{status == 'error' && (
-					<EuiEmptyPrompt
-						css={css`
-							background: white;
-						`}
-						actions={[
-							<EuiButton onClick={handleRetry} key="retry" iconType={'refresh'}>
-								Retry
-							</EuiButton>,
-							<EuiButton
-								onClick={() => handleEnterQuery(defaultQuery)}
-								key="clear"
-								iconType={'cross'}
-							>
-								Clear
-							</EuiButton>,
-						]}
-						body={<p>Sorry, failed to load because of {state.error}</p>}
-						hasBorder={true}
-					/>
-				)}
+					{status == 'error' && (
+						<EuiEmptyPrompt
+							css={css`
+								background: white;
+							`}
+							actions={[
+								<EuiButton
+									onClick={handleRetry}
+									key="retry"
+									iconType={'refresh'}
+								>
+									Retry
+								</EuiButton>,
+								<EuiButton
+									onClick={() => handleEnterQuery(defaultQuery)}
+									key="clear"
+									iconType={'cross'}
+								>
+									Clear
+								</EuiButton>,
+							]}
+							body={<p>Sorry, failed to load because of {state.error}</p>}
+							hasBorder={true}
+						/>
+					)}
+				</div>
 			</EuiPageTemplate>
 		</EuiProvider>
 	);


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Make the offline banner fixed so it can remain visible when scrolling through stories.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
