### PR TITLE
Fix update action after empty result

### DIFF
--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -170,12 +170,13 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 		if (state.status === 'success' || state.status === 'offline') {
 			pollingInterval = setInterval(() => {
 				if (state.autoUpdate) {
-					fetchResults(
-						currentConfig.query,
-						Math.max(
-							...state.queryData.results.map((wire) => wire.id),
-						).toString(),
-					)
+					const sinceId =
+						state.queryData.results.length > 0
+							? Math.max(
+									...state.queryData.results.map((wire) => wire.id),
+								).toString()
+							: undefined;
+					fetchResults(currentConfig.query, sinceId)
 						.then((data) => {
 							dispatch({ type: 'UPDATE_RESULTS', data });
 						})


### PR DESCRIPTION
If there are no existing results, then the `Math.max()` call returns `-Infinity`, which is not a valid id for the API.

To replicate the issue: Search for a phrase that won't exist in the database, then observe that while the initial search returns a 200 and an empty list of results, subsequent auto-update `fetch` requests receive a 400.

To test the fix: Make the same search and observer that auto-update requests receive a 200 with empty results.

