### PR TITLE
Fix self-invocation for fixed schedule poller lambdas

### DIFF
--- a/poller-lambdas/src/index.ts
+++ b/poller-lambdas/src/index.ts
@@ -86,7 +86,7 @@ const pollerWrapper =
 					}
 
 					if (isFixedFrequencyPollOutput(output)) {
-						const safeIdealFrequencyInSeconds = Math.min(
+						const safeIdealFrequencyInSeconds = Math.max(
 							5,
 							output.idealFrequencyInSeconds,
 						);


### PR DESCRIPTION
Change `Math.min()` to `Math.max()` when calculating `safeIdealFrequencyInSeconds`, which is used to decide when to schedule the next invocation of a scheduled poller lambda.

The previous code had the effect of making 5 seconds the _ceiling_ for the ideal interval, rather than the _floor_ (which is what was intended). The `idealFrequencyInSeconds` set for a given poller was therefore being ignored unless it was < 5 seconds. 

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Deploy to CODE, verify that the Reuters poller lambda starts to run roughly once per 60s (as specified in its config) rather than roughly once per 5 seconds.

<img width="1311" alt="image" src="https://github.com/user-attachments/assets/25be8499-4829-4b91-8ff7-8d0b46bb74fe" />

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

This will mean that the Reuters poller in particular is running less often than it has been, which means a) stories will come in slower sometimes, and b) it's more likely that we'll drop stories in the case where they fail first time, because trying more regularly was effectively giving us many retries per story. But this is a separate issue strictly speaking and I've made a ticket for it. 

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
