### PR TITLE
Pf/retry reuters failures

### DIFF
--- a/poller-lambdas/src/pollers/reuters/reutersPoller.ts
+++ b/poller-lambdas/src/pollers/reuters/reutersPoller.ts
@@ -288,13 +288,27 @@ export const reutersPoller = (async ({
 				await fetchWithReauth(itemQuery(itemId)),
 			);
 			if (!parsedItemResult.success) {
-				logger.log({
+				logger.warn({
 					externalId: itemId,
 					supplier: 'Reuters',
 					eventType: POLLER_FAILURE_EVENT_TYPE,
 					errors: parsedItemResult.error.errors,
-					message: `Failed to parse item response for ${itemId}`,
+					message: `Failed to parse item response for ${itemId}; retrying`,
 				});
+				await new Promise((resolve) => setTimeout(resolve, 5000));
+				const retryResult = await fetchWithReauth(itemQuery(itemId));
+				const retryParsedItemResult = itemResponseSchema.safeParse(retryResult);
+				if (!retryParsedItemResult.success) {
+					logger.error({
+						externalId: itemId,
+						supplier: 'Reuters',
+						eventType: POLLER_FAILURE_EVENT_TYPE,
+						errors: retryParsedItemResult.error.errors,
+						message: `Failed to parse item response for ${itemId} on retry`,
+					});
+					return;
+				}
+				return retryParsedItemResult.data;
 			}
 			return parsedItemResult.data;
 		}),

--- a/poller-lambdas/src/pollers/reuters/reutersPoller.ts
+++ b/poller-lambdas/src/pollers/reuters/reutersPoller.ts
@@ -18,7 +18,7 @@ import { auth } from './auth';
 const textItemsSearchQuery = (cursor?: string) => `query NewTextItemsSearch {
 search(${
 	cursor ? `cursor: "${cursor}", ` : ''
-}filter: { mediaTypes: TEXT, maxAge: "${REUTERS_POLLING_FREQUENCY_IN_SECONDS * 1.2}s" }) {
+}filter: { mediaTypes: TEXT, maxAge: "${REUTERS_POLLING_FREQUENCY_IN_SECONDS * 2.2}s" }) {
 	pageInfo {
 		endCursor
 		hasNextPage


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
