### PR TITLE
Add db migration to hold composer IDs against wire entry

### DIFF
--- a/db/migrations/V12__composer_link_cols.sql
+++ b/db/migrations/V12__composer_link_cols.sql
@@ -1,0 +1,4 @@
+-- alter the main table to add columns that can store the composer ID of a generated piece
+ALTER TABLE fingerpost_wire_entry
+  ADD COLUMN composer_id TEXT NULL,
+  ADD COLUMN composer_sent_by TEXT NULL;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

adds in migration to add columns for storing composer ID and identity of user sending to composer, so that the wire and the piece are linked and can be visited.

## How to test

Migrate locally.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

Unblocks faster development of #139 when running locally against the CODE database.