### PR TITLE
Add comet to suppliers

### DIFF
--- a/newswires/app/conf/SourceFeedSupplierMapping.scala
+++ b/newswires/app/conf/SourceFeedSupplierMapping.scala
@@ -101,6 +101,7 @@ object SourceFeedSupplierMapping {
       "PA HSL",
       "PA JUST GROUP",
       "PA BROOKE ACTION FOR WORKING HORSES AND DONKEYS"
-    )
+    ),
+    "COMET" -> List("COMET")
   )
 }

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -105,12 +105,14 @@ object FingerpostWireEntry
       fm: ResultName[FingerpostWireEntry]
   )(rs: WrappedResultSet): FingerpostWireEntry = {
     val fingerpostContent = Json.parse(rs.string(fm.content)).as[FingerpostWire]
+    val sourceFeed = fingerpostContent.sourceFeed
+    val supplier = sourceFeed
+      .flatMap(supplierFromSourceFeed)
+      .getOrElse(sourceFeed.getOrElse("Unknown"))
 
     FingerpostWireEntry(
       id = rs.long(fm.id),
-      supplier = fingerpostContent.sourceFeed
-        .flatMap(supplierFromSourceFeed)
-        .getOrElse("Unknown"),
+      supplier = supplier,
       externalId = rs.string(fm.externalId),
       ingestedAt = rs.zonedDateTime(fm.ingestedAt),
       content = fingerpostContent,

--- a/newswires/client/src/suppliers.ts
+++ b/newswires/client/src/suppliers.ts
@@ -32,6 +32,10 @@ export const supplierData: Record<
 		label: 'Reuters (Gu)',
 		colour: reutersBrand,
 	},
+	COMET: {
+		label: 'Comet',
+		colour: '#39756a',
+	},
 };
 
 export function getSupplierInfo(


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

* [Add Comet to suppliers on front and back ends](https://github.com/guardian/newswires/commit/c4026281ccdf29cb3eac0fa38d76325fa3120662)
* [Use sourceFeed as fallback value in API when supplier isn't recognised](https://github.com/guardian/newswires/commit/fc346dacc6eb0195b52189f44fa4d92f477bdfb5)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="531" alt="story with a green 'comet' label" src="https://github.com/user-attachments/assets/ad2d00d9-d992-4d24-a7c9-a02fdb6d162c" />


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
