### PR TITLE
Feed card layout tweaks

### DIFF
--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -1,10 +1,8 @@
 import {
 	EuiBadge,
 	EuiButton,
-	EuiHeader,
 	EuiSpacer,
 	EuiText,
-	EuiTitle,
 	useEuiBackgroundColor,
 	useEuiTheme,
 } from '@elastic/eui';

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -97,33 +97,35 @@ function decideMainHeadingContent({
 	return 'No headline';
 }
 
-function SecondaryCardContent({
+function MaybeSecondaryCardContent({
 	headline,
 	subhead,
 	bodyText,
 	highlight,
-}: Pick<WireData['content'], 'headline' | 'subhead' | 'bodyText'> & {
+}: WireData['content'] & {
 	highlight: string | undefined;
 }): string | ReactNode | undefined {
 	const theme = useEuiTheme();
 
 	if (highlight && highlight.trim().length > 0) {
 		return (
-			<EuiText
-				size="xs"
-				css={css`
-					margin-top: 0.1rem;
-					padding: 0.1rem 0.5rem;
-					background-color: ${theme.euiTheme.colors.highlight};
-					justify-self: start;
-				`}
-			>
-				<p dangerouslySetInnerHTML={{ __html: sanitizeHtml(highlight) }} />
-			</EuiText>
+			<p>
+				<EuiText
+					size="xs"
+					css={css`
+						margin-top: 0.1rem;
+						padding: 0.1rem 0.5rem;
+						background-color: ${theme.euiTheme.colors.highlight};
+						justify-self: start;
+					`}
+				>
+					<p dangerouslySetInnerHTML={{ __html: sanitizeHtml(highlight) }} />
+				</EuiText>
+			</p>
 		);
 	}
 	if (subhead && subhead !== headline) {
-		return subhead;
+		return <p>{subhead}</p>;
 	}
 	const maybeBodyTextPreview = bodyText
 		? sanitizeHtml(bodyText, { allowedTags: [], allowedAttributes: {} }).slice(
@@ -132,8 +134,9 @@ function SecondaryCardContent({
 			)
 		: undefined;
 	if (maybeBodyTextPreview && maybeBodyTextPreview !== headline) {
-		return maybeBodyTextPreview;
+		return <p>{maybeBodyTextPreview}</p>;
 	}
+	return null;
 }
 
 const WirePreviewCard = ({
@@ -171,11 +174,6 @@ const WirePreviewCard = ({
 	const supplierColour = supplierInfo?.colour ?? theme.euiTheme.colors.text;
 
 	const mainHeadingContent = decideMainHeadingContent(content);
-
-	const maybeSecondaryCardContent = SecondaryCardContent({
-		...content,
-		highlight,
-	});
 
 	const cardGrid = css`
 		display: grid;
@@ -248,7 +246,7 @@ const WirePreviewCard = ({
 						grid-area: content;
 					`}
 				>
-					{maybeSecondaryCardContent && <p>{maybeSecondaryCardContent}</p>}
+					<MaybeSecondaryCardContent {...content} highlight={highlight} />
 				</div>
 			</div>
 		</Link>

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -6,6 +6,7 @@ import {
 	useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
+import type { ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import sanitizeHtml from 'sanitize-html';
 import { useSearch } from './context/SearchContext.tsx';
@@ -95,11 +96,31 @@ function decideMainHeadingContent({
 	return 'No headline';
 }
 
-function decideSecondaryCardContent({
+function SecondaryCardContent({
 	headline,
 	subhead,
 	bodyText,
-}: WireData['content']): string | undefined {
+	highlight,
+}: Pick<WireData['content'], 'headline' | 'subhead' | 'bodyText'> & {
+	highlight: string | undefined;
+}): string | ReactNode | undefined {
+	const theme = useEuiTheme();
+
+	if (highlight && highlight.trim().length > 0) {
+		return (
+			<EuiText
+				size="xs"
+				css={css`
+					margin-top: 0.1rem;
+					padding: 0.1rem 0.5rem;
+					background-color: ${theme.euiTheme.colors.highlight};
+					justify-self: start;
+				`}
+			>
+				<p dangerouslySetInnerHTML={{ __html: sanitizeHtml(highlight) }} />
+			</EuiText>
+		);
+	}
 	if (subhead && subhead !== headline) {
 		return subhead;
 	}
@@ -150,7 +171,10 @@ const WirePreviewCard = ({
 
 	const mainHeadingContent = decideMainHeadingContent(content);
 
-	const maybeSecondaryCardContent = decideSecondaryCardContent(content);
+	const maybeSecondaryCardContent = SecondaryCardContent({
+		...content,
+		highlight,
+	});
 
 	const cardGrid = css`
 		display: grid;

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -1,7 +1,10 @@
 import {
 	EuiBadge,
 	EuiButton,
+	EuiHeader,
+	EuiSpacer,
 	EuiText,
+	EuiTitle,
 	useEuiBackgroundColor,
 	useEuiTheme,
 } from '@elastic/eui';
@@ -180,8 +183,8 @@ const WirePreviewCard = ({
 		display: grid;
 		gap: 0.5rem;
 		align-items: baseline;
-		grid-template-areas: 'badge title date' 'content content content';
-		grid-template-columns: min-content 1fr auto;
+		grid-template-areas: 'title title meta' 'content content meta';
+		grid-template-columns: 1fr 1fr min-content;
 		grid-template-rows: auto auto;
 	`;
 
@@ -204,49 +207,50 @@ const WirePreviewCard = ({
 						color: ${theme.euiTheme.colors.text};
 						background-color: ${selected ? accentBgColor : 'inherit'};
 						${isFromRefresh ? fadeOutBackground : ''}
+
+						& h3 {
+							grid-area: title;
+						}
 					`,
 				]}
 			>
-				<EuiBadge color={supplierColour}>{supplierLabel}</EuiBadge>
-				<h3>
-					<p>{mainHeadingContent}</p>
+				<h3
+					css={css`
+						font-weight: ${theme.euiTheme.font.weight.medium};
+					`}
+				>
+					{mainHeadingContent}
 				</h3>
-				{content.versionCreated
-					? formatTimestamp(content.versionCreated)
-							.split(', ')
-							.map((part) => (
-								<EuiText
-									size="xs"
-									key={part}
-									css={css`
-										padding-left: 5px;
-									`}
-								>
-									{part}
-								</EuiText>
-							))
-					: ''}
+				<div
+					css={css`
+						grid-area: meta;
+						text-align: right;
+					`}
+				>
+					{content.versionCreated
+						? formatTimestamp(content.versionCreated)
+								.split(', ')
+								.map((part) => (
+									<EuiText
+										size="xs"
+										key={part}
+										css={css`
+											padding-left: 5px;
+										`}
+									>
+										{part}
+									</EuiText>
+								))
+						: ''}
+					<EuiSpacer size="xs" />
+					<EuiBadge color={supplierColour}>{supplierLabel}</EuiBadge>
+				</div>
 				<div
 					css={css`
 						grid-area: content;
 					`}
 				>
 					{maybeSecondaryCardContent && <p>{maybeSecondaryCardContent}</p>}
-					{highlight && highlight.trim().length > 0 && (
-						<EuiText
-							size="xs"
-							css={css`
-								margin-top: 0.1rem;
-								padding: 0.1rem 0.5rem;
-								background-color: ${theme.euiTheme.colors.highlight};
-								justify-self: start;
-							`}
-						>
-							<p
-								dangerouslySetInnerHTML={{ __html: sanitizeHtml(highlight) }}
-							/>
-						</EuiText>
-					)}
 				</div>
 			</div>
 		</Link>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

* Fix a bug in the wire feed card layout, whereby the time stamp was being pushed down to the bottom of the card if the date was also showing (i.e. when it wasn't today's date)
* Move the supplier badge to the right hand side, under the date, to de-emphasise
* Fix a regression whereby the main heading wasn't being rendered in bolder text anymore
* When we have a search highlight to show, don't render other secondary content.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

|Before|After|
|-|-|
|<img width="971" alt="image" src="https://github.com/user-attachments/assets/071aae86-9051-48d3-9209-bc3f473b0527" />|<img width="966" alt="image" src="https://github.com/user-attachments/assets/980de542-4464-4cd9-9ce2-7523d3311cee" />|
|<img width="975" alt="image" src="https://github.com/user-attachments/assets/659fae64-aed3-4114-911a-d771a08917a1" />|<img width="965" alt="image" src="https://github.com/user-attachments/assets/aac32b0a-d805-48ca-8231-848ab530485d" />|


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
