### PR TITLE
Typecheck in CI, and fix type errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,6 +40,7 @@ jobs:
         run: |
           npm ci
           npm run lint:ci
+          npm run typecheck
           npm test
 
       - name: Build CDK

--- a/cdk/package.json
+++ b/cdk/package.json
@@ -4,6 +4,7 @@
 	"private": true,
 	"scripts": {
 		"build": "tsc",
+		"typecheck": "tsc --noEmit",
 		"test": "jest --detectOpenHandles --config ../jest.config.js --selectProjects cdk",
 		"test-update": "jest -u",
 		"synth": "cdk synth --path-metadata false --version-reporting false",

--- a/poller-lambdas/localRun.ts
+++ b/poller-lambdas/localRun.ts
@@ -26,6 +26,7 @@ const fakeInvoke = async (
 		Records: [
 			{
 				body: input,
+				messageId: 'FAKE_MESSAGE_ID',
 			},
 		],
 	});

--- a/poller-lambdas/src/pollers/EXAMPLE_fixed_frequency.ts
+++ b/poller-lambdas/src/pollers/EXAMPLE_fixed_frequency.ts
@@ -1,17 +1,11 @@
-import type {
-	FixedFrequencyPollFunction,
-	PollerInput,
-	SecretValue,
-} from '../types';
+import type { FixedFrequencyPollFunction } from '../types';
 
-export const EXAMPLE_fixed_frequency = (async (
-	secret: SecretValue,
-	input: PollerInput,
-) => {
+export const EXAMPLE_fixed_frequency = (async ({ secret, input, logger }) => {
 	const previousCounterValue = parseInt(input);
 	await new Promise((resolve) => setTimeout(resolve, 1000)); // simulate polling work taking a short time
 	const newCounterValue = previousCounterValue + 1;
-	console.log({
+	logger.log({
+		message: 'commence fixed frequency poll',
 		secretLength: secret.length,
 		input,
 		previousCounterValue,
@@ -24,6 +18,7 @@ export const EXAMPLE_fixed_frequency = (async (
 				body: {
 					body_text: 'foo',
 					keywords: [],
+					imageIds: [],
 				},
 			},
 		],

--- a/poller-lambdas/src/pollers/EXAMPLE_long_polling.ts
+++ b/poller-lambdas/src/pollers/EXAMPLE_long_polling.ts
@@ -1,16 +1,17 @@
-import type { LongPollFunction, PollerInput, SecretValue } from '../types';
+import type { LongPollFunction } from '../types';
 
-export const EXAMPLE_long_polling = (async (
-	secret: SecretValue,
-	input: PollerInput,
-) => {
+export const EXAMPLE_long_polling = (async ({
+	secret,
+	input,
+	logger: logger,
+}) => {
 	const previousCounterValue = parseInt(input);
-	console.log({
+	logger.log({
+		message: 'commence long poll (hard coded example to return after 5s)...',
 		secretLength: secret.length,
 		input,
 		previousCounterValue,
 	});
-	console.log('commence long poll (hard coded example to return after 5s)...');
 	await new Promise((resolve) => setTimeout(resolve, 5_000)); // simulate long poll taking 5s
 	const newCounterValue = previousCounterValue + 1;
 	console.log({
@@ -23,6 +24,7 @@ export const EXAMPLE_long_polling = (async (
 				body: {
 					body_text: 'foo',
 					keywords: [],
+					imageIds: [],
 				},
 			},
 			{
@@ -30,6 +32,7 @@ export const EXAMPLE_long_polling = (async (
 				body: {
 					body_text: 'bar',
 					keywords: [],
+					imageIds: [],
 				},
 			},
 		],

--- a/poller-lambdas/src/pollers/ap/apPoller.test.ts
+++ b/poller-lambdas/src/pollers/ap/apPoller.test.ts
@@ -1,137 +1,145 @@
-
-import {apPoller} from "./apPoller"; // Replace with actual path
-import {apItems, apTransformedItems} from "./fixtures/apItems";
+import { createLogger } from '../../../../shared/lambda-logging';
+import { apPoller } from './apPoller'; // Replace with actual path
+import { apItems, apTransformedItems } from './fixtures/apItems';
 import { parseNitfContent } from './parseNitfContent';
 
 global.fetch = jest.fn(() =>
-    Promise.resolve({
-        json: () => Promise.resolve({
-            data: {
-                current_item_count: 0,
-                items: [],
-                next_page: 'https://api.ap.org/media/v/content/feed?page=1',
-            },
-        }),
-        ok: true,
-    })
+	Promise.resolve({
+		json: () =>
+			Promise.resolve({
+				data: {
+					current_item_count: 0,
+					items: [],
+					next_page: 'https://api.ap.org/media/v/content/feed?page=1',
+				},
+			}),
+		ok: true,
+	}),
 ) as jest.Mock;
 
 jest.mock('./parseNitfContent', () => ({
-    parseNitfContent: jest.fn(),
+	parseNitfContent: jest.fn(),
 }));
 
+const logger = createLogger({});
+
 describe('apPoller', () => {
-    const secret = 'test-api-key';
-    const input = 'https://api.ap.org/media/v/content/feed?page=1';
+	const secret = 'test-api-key';
+	const input = 'https://api.ap.org/media/v/content/feed?page=1';
 
-    beforeEach(() => {
-        jest.clearAllMocks();
-    });
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
 
-    it('should return an empty payload if no new items are in the feed', async () => {
-        global.fetch = jest.fn(() =>
-            Promise.resolve({
-                json: () => Promise.resolve({
-                    data: {
-                        current_item_count: 0,
-                        items: [],
-                        next_page: 'https://api.ap.org/media/v/content/feed?page=2',
-                    },
-                }),
-                ok: true,
-            })
-        ) as jest.Mock;
+	it('should return an empty payload if no new items are in the feed', async () => {
+		global.fetch = jest.fn(() =>
+			Promise.resolve({
+				json: () =>
+					Promise.resolve({
+						data: {
+							current_item_count: 0,
+							items: [],
+							next_page: 'https://api.ap.org/media/v/content/feed?page=2',
+						},
+					}),
+				ok: true,
+			}),
+		) as jest.Mock;
 
-        const result = await apPoller(secret, input);
+		const result = await apPoller({ secret, input, logger });
 
-        expect(result.payloadForIngestionLambda).toEqual([]);
-        expect(result.valueForNextPoll).toBe(
-            'https://api.ap.org/media/v/content/feed?page=2&include=*',
-        );
-    });
+		expect(result.payloadForIngestionLambda).toEqual([]);
+		expect(result.valueForNextPoll).toBe(
+			'https://api.ap.org/media/v/content/feed?page=2&include=*',
+		);
+	});
 
-    it('should process feed items with NITF content and return payloads', async () => {
-        global.fetch = jest.fn()
-            .mockImplementationOnce(() =>
-                Promise.resolve({
-                    json: () => Promise.resolve({
-                        data: {
-                            current_item_count: 2,
-                            items: apItems,
-                            next_page: 'https://api.ap.org/media/v/content/feed?page=2',
-                        },
-                    }),
-                    ok: true,
-                })
-            )
-            .mockImplementationOnce(() =>
-                Promise.resolve({
-                    text: () => Promise.resolve('<nitf>content1</nitf>'),
-                    ok: true,
-                })
-            )
-            .mockImplementationOnce(() =>
-                Promise.resolve({
-                    text: () => Promise.resolve('<nitf>content2</nitf>'),
-                    ok: true,
-                })
-            );
+	it('should process feed items with NITF content and return payloads', async () => {
+		global.fetch = jest
+			.fn()
+			.mockImplementationOnce(() =>
+				Promise.resolve({
+					json: () =>
+						Promise.resolve({
+							data: {
+								current_item_count: 2,
+								items: apItems,
+								next_page: 'https://api.ap.org/media/v/content/feed?page=2',
+							},
+						}),
+					ok: true,
+				}),
+			)
+			.mockImplementationOnce(() =>
+				Promise.resolve({
+					text: () => Promise.resolve('<nitf>content1</nitf>'),
+					ok: true,
+				}),
+			)
+			.mockImplementationOnce(() =>
+				Promise.resolve({
+					text: () => Promise.resolve('<nitf>content2</nitf>'),
+					ok: true,
+				}),
+			);
 
-        (parseNitfContent as jest.Mock).mockImplementation((_xmlContent) => ({
-            byline: 'Author Name',
-            headline: 'Headline',
-            bodyContentHtml: '<p>Body content</p>',
-            abstract: 'Abstract content',
-        }));
+		(parseNitfContent as jest.Mock).mockImplementation((_xmlContent) => ({
+			byline: 'Author Name',
+			headline: 'Headline',
+			bodyContentHtml: '<p>Body content</p>',
+			abstract: 'Abstract content',
+		}));
 
-        const result = await apPoller(secret, input);
+		const result = await apPoller({ secret, input, logger });
 
-        expect(result.payloadForIngestionLambda).toHaveLength(2);
-        expect(result.payloadForIngestionLambda[0]).toEqual(apTransformedItems[0]);
-        expect(result.payloadForIngestionLambda[1]).toEqual(apTransformedItems[1]);
-    });
+		expect(result.payloadForIngestionLambda).toHaveLength(2);
+		expect(result.payloadForIngestionLambda[0]).toEqual(apTransformedItems[0]);
+		expect(result.payloadForIngestionLambda[1]).toEqual(apTransformedItems[1]);
+	});
 
-    it('should exclude items without NITF renditions', async () => {
-        global.fetch = jest.fn(() =>
-            Promise.resolve({
-                json: () => Promise.resolve({
-                    data: {
-                        current_item_count: 2,
-                        items: [
-                            {
-                                item: {
-                                    altids: { etag: '123' },
-                                    renditions: {},
-                                },
-                            },
-                        ],
-                        next_page: 'https://api.ap.org/media/v/content/feed?page=2',
-                    },
-                }),
-                ok: true,
-            })
-        ) as jest.Mock;
+	it('should exclude items without NITF renditions', async () => {
+		global.fetch = jest.fn(() =>
+			Promise.resolve({
+				json: () =>
+					Promise.resolve({
+						data: {
+							current_item_count: 2,
+							items: [
+								{
+									item: {
+										altids: { etag: '123' },
+										renditions: {},
+									},
+								},
+							],
+							next_page: 'https://api.ap.org/media/v/content/feed?page=2',
+						},
+					}),
+				ok: true,
+			}),
+		) as jest.Mock;
 
-        const result = await apPoller(secret, input);
+		const result = await apPoller({ secret, input, logger });
 
-        expect(result.payloadForIngestionLambda).toEqual([]);
-        expect(result.valueForNextPoll).toBe(
-            'https://api.ap.org/media/v/content/feed?page=2&include=*',
-        );
-    });
+		expect(result.payloadForIngestionLambda).toEqual([]);
+		expect(result.valueForNextPoll).toBe(
+			'https://api.ap.org/media/v/content/feed?page=2&include=*',
+		);
+	});
 
-    it('should throw an error if the feed response contains an error', async () => {
-        global.fetch = jest.fn(() =>
-            Promise.resolve({
-                json: () => Promise.resolve({
-                    error: { message: 'Some API error occurred' },
-                }),
-                ok: true,
-            })
-        ) as jest.Mock;
+	it('should throw an error if the feed response contains an error', async () => {
+		global.fetch = jest.fn(() =>
+			Promise.resolve({
+				json: () =>
+					Promise.resolve({
+						error: { message: 'Some API error occurred' },
+					}),
+				ok: true,
+			}),
+		) as jest.Mock;
 
-        await expect(apPoller(secret, input)).rejects.toThrow('Some API error occurred');
-    });
+		await expect(apPoller({ secret, input, logger })).rejects.toThrow(
+			'Some API error occurred',
+		);
+	});
 });
-
-


### PR DESCRIPTION
- Add `typecheck` script to `cdk` workspace, and run `npm run typecheck` for all workspaces in CI.
- Fix some type errors introduced by #124 