### PR TITLE
Fix: Wire detail panel sometimes extends past edge of window

### DIFF
--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -165,6 +165,7 @@ export const WireDetail = ({
 																				label={category}
 																				size="xs"
 																				iconType={'dot'}
+																				wrapText={true}
 																			></EuiListGroupItem>
 																		),
 																	)}


### PR DESCRIPTION
Set `wrapText={true}` for subject labels in WireDetail component. This prevents long lines from breaking layout. 

The `<ListGroupItem>` component from eUI truncates long labels by default, but this behaviour doesn't always seem to work when switching from one wire item to another. I don't think there's any problem with wrapping the text here, so it seems like a good fix.


### Before

<img width="1314" alt="screenshot of an open wire item where the text extends beyond the window" src="https://github.com/user-attachments/assets/340131f3-11a3-4bd3-8889-d5d65bf1284c" />


### After

<img width="1313" alt="same item with the text wrapping so that it's all visible" src="https://github.com/user-attachments/assets/5c59fc93-a1c0-4c2d-9166-0c5446962a78" />


