### PR TITLE
Newswires UI: decode stories text body to remove escaped characters

### DIFF
--- a/ingestion-lambda/src/handler.ts
+++ b/ingestion-lambda/src/handler.ts
@@ -72,14 +72,47 @@ const processCategoryCodes = (
 	}
 };
 
+const decodeBodyTextContent = (text: string | undefined): string | undefined =>
+	text
+		?.replace(
+			/\\u([0-9a-fA-F]{4})/g,
+			(_: string, hex: string) => String.fromCharCode(parseInt(hex, 16)), // Replace Unicode escape sequences, e.g. \u00a0 → non-breaking space.
+		)
+		.replace(/\\([\\nrt"'])/g, (_: string, group1: string) => {
+			switch (group1) {
+				case '\\':
+					return '\\';
+				case 'n':
+					return '\n';
+				case 'r':
+					return '\r';
+				case 't':
+					return '\t';
+				case '"':
+					return '"';
+				case "'":
+					return "'";
+				default:
+					return group1;
+			}
+		})
+		.replace(/\n/g, '<br />');
+
 const safeBodyParse = (body: string): IngestorInputBody => {
 	try {
 		const json = JSON.parse(body) as Record<string, unknown>;
+
 		const preprocessedKeywords = processKeywords(
 			json.keywords as string | string[] | undefined,
 		); // if it's not one of these, we probably want to throw an error
+
+		const preprocessedBodyTextContent = decodeBodyTextContent(
+			json.body_Text as string | undefined,
+		);
+
 		return IngestorInputBodySchema.parse({
 			...json,
+			body_text: preprocessedBodyTextContent,
 			keywords: preprocessedKeywords,
 		});
 	} catch (e) {

--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -48,8 +48,8 @@ class QueryController(
     val bucket = request.getQueryString("bucket").flatMap(SearchBuckets.get)
 
     val suppliersToExcludeByDefault =
-      if (FeatureSwitchProvider.ShowGuSuppliers.isOn) List("GuReuters", "GuAP")
-      else Nil
+      if (FeatureSwitchProvider.ShowGuSuppliers.isOn) Nil
+      else List("GuReuters", "GuAP")
 
     val queryParams = SearchParams(
       text = maybeFreeTextQuery,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Decode stories text body to remove escaped characters.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
