### PR TITLE
Add 'category_codes' column, populate it for incoming AP stories

### DIFF
--- a/db/migrations/V13__category_codes_column.sql
+++ b/db/migrations/V13__category_codes_column.sql
@@ -1,0 +1,4 @@
+ALTER TABLE fingerpost_wire_entry
+    ADD category_codes text[];
+
+CREATE INDEX category_codes_index ON fingerpost_wire_entry(category_codes);

--- a/ingestion-lambda/localRun.ts
+++ b/ingestion-lambda/localRun.ts
@@ -69,8 +69,7 @@ function createDummyFeedEntry(): {
 			byline: '',
 			priority: '4',
 			subjects: {
-				// @ts-expect-error -- FIXME zod issue
-				code: '',
+				code: ['iptc:a', 'iptc:b', 'service:AP'],
 			},
 			mediaCatCodes: 'f',
 			keywords,

--- a/ingestion-lambda/src/categoryCodes.test.ts
+++ b/ingestion-lambda/src/categoryCodes.test.ts
@@ -1,0 +1,57 @@
+import { processFingerpostAPCategoryCodes } from './categoryCodes';
+
+describe('processFingerpostAPCategoryCodes', () => {
+	it('should return an empty array if provided with an empty array', () => {
+		expect(processFingerpostAPCategoryCodes([])).toEqual([]);
+	});
+
+	it('should strip out service codes', () => {
+		expect(processFingerpostAPCategoryCodes(['service:news'])).toEqual([]);
+	});
+
+	it('should return simple category codes as they were received', () => {
+		expect(
+			processFingerpostAPCategoryCodes(['iptccat:a', 'iptccat:b']),
+		).toEqual(['iptccat:a', 'iptccat:b']);
+	});
+
+	it('should expand category codes with multiple subcodes', () => {
+		expect(processFingerpostAPCategoryCodes(['iptccat:c+d'])).toEqual([
+			'iptccat:c',
+			'iptccat:d',
+		]);
+	});
+
+	it('should pass other codes through untransformed', () => {
+		expect(processFingerpostAPCategoryCodes(['qCode:value+value'])).toEqual([
+			'qCode:value+value',
+		]);
+	});
+
+	it('should remove empty strings', () => {
+		expect(
+			processFingerpostAPCategoryCodes(['iptccat:a', '', 'iptccat:c']),
+		).toEqual(['iptccat:a', 'iptccat:c']);
+	});
+
+	it('should remove trailing and leading whitespace', () => {
+		expect(
+			processFingerpostAPCategoryCodes([
+				'iptccat:a ',
+				' iptccat:c',
+				' service:news ',
+				'qCode:value ',
+			]),
+		).toEqual(['iptccat:a', 'iptccat:c', 'qCode:value']);
+	});
+
+	it('should deduplicate category codes after stripping whitespace', () => {
+		expect(
+			processFingerpostAPCategoryCodes([
+				'iptccat:a ',
+				' iptccat:a',
+				'iptccat:c',
+			]),
+		).toEqual(['iptccat:a', 'iptccat:c']);
+	});
+});

--- a/ingestion-lambda/src/categoryCodes.ts
+++ b/ingestion-lambda/src/categoryCodes.ts
@@ -1,0 +1,39 @@
+function partition<T>(
+	inputArray: T[],
+	predicate: (item: T) => boolean,
+): [T[], T[]] {
+	const first = [];
+	const second = [];
+	for (const item of inputArray) {
+		if (predicate(item)) {
+			first.push(item);
+		} else {
+			second.push(item);
+		}
+	}
+	return [first, second];
+}
+
+function flattenCategoryCodes(categoryCodes: string): string[] {
+	const [prefix, ...codes] = categoryCodes.split(':');
+	return codes
+		.flatMap((_) => _.split('+'))
+		.flatMap((code) => `${prefix}:${code}`);
+}
+
+export function processFingerpostAPCategoryCodes(original: string[]): string[] {
+	const [_serviceCodes, remainingNotServiceCodes] = partition(
+		original,
+		(code) => code.includes('service:'),
+	); // we aren't interested in keeping the service codes here
+	const [iptccatCodes, rest] = partition(remainingNotServiceCodes, (code) =>
+		code.includes('iptccat:'),
+	);
+	const transformedIptccatCodes = iptccatCodes.flatMap(flattenCategoryCodes);
+
+	const allCategoryCodes = [...transformedIptccatCodes, ...rest]
+		.map((_) => _.trim())
+		.filter((_) => _.length > 0);
+	const deduped = [...new Set(allCategoryCodes)];
+	return deduped;
+}

--- a/ingestion-lambda/src/categoryCodes.ts
+++ b/ingestion-lambda/src/categoryCodes.ts
@@ -22,10 +22,7 @@ function flattenCategoryCodes(categoryCodes: string): string[] {
 }
 
 export function processFingerpostAPCategoryCodes(original: string[]): string[] {
-	const [_serviceCodes, remainingNotServiceCodes] = partition(
-		original,
-		(code) => code.includes('service:'),
-	); // we aren't interested in keeping the service codes here
+	const remainingNotServiceCodes = original.filter((_) => !_.includes('service:'));
 	const [iptccatCodes, rest] = partition(remainingNotServiceCodes, (code) =>
 		code.includes('iptccat:'),
 	);

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -71,6 +71,7 @@ case class FingerpostWireEntry(
     content: FingerpostWire,
     composerId: Option[String],
     composerSentBy: Option[String],
+    categoryCodes: List[String],
     highlight: Option[String] = None
 )
 
@@ -90,6 +91,7 @@ object FingerpostWireEntry
       "supplier",
       "composer_id",
       "composer_sent_by",
+      "category_codes",
       "combined_textsearch",
       "highlight"
     )
@@ -102,6 +104,7 @@ object FingerpostWireEntry
     |   ${FingerpostWireEntry.syn.result.supplier},
     |   ${FingerpostWireEntry.syn.result.composerId},
     |   ${FingerpostWireEntry.syn.result.composerSentBy},
+    |   ${FingerpostWireEntry.syn.result.categoryCodes},
     |   ${FingerpostWireEntry.syn.result.content}
     |""".stripMargin
 
@@ -109,6 +112,14 @@ object FingerpostWireEntry
       fm: ResultName[FingerpostWireEntry]
   )(rs: WrappedResultSet): FingerpostWireEntry = {
     val fingerpostContent = Json.parse(rs.string(fm.content)).as[FingerpostWire]
+    val maybeCategoryCodes = rs.arrayOpt(fm.categoryCodes)
+    val categoryCodes = maybeCategoryCodes match {
+      case Some(array) =>
+        array.getArray
+          .asInstanceOf[Array[String]]
+          .toList
+      case None => Nil
+    }
 
     FingerpostWireEntry(
       id = rs.long(fm.id),
@@ -118,6 +129,7 @@ object FingerpostWireEntry
       content = fingerpostContent,
       composerId = rs.stringOpt(fm.composerId),
       composerSentBy = rs.stringOpt(fm.composerSentBy),
+      categoryCodes = categoryCodes,
       highlight = rs.stringOpt(fm.column("highlight"))
     )
   }

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -32,6 +32,7 @@ export const WireDataSchema = z.object({
 	supplier: z.string(),
 	externalId: z.string(),
 	ingestedAt: z.string(),
+	categoryCodes: z.array(z.string()),
 	content: FingerpostContentSchema,
 	composerId: z.string().optional(),
 	composerSentBy: z.string().optional(),

--- a/newswires/client/src/tests/fixtures/wireData.ts
+++ b/newswires/client/src/tests/fixtures/wireData.ts
@@ -29,6 +29,7 @@ export const sampleWireData: WireData = {
 	supplier: 'TestSupplier',
 	externalId: 'external-123',
 	ingestedAt: '2025-01-01T00:00:00Z',
+	categoryCodes: ['category1', 'category2'],
 	content: sampleFingerpostContent,
 	highlight: 'Sample Highlight',
 	isFromRefresh: false,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Add `category_codes` column to the database (migration script has been run against CODE already).
- Populate the new column from the ingestion lambda. Currently defaults to an empty array for all suppliers except AP. Other suppliers will be added later.
- Let the API and UI know about the new column, though currently we're just reading it (will add queries on it in future PR)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Deploy to CODE, check:

### Category codes are being processed as expected for new AP stories

```
// incoming data (preserved as-is, in 'content'):
"subjects": {
  "code": [
    "iptccat:i+a",
    "service:"
  ]
},

// new field, generated from incoming data by ingestion lambda
"categoryCodes": [
  "iptccat:i",
  "iptccat:a"
],
```

### Old entries, and new entries from other suppliers, still work

New, non-AP: https://newswires.local.dev-gutools.co.uk/item/1258297

```
  "id": 1258297,
  "supplier": "PA",
  "externalId": "PA PA SPORT DATA/HSA5087/2025-02-11T17:37:36.000Z/0",
  "ingestedAt": "2025-02-11T17:42:40.774372Z[Europe/London]",
  "categoryCodes": [],
  "content": { ... }
```

Old AP entry:

```
  "id": 1258114,
  "supplier": "AP",
  "externalId": "LOST/6154991148819042/2025-02-11T17:03:11.000Z/1",
  "ingestedAt": "2025-02-11T17:03:14.054076Z[Europe/London]",
  "categoryCodes": [],
  "content": { ... }
```



<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
