### PR TITLE
More logging on ingestion-lambda and AP poller

### DIFF
--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -683,7 +683,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
         },
         "Handler": "handler.main",
         "LoggingConfig": {
-          "LogFormat": "JSON",
+          "LogFormat": "Text",
         },
         "MemorySize": 512,
         "ReservedConcurrentExecutions": 10,
@@ -1105,7 +1105,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
     },
     "IngestionSourceFeeds54B3095A": {
       "Properties": {
-        "FilterPattern": "{ $.message.eventType = "SUCCESSFUL_INGESTION" }",
+        "FilterPattern": "{ $.message.eventType = "INGESTION_SUCCESS" }",
         "LogGroupName": {
           "Fn::Join": [
             "",

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -1,6 +1,11 @@
 // FIXME we should probably have a dedicated stack for the Newswires app for e.g. cost explorer purposes (as the App tag needs to be different for riff-raff etc. to differentiate)
 export const STACK = 'editorial-feeds';
 
-export const SUCCESSFUL_INGESTION_EVENT_TYPE = 'SUCCESSFUL_INGESTION';
+export const SUCCESSFUL_INGESTION_EVENT_TYPE = 'INGESTION_SUCCESS';
+export const FAILED_INGESTION_EVENT_TYPE = 'INGESTION_FAILURE';
+export const INGESTION_DUPLICATE_STORY_EVENT_TYPE = 'INGESTION_DUPLICATE_STORY';
+export const INGESTION_PROCESSING_SQS_MESSAGE_EVENT_TYPE =
+	'INGESTION_PROCESSING_SQS_MESSAGE';
+
 export const POLLER_FAILURE_EVENT_TYPE = 'POLLER_FAILURE';
 export const POLLER_INVOCATION_EVENT_TYPE = 'POLLER_INVOCATION';


### PR DESCRIPTION
- Log the externalId of successfully ingested items, along with some other metadata.
- Make the namespacing more consistent for eventTypes.
- Use `logger` helper for logging in `apPoller`.

Logging `externalId` and `sqsMessageId` in more places makes it easier to track a given story across lambda, and easier to track the steps within a given lambda, respectively.

<img width="1357" alt="logs in ELK showing a single 'externalId' across both the 'reuters_poller_lambda' app and the 'ingestion_lambda' app" src="https://github.com/user-attachments/assets/9cc8c59a-40d7-4970-a1fd-e69b2455fd23" />


<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Deploy to CODE, verify that the expected logs are showing up.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
