### PR TITLE
Rename cat codes labelled 'iptccat' as 'apCat' instead

### DIFF
--- a/ingestion-lambda/src/categoryCodes.test.ts
+++ b/ingestion-lambda/src/categoryCodes.test.ts
@@ -9,16 +9,16 @@ describe('processFingerpostAPCategoryCodes', () => {
 		expect(processFingerpostAPCategoryCodes(['service:news'])).toEqual([]);
 	});
 
-	it('should return simple category codes as they were received', () => {
+	it('should return simple codes labelled "iptccat" as simple "apCat" codes', () => {
 		expect(
 			processFingerpostAPCategoryCodes(['iptccat:a', 'iptccat:b']),
-		).toEqual(['iptccat:a', 'iptccat:b']);
+		).toEqual(['apCat:a', 'apCat:b']);
 	});
 
 	it('should expand category codes with multiple subcodes', () => {
 		expect(processFingerpostAPCategoryCodes(['iptccat:c+d'])).toEqual([
-			'iptccat:c',
-			'iptccat:d',
+			'apCat:c',
+			'apCat:d',
 		]);
 	});
 
@@ -31,7 +31,7 @@ describe('processFingerpostAPCategoryCodes', () => {
 	it('should remove empty strings', () => {
 		expect(
 			processFingerpostAPCategoryCodes(['iptccat:a', '', 'iptccat:c']),
-		).toEqual(['iptccat:a', 'iptccat:c']);
+		).toEqual(['apCat:a', 'apCat:c']);
 	});
 
 	it('should remove trailing and leading whitespace', () => {
@@ -42,7 +42,7 @@ describe('processFingerpostAPCategoryCodes', () => {
 				' service:news ',
 				'qCode:value ',
 			]),
-		).toEqual(['iptccat:a', 'iptccat:c', 'qCode:value']);
+		).toEqual(['apCat:a', 'apCat:c', 'qCode:value']);
 	});
 
 	it('should deduplicate category codes after stripping whitespace', () => {
@@ -52,6 +52,6 @@ describe('processFingerpostAPCategoryCodes', () => {
 				' iptccat:a',
 				'iptccat:c',
 			]),
-		).toEqual(['iptccat:a', 'iptccat:c']);
+		).toEqual(['apCat:a', 'apCat:c']);
 	});
 });

--- a/ingestion-lambda/src/categoryCodes.ts
+++ b/ingestion-lambda/src/categoryCodes.ts
@@ -14,21 +14,26 @@ function partition<T>(
 	return [first, second];
 }
 
+/**
+ * We receive AP codes from Fingerpost in the format `prefix:code1+code2+code3:code4+code5`.
+ * At the time of writing these are AP category codes, but mislabelled as `iptccat` codes.
+ * This function transforms the prefix, and splits the codes into individual category codes.
+ */
 function flattenCategoryCodes(categoryCodes: string): string[] {
 	const [prefix, ...codes] = categoryCodes.split(':');
 	return codes
 		.flatMap((_) => _.split('+'))
-		.flatMap((code) => `${prefix}:${code}`);
+		.map((code) => `${prefix?.match(/\s?iptccat/) ? 'apCat' : prefix}:${code}`);
 }
 
 export function processFingerpostAPCategoryCodes(original: string[]): string[] {
-	const remainingNotServiceCodes = original.filter((_) => !_.includes('service:'));
-	const [iptccatCodes, rest] = partition(remainingNotServiceCodes, (code) =>
+	const notServiceCodes = original.filter((_) => !_.includes('service:')); // we aren't interested in keeping the service codes here
+	const [categoryCodes, rest] = partition(notServiceCodes, (code) =>
 		code.includes('iptccat:'),
 	);
-	const transformedIptccatCodes = iptccatCodes.flatMap(flattenCategoryCodes);
+	const transformedCategoryCodes = categoryCodes.flatMap(flattenCategoryCodes);
 
-	const allCategoryCodes = [...transformedIptccatCodes, ...rest]
+	const allCategoryCodes = [...transformedCategoryCodes, ...rest]
 		.map((_) => _.trim())
 		.filter((_) => _.length > 0);
 	const deduped = [...new Set(allCategoryCodes)];

--- a/ingestion-lambda/src/categoryCodes.ts
+++ b/ingestion-lambda/src/categoryCodes.ts
@@ -23,7 +23,7 @@ function flattenCategoryCodes(categoryCodes: string): string[] {
 	const [prefix, ...codes] = categoryCodes.split(':');
 	return codes
 		.flatMap((_) => _.split('+'))
-		.map((code) => `${prefix?.match(/\s?iptccat/) ? 'apCat' : prefix}:${code}`);
+		.map((code) => `${prefix?.trim() === 'iptccat' ? 'apCat' : prefix}:${code}`);
 }
 
 export function processFingerpostAPCategoryCodes(original: string[]): string[] {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

When we receive them from Fingerpost they're labelled with the prefix `iptccat:`, but the codes seem to actually be [AP category codes](https://developer.ap.org/ap-media-api/agent/AP_Classification_Metadata.htm) instead. This change relabels them at ingestion, while we're putting them into the `category_codes` column.

As before, other prefixes will be either filtered out (`service:`) or passed through unchanged (everything else).

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Unit tests

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
