### PR TITLE
Fix: More sensible handling of headline and subhead in wires list

### DIFF
--- a/newswires/client/src/Item.tsx
+++ b/newswires/client/src/Item.tsx
@@ -9,6 +9,7 @@ import {
 	EuiSpacer,
 	EuiSplitPanel,
 	EuiSwitch,
+	EuiText,
 	EuiTitle,
 	useGeneratedHtmlId,
 } from '@elastic/eui';
@@ -18,6 +19,20 @@ import { pandaFetch } from './panda-session';
 import { type WireData, WireDataSchema } from './sharedTypes';
 import { paramsToQuerystring } from './urlState';
 import { WireDetail } from './WireDetail';
+
+function decideTitleContentForItem(wire: WireData) {
+	const { slug, headline } = wire.content;
+
+	if (headline && headline.length > 0) {
+		return (
+			<>
+				{slug && <EuiText size={'xs'}>{slug}</EuiText>} {headline}
+			</>
+		);
+	}
+
+	return <>{slug ?? 'No title'}</>;
+}
 
 export const Item = ({ id }: { id: string }) => {
 	const { handleDeselectItem, config } = useSearch();
@@ -97,7 +112,9 @@ export const Item = ({ id }: { id: string }) => {
 						<EuiFlexGroup justifyContent="spaceBetween">
 							<EuiFlexItem grow={true}>
 								<EuiTitle size="xs">
-									<h2 id={pushedFlyoutTitleId}>{itemData.content.headline}</h2>
+									<h2 id={pushedFlyoutTitleId}>
+										{decideTitleContentForItem(itemData)}
+									</h2>
 								</EuiTitle>
 							</EuiFlexItem>
 						</EuiFlexGroup>

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -82,6 +82,38 @@ export const WireItemList = ({
 	);
 };
 
+function decideMainHeadingContent({
+	headline,
+	slug,
+}: WireData['content']): string {
+	if (headline && headline.length > 0) {
+		return headline;
+	}
+	if (slug && slug.length > 0) {
+		return slug;
+	}
+	return 'No headline';
+}
+
+function decideSecondaryCardContent({
+	headline,
+	subhead,
+	bodyText,
+}: WireData['content']): string | undefined {
+	if (subhead && !(subhead === headline)) {
+		return subhead;
+	}
+	const maybeBodyTextPreview = bodyText
+		? sanitizeHtml(bodyText, { allowedTags: [], allowedAttributes: {} }).slice(
+				0,
+				100,
+			)
+		: undefined;
+	if (maybeBodyTextPreview && !(maybeBodyTextPreview === headline)) {
+		return maybeBodyTextPreview;
+	}
+}
+
 const WirePreviewCard = ({
 	id,
 	supplier,
@@ -116,9 +148,9 @@ const WirePreviewCard = ({
 	const supplierLabel = supplierInfo?.label ?? supplier;
 	const supplierColour = supplierInfo?.colour ?? theme.euiTheme.colors.text;
 
-	const hasSlug = content.slug && content.slug.length > 0;
+	const mainHeadingContent = decideMainHeadingContent(content);
 
-	const mainHeadingContent = hasSlug ? content.slug : content.headline;
+	const maybeSecondaryCardContent = decideSecondaryCardContent(content);
 
 	const cardGrid = css`
 		display: grid;
@@ -175,7 +207,7 @@ const WirePreviewCard = ({
 						grid-area: content;
 					`}
 				>
-					{hasSlug && <p>{content.headline}</p>}
+					{maybeSecondaryCardContent && <p>{maybeSecondaryCardContent}</p>}
 					{highlight && highlight.trim().length > 0 && (
 						<EuiText
 							size="xs"

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -100,7 +100,7 @@ function decideSecondaryCardContent({
 	subhead,
 	bodyText,
 }: WireData['content']): string | undefined {
-	if (subhead && !(subhead === headline)) {
+	if (subhead && subhead !== headline) {
 		return subhead;
 	}
 	const maybeBodyTextPreview = bodyText
@@ -109,7 +109,7 @@ function decideSecondaryCardContent({
 				100,
 			)
 		: undefined;
-	if (maybeBodyTextPreview && !(maybeBodyTextPreview === headline)) {
+	if (maybeBodyTextPreview && maybeBodyTextPreview !== headline) {
 		return maybeBodyTextPreview;
 	}
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Feed list: 

* main heading: use `headline` in preference to `slug` for the main heading; only use slug if there is no headline.
* sub heading: instead of using the `headline`, use the `subhead` if it's present, or the first 100 characters of the body text if not. Only show if it's not the same as the heading.


Detail view:

Show the `slug` as part of the headline, but visually de-emphasized unless there is no `headline`.

This seems like the 'right' way to use `slug`, `headline` and `subhead`, and it's more in line with how the agencies render their own content. There are cases where this doesn't work perfectly for our current data (noted below) but it feels like we should try to fix those upstream unless that's not possible.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## Known issues

These are not ideal, but it feels most sensible to try and fix these upstream so that we can use the headline as the main heading, and the subhead (where present) as the subheading.

### AFP

Currently all the AFP stories we're getting from Fip have their subhead set to `JZ`, which is surfaced by this change:
<img width="935" alt="image" src="https://github.com/user-attachments/assets/f30c6def-0b98-4d43-8fb7-adaf14a7380e" />

### AP

AP stories from Fip seem to have their `headline` and `subhead` switched around.

### PA

When a `headline` is set, it's often repeated at the beginning of the body text, which means that the subheading is repetitive.


## How to test

* Running locally against the CODE db should provide a good sense of how this works with the existing feeds.


## Images

|Before|After|
|-|-|
|<img width="675" alt="image" src="https://github.com/user-attachments/assets/77619e05-4da1-440f-9db6-6bc3ae314aa6" />|<img width="699" alt="image" src="https://github.com/user-attachments/assets/415a08f4-91a4-4493-b321-b9fe0f3bedc0" />|
|<img width="645" alt="image" src="https://github.com/user-attachments/assets/e17fb6e7-fe28-444b-b691-bb660a235c18" />|<img width="619" alt="image" src="https://github.com/user-attachments/assets/0c0826b3-89a5-4125-b412-573d196b4b89" />|
|<img width="1270" alt="image" src="https://github.com/user-attachments/assets/c244fb52-95b3-4e3c-8f40-0f61a7d6eb8e" />|<img width="1345" alt="image" src="https://github.com/user-attachments/assets/912bcea0-84b5-4c1b-a892-5c4a583277b2" />|

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
