### PR TITLE
Add log metric filter for source feeds on ingestion

### DIFF
--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -1041,6 +1041,36 @@ exports[`The Newswires stack matches the snapshot 1`] = `
       },
       "Type": "AWS::Lambda::EventSourceMapping",
     },
+    "IngestionSourceFeeds54B3095A": {
+      "Properties": {
+        "FilterPattern": "{ $.message.eventType = "SUCCESSFUL_INGESTION" }",
+        "LogGroupName": {
+          "Fn::Join": [
+            "",
+            [
+              "/aws/lambda/",
+              {
+                "Ref": "IngestionLambdaTESTC02B3E43",
+              },
+            ],
+          ],
+        },
+        "MetricTransformations": [
+          {
+            "Dimensions": [
+              {
+                "Key": "sourceFeed",
+                "Value": "$.message.sourceFeed",
+              },
+            ],
+            "MetricName": "IngestionSourceFeeds",
+            "MetricNamespace": "TEST/editorial-feeds/newswires-ingestion-lambda",
+            "MetricValue": "1",
+          },
+        ],
+      },
+      "Type": "AWS::Logs::MetricFilter",
+    },
     "InstanceRoleNewswiresC10A0615": {
       "Properties": {
         "AssumeRolePolicyDocument": {

--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -26,6 +26,7 @@ import {
 } from 'aws-cdk-lib/aws-rds';
 import { Topic } from 'aws-cdk-lib/aws-sns';
 import type { Queue } from 'aws-cdk-lib/aws-sqs';
+import { SUCCESSFUL_INGESTION_EVENT_TYPE } from '../../shared/constants';
 import type { PollerId } from '../../shared/pollers';
 import { POLLERS_CONFIG } from '../../shared/pollers';
 import { LAMBDA_ARCHITECTURE, LAMBDA_RUNTIME } from './constants';
@@ -146,7 +147,7 @@ export class Newswires extends GuStack {
 			filterPattern: aws_logs.FilterPattern.stringValue(
 				'$.message.eventType',
 				'=',
-				'SUCCESSFUL_INGESTION',
+				SUCCESSFUL_INGESTION_EVENT_TYPE,
 			),
 			dimensions: { sourceFeed: '$.message.sourceFeed' },
 		});

--- a/ingestion-lambda/src/handler.ts
+++ b/ingestion-lambda/src/handler.ts
@@ -134,6 +134,12 @@ export const main = async (event: SQSEvent): Promise<SQSBatchResponse> => {
 							console.warn(
 								`A record with the provided external_id (messageId: ${messageId}) already exists. No new data was inserted to prevent duplication.`,
 							);
+						} else {
+							console.log({
+								messageId,
+								sourceFeed: snsMessageContent['source-feed'],
+								eventType: 'SUCCESSFUL_INGESTION',
+							});
 						}
 					} catch (e) {
 						const reason = e instanceof Error ? e.message : 'Unknown error';

--- a/ingestion-lambda/src/handler.ts
+++ b/ingestion-lambda/src/handler.ts
@@ -1,5 +1,6 @@
 import { PutObjectCommand } from '@aws-sdk/client-s3';
 import type { SQSBatchResponse, SQSEvent } from 'aws-lambda';
+import { SUCCESSFUL_INGESTION_EVENT_TYPE } from '../../shared/constants';
 import type { IngestorInputBody } from '../../shared/types';
 import { IngestorInputBodySchema } from '../../shared/types';
 import { BUCKET_NAME } from './config';
@@ -138,7 +139,7 @@ export const main = async (event: SQSEvent): Promise<SQSBatchResponse> => {
 							console.log({
 								messageId,
 								sourceFeed: snsMessageContent['source-feed'],
-								eventType: 'SUCCESSFUL_INGESTION',
+								eventType: SUCCESSFUL_INGESTION_EVENT_TYPE,
 							});
 						}
 					} catch (e) {

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,2 +1,4 @@
 // FIXME we should probably have a dedicated stack for the Newswires app for e.g. cost explorer purposes (as the App tag needs to be different for riff-raff etc. to differentiate)
 export const STACK = 'editorial-feeds';
+
+export const SUCCESSFUL_INGESTION_EVENT_TYPE = 'SUCCESSFUL_INGESTION';


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Add a logs metric filter to the log group for the ingestion lambda, which collects the `sourceFeed` from successfully ingested items.
- Also adds the corresponding logging to the lambda handler code.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Deploy to CODE, verify that appropriate metrics are being produced.

<img width="687" alt="sourceFeed metrics, graphed in Grafana" src="https://github.com/user-attachments/assets/7efcc652-aac0-48d5-a6b3-4cc2d5f39e4c" />


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
