### PR TITLE
Load a list of suppliers to exclude, from index.html

### DIFF
--- a/newswires/client/index.html
+++ b/newswires/client/index.html
@@ -8,6 +8,14 @@
   </head>
   <body>
     <div id="root"></div>
+    <script>
+      window.configuration = {
+        suppliersToExclude: [
+          "GuReuters",
+          "GuAP"
+        ]
+      }
+    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/newswires/client/src/serverSideConfig.ts/serverSideConfig.ts
+++ b/newswires/client/src/serverSideConfig.ts/serverSideConfig.ts
@@ -1,0 +1,1 @@
+export const SUPPLIERS_TO_EXCLUDE = window.configuration.suppliersToExclude;

--- a/newswires/client/src/serverSideConfig.ts/windowConfigType.ts
+++ b/newswires/client/src/serverSideConfig.ts/windowConfigType.ts
@@ -1,0 +1,12 @@
+declare global {
+	/* ~ Here, declare things that go in the global namespace, or augment
+	 *~ existing declarations in the global namespace
+	 */
+	interface Window {
+		configuration: {
+			suppliersToExclude: string[];
+		};
+	}
+}
+/* ~ this line is required as per TypeScript's global-modifying-module.d.ts instructions */
+export {};

--- a/newswires/client/src/suppliers.ts
+++ b/newswires/client/src/suppliers.ts
@@ -1,10 +1,12 @@
+import { SUPPLIERS_TO_EXCLUDE } from './serverSideConfig.ts/serverSideConfig';
+
 export const reutersBrand = '#fb8023';
 export const APBrand = '#eb483b';
 export const AFPBrand = '#325aff';
 export const PABrand = '#6352ba';
 export const AAPBrand = '#013a81';
 
-export const supplierData: Record<
+const allSupplierData: Record<
 	string,
 	{
 		label: string;
@@ -40,8 +42,19 @@ export const supplierData: Record<
 
 export function getSupplierInfo(
 	supplier: string,
-): (typeof supplierData)[keyof typeof supplierData] | undefined {
-	return supplierData[supplier.toUpperCase()];
+): (typeof allSupplierData)[keyof typeof allSupplierData] | undefined {
+	return allSupplierData[supplier.toUpperCase()];
 }
 
-export const recognisedSuppliers = Object.keys(supplierData);
+export const recognisedSuppliers = Object.keys(allSupplierData).filter(
+	(supplier) =>
+		!SUPPLIERS_TO_EXCLUDE.map((_) => _.toUpperCase()).includes(
+			supplier.toUpperCase(),
+		),
+);
+
+export const supplierData = Object.fromEntries(
+	Object.entries(allSupplierData).filter(([supplier]) =>
+		recognisedSuppliers.includes(supplier),
+	),
+);


### PR DESCRIPTION
Establishing this as a pattern in preparation for adding server-side feature switches to the app.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
