### PR TITLE
Add FeatureSwitchProvider and use it for 'show Gu suppliers' functionality

### DIFF
--- a/newswires/app/controllers/ViteController.scala
+++ b/newswires/app/controllers/ViteController.scala
@@ -7,6 +7,8 @@ import play.api.libs.ws.WSClient
 import play.api.mvc._
 import play.api.{Configuration, Mode}
 import play.filters.csrf.CSRFAddToken
+import service.FeatureSwitchProvider
+import service.FeatureSwitchProvider.FeatureSwitch
 import views.html.helper.CSRF
 
 import java.net.URL
@@ -14,7 +16,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import scala.io.Source
 
 case class ClientConfig(
-    suppliersToExclude: List[String]
+    switches: Map[String, Boolean]
 )
 
 object ClientConfig {
@@ -61,7 +63,7 @@ class ViteController(
     def injectClientConfig(body: String): String = {
       val config =
         views.html.fragments.clientConfig(
-          ClientConfig(List("GuReuters", "GuAP"))
+          ClientConfig(FeatureSwitchProvider.clientSideSwitchStates)
         )
 
       body.replace(

--- a/newswires/app/service/FeatureSwitchProvider.scala
+++ b/newswires/app/service/FeatureSwitchProvider.scala
@@ -1,0 +1,34 @@
+package service
+
+import play.api.libs.json.{Json, OFormat}
+
+sealed trait SwitchState
+case object On extends SwitchState
+case object Off extends SwitchState
+
+object FeatureSwitchProvider {
+
+  case class FeatureSwitch(
+      name: String,
+      description: String,
+      exposeToClient: Boolean = false,
+      private val safeState: SwitchState
+  ) {
+    def isOn: Boolean =
+      safeState == On // currently we're only using safeState to determine state
+  }
+
+  val ShowGuSuppliers: FeatureSwitch =
+    FeatureSwitch(
+      name = "ShowGuSuppliers",
+      safeState = Off,
+      description = "Show suppliers from the Guardian",
+      exposeToClient = true
+    )
+
+  private val switches = List(
+    ShowGuSuppliers
+  )
+  def clientSideSwitchStates: Map[String, Boolean] =
+    switches.filter(_.exposeToClient).map(s => s.name -> s.isOn).toMap
+}

--- a/newswires/client/src/context/SearchContext.test.tsx
+++ b/newswires/client/src/context/SearchContext.test.tsx
@@ -1,5 +1,4 @@
 import { act, render } from '@testing-library/react';
-import type React from 'react';
 import { flushPendingPromises } from '../tests/testHelpers.ts';
 import type { SearchContextShape } from './SearchContext.tsx';
 import { SearchContextProvider, useSearch } from './SearchContext.tsx';

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -5,7 +5,6 @@ import {
 	useContext,
 	useEffect,
 	useReducer,
-	useRef,
 	useState,
 } from 'react';
 import { z } from 'zod';

--- a/newswires/client/src/serverSideConfig.ts/serverSideConfig.ts
+++ b/newswires/client/src/serverSideConfig.ts/serverSideConfig.ts
@@ -1,1 +1,4 @@
-export const SUPPLIERS_TO_EXCLUDE = window.configuration.suppliersToExclude;
+export const SUPPLIERS_TO_EXCLUDE = window.configuration.switches
+	.ShowGuSuppliers
+	? []
+	: ['GUAP', 'GUREUTERS'];

--- a/newswires/client/src/serverSideConfig.ts/windowConfigType.ts
+++ b/newswires/client/src/serverSideConfig.ts/windowConfigType.ts
@@ -1,10 +1,14 @@
+interface FeatureSwitches {
+	ShowGuSuppliers: boolean;
+}
+
 declare global {
 	/* ~ Here, declare things that go in the global namespace, or augment
 	 *~ existing declarations in the global namespace
 	 */
 	interface Window {
 		configuration: {
-			suppliersToExclude: string[];
+			switches: FeatureSwitches;
 		};
 	}
 }

--- a/newswires/client/src/suppliers.ts
+++ b/newswires/client/src/suppliers.ts
@@ -54,7 +54,7 @@ export const recognisedSuppliers = Object.keys(allSupplierData).filter(
 );
 
 export const supplierData = Object.fromEntries(
-	Object.entries(allSupplierData).filter(([supplier]) =>
+	Object.entries(allSupplierData).filter(([supplier, _]) =>
 		recognisedSuppliers.includes(supplier),
 	),
 );


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a `FeatureSwitchProvider` object which contains config for feature switches, and exposes a limited set of public methods that will hopefully make feature switch use intuitive and clear, i.e. it currently just exposes lists of switches, which have an `isOn` method.

Possibly over-engineering given that we've only got a single case at the moment. I lean towards thinking it's worthwhile because it will hopefully help us stay disciplined when adding this kind of logic, but open to other perspectives.

Also refactors the client side filtering out of `Gu*` suppliers so that it consumes the same switch, rather than consuming a list of suppliers to filter out. There's a bit more code duplication here but it seems overall simpler to have the contract between the client and server fit the same model as the switch mechanism here.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
