### PR TITLE
Add more fields to JSON view in UI

### DIFF
--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -48,8 +48,10 @@ case class FingerpostWire(
     language: Option[String],
     usage: Option[String],
     location: Option[String],
-    bodyText: Option[String],
-    ednote: Option[String]
+    ednote: Option[String],
+    mediaCatCodes: Option[String],
+    `abstract`: Option[String],
+    bodyText: Option[String]
 )
 object FingerpostWire {
   // rename a couple of fields

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -48,7 +48,7 @@ export const WireDetail = ({
 		<Fragment>
 			{isShowingJson ? (
 				<EuiCodeBlock language="json">
-					{JSON.stringify(wire.content, null, 2)}
+					{JSON.stringify(wire, null, 2)}
 				</EuiCodeBlock>
 			) : (
 				<>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Passes a couple of extra fields from `content` down to the UI, and includes the wrapper around the content in the JSON view.

More info for debugging.

