### PR TITLE
Pass client config from ViteController

### DIFF
--- a/newswires/app/views/fragments/clientConfig.scala.html
+++ b/newswires/app/views/fragments/clientConfig.scala.html
@@ -1,0 +1,7 @@
+@import play.api.libs.json.Json
+
+@(config: ClientConfig)
+
+<script>
+    window.configuration = @Html(Json.stringify(Json.toJson(config)))
+</script>

--- a/newswires/client/index.html
+++ b/newswires/client/index.html
@@ -5,17 +5,10 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Newswires</title>
+    <!-- configuration script gets injected here at runtime by ViteController -->
   </head>
   <body>
     <div id="root"></div>
-    <script>
-      window.configuration = {
-        suppliersToExclude: [
-          "GuReuters",
-          "GuAP"
-        ]
-      }
-    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Inject config into client SPA entrypoint (`index.html`) at runtime.
- Refactor ViteController to contain CSRF injection and config injection in a single function, to make it easier to keep dev server and prod server config in sync.

Runtime consumption of config on the `Window` by the client was introduced in #141. This PR builds on that, to inject the config at runtime. The config is still hard coded, but by generating the JS code from Scala code, we take another step towards the eventual goal of generating dynamic client config on the server at runtime.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
