### PR TITLE
AP poller: link AP images to wire stories

### DIFF
--- a/poller-lambdas/src/pollers/ap/apPoller.test.ts
+++ b/poller-lambdas/src/pollers/ap/apPoller.test.ts
@@ -1,0 +1,137 @@
+
+import {apPoller} from "./apPoller"; // Replace with actual path
+import {apItems, apTransformedItems} from "./fixtures/apItems";
+import { parseNitfContent } from './parseNitfContent';
+
+global.fetch = jest.fn(() =>
+    Promise.resolve({
+        json: () => Promise.resolve({
+            data: {
+                current_item_count: 0,
+                items: [],
+                next_page: 'https://api.ap.org/media/v/content/feed?page=1',
+            },
+        }),
+        ok: true,
+    })
+) as jest.Mock;
+
+jest.mock('./parseNitfContent', () => ({
+    parseNitfContent: jest.fn(),
+}));
+
+describe('apPoller', () => {
+    const secret = 'test-api-key';
+    const input = 'https://api.ap.org/media/v/content/feed?page=1';
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('should return an empty payload if no new items are in the feed', async () => {
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                json: () => Promise.resolve({
+                    data: {
+                        current_item_count: 0,
+                        items: [],
+                        next_page: 'https://api.ap.org/media/v/content/feed?page=2',
+                    },
+                }),
+                ok: true,
+            })
+        ) as jest.Mock;
+
+        const result = await apPoller(secret, input);
+
+        expect(result.payloadForIngestionLambda).toEqual([]);
+        expect(result.valueForNextPoll).toBe(
+            'https://api.ap.org/media/v/content/feed?page=2&include=*',
+        );
+    });
+
+    it('should process feed items with NITF content and return payloads', async () => {
+        global.fetch = jest.fn()
+            .mockImplementationOnce(() =>
+                Promise.resolve({
+                    json: () => Promise.resolve({
+                        data: {
+                            current_item_count: 2,
+                            items: apItems,
+                            next_page: 'https://api.ap.org/media/v/content/feed?page=2',
+                        },
+                    }),
+                    ok: true,
+                })
+            )
+            .mockImplementationOnce(() =>
+                Promise.resolve({
+                    text: () => Promise.resolve('<nitf>content1</nitf>'),
+                    ok: true,
+                })
+            )
+            .mockImplementationOnce(() =>
+                Promise.resolve({
+                    text: () => Promise.resolve('<nitf>content2</nitf>'),
+                    ok: true,
+                })
+            );
+
+        (parseNitfContent as jest.Mock).mockImplementation((_xmlContent) => ({
+            byline: 'Author Name',
+            headline: 'Headline',
+            bodyContentHtml: '<p>Body content</p>',
+            abstract: 'Abstract content',
+        }));
+
+        const result = await apPoller(secret, input);
+
+        expect(result.payloadForIngestionLambda).toHaveLength(2);
+        expect(result.payloadForIngestionLambda[0]).toEqual(apTransformedItems[0]);
+        expect(result.payloadForIngestionLambda[1]).toEqual(apTransformedItems[1]);
+    });
+
+    it('should exclude items without NITF renditions', async () => {
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                json: () => Promise.resolve({
+                    data: {
+                        current_item_count: 2,
+                        items: [
+                            {
+                                item: {
+                                    altids: { etag: '123' },
+                                    renditions: {},
+                                },
+                            },
+                        ],
+                        next_page: 'https://api.ap.org/media/v/content/feed?page=2',
+                    },
+                }),
+                ok: true,
+            })
+        ) as jest.Mock;
+
+        const result = await apPoller(secret, input);
+
+        expect(result.payloadForIngestionLambda).toEqual([]);
+        expect(result.valueForNextPoll).toBe(
+            'https://api.ap.org/media/v/content/feed?page=2&include=*',
+        );
+    });
+
+    it('should throw an error if the feed response contains an error', async () => {
+        global.fetch = jest.fn(() =>
+            Promise.resolve({
+                json: () => Promise.resolve({
+                    error: { message: 'Some API error occurred' },
+                }),
+                ok: true,
+            })
+        ) as jest.Mock;
+
+        await expect(apPoller(secret, input)).rejects.toThrow('Some API error occurred');
+    });
+});
+
+

--- a/poller-lambdas/src/pollers/ap/apPoller.ts
+++ b/poller-lambdas/src/pollers/ap/apPoller.ts
@@ -169,6 +169,7 @@ function itemWithContentToDesiredOutput({
 		ednote,
 		subject,
 		keywords,
+		associations,
 	} = feedItem;
 
 	const { abstract, bodyContentHtml } = contentFromNitf;
@@ -201,6 +202,12 @@ function itemWithContentToDesiredOutput({
 			abstract,
 			originalContentText: originalXmlContent,
 			ednote,
+			imageIds: associations
+				? Object.keys(associations)
+						.filter(key  => associations[key]?.type === 'picture')
+						.map((key) => associations[key]?.altids?.itemid)
+						.filter((item): item is string => item !== undefined)
+				: [],
 		},
 	};
 }

--- a/poller-lambdas/src/pollers/ap/fixtures/apItems.ts
+++ b/poller-lambdas/src/pollers/ap/fixtures/apItems.ts
@@ -1,0 +1,128 @@
+export const apItems = [
+	{
+		item: {
+			headline: 'Test headline 1',
+			type: 'text',
+			pubstatus: 'usable',
+			versioncreated: '2025-01-20T10:00:32Z',
+			firstcreated: '2025-01-19T05:35:11Z',
+			altids: { etag: '123' },
+			renditions: { nitf: { href: 'https://example.com/nitf1' } },
+			ednote: 'UPDATES',
+			keywords: ['keyword2 keyword3 keyword4 keyword5'],
+			subject: [
+				{
+					scheme: 'http://cv.ap.org/id/',
+					code: 'test-code-1',
+					name: 'keyword1',
+					creator: 'Machine',
+					rels: ['direct'],
+					relevance: 99,
+				},
+				{
+					rels: ['category'],
+					creator: 'Editorial',
+					code: 'l',
+					name: 'l',
+				},
+				{
+					rels: ['category'],
+					creator: 'Editorial',
+					code: 'a',
+					name: 'a',
+				},
+				{
+					rels: ['category'],
+					creator: 'Editorial',
+					code: 'n',
+					name: 'n',
+				},
+			],
+			associations: {
+				'1': {
+					uri: 'https://api.ap.org/media/v/content/test-uid-1?qt=fi9WsJei_reF&et=1a1aza3c0&ai=bd13ed5ea1d9f71c4547f50a5016433c',
+					altids: {
+						itemid: 'test-uid-1',
+						etag: 'test-etag-1',
+					},
+					version: 1,
+					type: 'picture',
+					headline: 'Test headline 1',
+				},
+				'2': {
+					uri: 'https://api.ap.org/media/v/content/test-uid-2?qt=fi9WsJei_reF&et=1a1aza3c0&ai=bd13ed5ea1d9f71c4547f50a5016433c',
+					altids: {
+						itemid: 'test-uid-2',
+						etag: 'test-etag-2',
+					},
+					version: 1,
+					type: 'picture',
+					headline: 'Test headline 2',
+				},
+				'3': {
+					uri: 'https://api.ap.org/media/v/content/test-uid-3?qt=fi9WsJei_reF&et=1a1aza3c0&ai=bd13ed5ea1d9f71c4547f50a5016433c',
+					altids: {
+						itemid: 'test-uid-3',
+						etag: 'test-etag-3',
+					},
+					version: 1,
+					type: 'video',
+					headline: 'Test headline 3',
+				},
+			},
+		},
+	},
+	{
+		item: {
+			headline: 'Test headline 2',
+			type: 'text',
+			pubstatus: 'usable',
+			versioncreated: '2025-01-20T10:01:32Z',
+			firstcreated: '2025-01-19T05:36:11Z',
+			altids: { etag: '456' },
+			renditions: { nitf: { href: 'https://example.com/nitf2' } },
+			ednote: 'UPDATES',
+		},
+	},
+];
+
+export const apTransformedItems = [
+	{
+		externalId: '123',
+		body: {
+			abstract: 'Abstract content',
+			'source-feed': 'AP-Newswires',
+			version: '0',
+			headline: 'Test headline 1',
+			type: 'text',
+			status: 'usable',
+			versionCreated: '2025-01-20T10:00:32Z',
+			firstVersion: '2025-01-19T05:35:11Z',
+			originalContentText: '<nitf>content1</nitf>',
+			ednote: 'UPDATES',
+			imageIds: ['test-uid-1', 'test-uid-2'],
+			keywords: ['keyword1', 'keyword2', 'keyword3', 'keyword4', 'keyword5'],
+			body_text: '<p>Body content</p>',
+			byline: 'Author Name',
+		},
+	},
+	{
+		externalId: '456',
+		body: {
+			abstract: 'Abstract content',
+			'source-feed': 'AP-Newswires',
+			version: '0',
+			headline: 'Test headline 2',
+			type: 'text',
+			status: 'usable',
+			versionCreated: '2025-01-20T10:01:32Z',
+			firstVersion: '2025-01-19T05:36:11Z',
+			originalContentText: '<nitf>content2</nitf>',
+			ednote: 'UPDATES',
+			imageIds: [],
+			keywords: [],
+			body_text: '<p>Body content</p>',
+			byline: 'Author Name',
+		},
+	},
+];

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -56,6 +56,7 @@ const FingerpostFeedPayloadSchema = z.object({
 
 export const IngestorInputBodySchema = FingerpostFeedPayloadSchema.extend({
 	originalContentText: z.string().optional(),
+	imageIds:  z.array(z.string()).default([]),
 });
 
 const WireEntryContentSchema = IngestorInputBodySchema.omit({


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Link AP images to wire stories.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
