### PR TITLE
Initial fingerpost-based AP world bucket

### DIFF
--- a/newswires/app/conf/SearchBuckets.scala
+++ b/newswires/app/conf/SearchBuckets.scala
@@ -659,10 +659,37 @@ object SearchBuckets {
     )
   )
 
+  // format: off
+  /**
+    * Main config table for AP world ('NY:for') bucket in Fip system.
+    * (nb. 'NY' here is a Fip header, and doesn't seem to stand for New York)
+
+      > ; Category Codes
+      >  2	JC=a*				>w4apapi#NY:for
+      >  2	JC=d*				>w4apapi#NY:fea
+      >  2	JC=e*				>w4apapi#NY:fea
+      >  2	JC=f*				>w4apapi#NY:fin
+      >  2	JC=i*				>w4apapi#NY:for
+      >  2	JC=s*				>w4apapi#NY:spt
+      >  2	JC=t*				>w4apapi#NY:fea
+      >  2	JC=w*				>w4apapi#NY:for
+      > ; Default
+      >  2	JC=*				>w4apapi#NY:for
+
+    * The fingerpost system runs top to bottom, and '>' tells it to stop once it finds a match, so an item with
+    * category code 'JC:ae' would be bucketed as 'NY:for' and not 'NY:fea', and an item with category code 'JC:ew'
+    * would be bucketed as 'NY:fea' rather than 'NY:for'.
+    * We're inclined to exclude sports, entertainment, finance, and technology news from this bucket instead, even
+    * if they have e.g. code 'a' (US news) code, because they're likely to be less relevant to International desk.
+    * However, we should remain open to changing this in response to user feedback.
+    */
+  // format: on
   private val ApWorld = SearchParams(
     text = None,
+    suppliersIncl = List("AP"),
     keywordIncl = List("World news"),
-    subjectsIncl = Nil
+    categoryCodesIncl = List("apCat:i", "apCat:a", "apCat:w"),
+    categoryCodesExcl = List("apCat:s", "apCat:e", "apCat:f")
   )
 
   private val ReutersWorld = SearchParams(

--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -37,6 +37,8 @@ class QueryController(
       suppliers: List[String],
       subjects: List[String],
       subjectsExcl: List[String],
+      categoryCode: List[String],
+      categoryCodeExcl: List[String],
       maybeBeforeId: Option[Int],
       maybeSinceId: Option[Int]
   ): Action[AnyContent] = apiAuthAction { request: UserRequest[AnyContent] =>
@@ -50,7 +52,9 @@ class QueryController(
       suppliersExcl =
         request.queryString.get("supplierExcl").map(_.toList).getOrElse(Nil),
       subjectsIncl = subjects,
-      subjectsExcl = subjectsExcl
+      subjectsExcl = subjectsExcl,
+      categoryCodesIncl = categoryCode,
+      categoryCodesExcl = categoryCodeExcl
     )
 
     val mergedParams = bucket.map(_ merge queryParams).getOrElse(queryParams)

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -262,7 +262,7 @@ object FingerpostWireEntry
       case Nil => None
       case categoryCodes =>
         Some(
-          sqls"${syn.categoryCodes} && array[${categoryCodes.map(code => sqls"$code")}]::text[]"
+          sqls"${syn.categoryCodes} && ${textArray(categoryCodes)}"
         )
     }
 
@@ -271,7 +271,7 @@ object FingerpostWireEntry
       case categoryCodesExcl =>
         val cce = this.syntax("categoryCodesExcl")
         val doesContainCategoryCodes =
-          sqls"${cce.categoryCodes} && array[${categoryCodesExcl.map(code => sqls"$code")}]::text[]"
+          sqls"${cce.categoryCodes} && ${textArray(categoryCodesExcl)}"
 
         Some(
           sqls"""|NOT EXISTS (

--- a/newswires/app/db/SearchParams.scala
+++ b/newswires/app/db/SearchParams.scala
@@ -7,7 +7,9 @@ case class SearchParams(
     suppliersIncl: List[String] = Nil,
     suppliersExcl: List[String] = Nil,
     subjectsIncl: List[String] = Nil,
-    subjectsExcl: List[String] = Nil
+    subjectsExcl: List[String] = Nil,
+    categoryCodesIncl: List[String] = Nil,
+    categoryCodesExcl: List[String] = Nil
 ) {
   def merge(o: SearchParams): SearchParams = {
     val mergedText = (text, o.text) match {
@@ -21,7 +23,9 @@ case class SearchParams(
       suppliersIncl = suppliersIncl ++ o.suppliersIncl,
       suppliersExcl = suppliersExcl ++ o.suppliersExcl,
       subjectsIncl = subjectsIncl ++ o.subjectsIncl,
-      subjectsExcl = subjectsExcl ++ o.subjectsExcl
+      subjectsExcl = subjectsExcl ++ o.subjectsExcl,
+      categoryCodesIncl = categoryCodesIncl ++ o.categoryCodesIncl,
+      categoryCodesExcl = categoryCodesExcl ++ o.categoryCodesExcl
     )
   }
 }

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -5,7 +5,6 @@ import {
 	useContext,
 	useEffect,
 	useReducer,
-	useRef,
 	useState,
 } from 'react';
 import { z } from 'zod';

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -58,6 +58,8 @@ export const QuerySchema = z.object({
 	keywordsExcl: z.ostring(),
 	subjects: z.array(z.string()).optional(),
 	subjectsExcl: z.array(z.string()).optional(),
+	categoryCode: z.array(z.string()).optional(),
+	categoryCodeExcl: z.array(z.string()).optional(),
 	bucket: z.ostring(),
 });
 

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -9,6 +9,8 @@ export const defaultQuery: Query = {
 	subjects: [],
 	subjectsExcl: [],
 	bucket: undefined,
+	categoryCode: [],
+	categoryCodeExcl: [],
 };
 
 export const defaultConfig: Config = Object.freeze({
@@ -31,6 +33,8 @@ export function urlToConfig(location: {
 	const keywordsExcl = urlSearchParams.get('keywordsExcl') ?? undefined;
 	const subjects = urlSearchParams.getAll('subjects');
 	const subjectsExcl = urlSearchParams.getAll('subjectsExcl');
+	const categoryCode = urlSearchParams.getAll('categoryCode');
+	const categoryCodeExcl = urlSearchParams.getAll('categoryCodeExcl');
 	const bucket = urlSearchParams.get('bucket') ?? undefined;
 	const query: Query = {
 		q:
@@ -43,6 +47,8 @@ export function urlToConfig(location: {
 		keywordsExcl,
 		subjects,
 		subjectsExcl,
+		categoryCode,
+		categoryCodeExcl,
 		bucket,
 	};
 

--- a/newswires/conf/routes
+++ b/newswires/conf/routes
@@ -7,7 +7,7 @@
 GET     /                           controllers.ViteController.index()
 GET     /feed                       controllers.ViteController.index()
 GET     /item/*id                   controllers.ViteController.item(id: String)
-GET     /api/search                 controllers.QueryController.query(q: Option[String], keywords: Option[String], supplier: List[String], subjects: List[String], subjectsExcl: List[String], beforeId: Option[Int], sinceId: Option[Int])
+GET     /api/search                 controllers.QueryController.query(q: Option[String], keywords: Option[String], supplier: List[String], subjects: List[String], subjectsExcl: List[String], categoryCode: List[String], categoryCodeExcl: List[String], beforeId: Option[Int], sinceId: Option[Int])
 GET     /api/keywords               controllers.QueryController.keywords(inLastHours: Option[Int], limit:Option[Int])
 GET     /api/item/:id               controllers.QueryController.item(id: Int, q: Option[String])
 PUT     /api/item/:id/composerId    controllers.QueryController.linkToComposer(id: Int)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

* Add a set of criteria for the AP World bucket that is loosely based on the Fingerpost criteria. General sense-checking seems to suggest that it's catching the right content, and I'd suggest that we should iterate on it as we go if refinements are required (and this should be easier once the initial pass is merged, so everyone can see it).
* To support the new bucket, this branch also adds the ability to query on the `category_codes` column that was added in #150 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
