### PR TITLE
Newswires UI: filter search by date

### DIFF
--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -40,6 +40,8 @@ class QueryController(
       subjectsExcl: List[String],
       categoryCode: List[String],
       categoryCodeExcl: List[String],
+      maybeStart: Option[String],
+      maybeEnd: Option[String],
       maybeBeforeId: Option[Int],
       maybeSinceId: Option[Int]
   ): Action[AnyContent] = apiAuthAction { request: UserRequest[AnyContent] =>
@@ -51,6 +53,8 @@ class QueryController(
 
     val queryParams = SearchParams(
       text = maybeFreeTextQuery,
+      start = maybeStart,
+      end = maybeEnd,
       keywordIncl = maybeKeywords.map(_.split(",").toList).getOrElse(Nil),
       keywordExcl = paramToList(request, "keywordsExcl"),
       suppliersIncl = suppliers,

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -282,6 +282,23 @@ object FingerpostWireEntry
         )
     }
 
+    val dateRangeQuery = (search.start, search.end) match {
+      case (Some(startDate), Some(endDate)) =>
+        Some(
+          sqls"${FingerpostWireEntry.syn.ingestedAt} BETWEEN CAST($startDate AS timestamptz) AND CAST($endDate AS timestamptz)"
+        )
+      case (Some(startDate), None) =>
+        Some(
+          sqls"${FingerpostWireEntry.syn.ingestedAt} >= CAST($startDate AS timestamptz)"
+        )
+      case (None, Some(endDate)) =>
+        Some(
+          sqls"${FingerpostWireEntry.syn.ingestedAt} <= CAST($endDate AS timestamptz)"
+        )
+      case _ => None
+    }
+
+
     // grr annoying but broadly I think subjects(/categoryCodes) and keywords are the same "axis" to search on
     val clausesJoinedWithOr =
       List(keywordsQuery, subjectsQuery, categoryCodesInclQuery).flatten match {
@@ -299,6 +316,7 @@ object FingerpostWireEntry
       ),
       sourceFeedsQuery,
       sourceFeedsExclQuery,
+      dateRangeQuery,
       categoryCodesInclQuery,
       categoryCodesExclQuery
     ).flatten

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -298,7 +298,6 @@ object FingerpostWireEntry
       case _ => None
     }
 
-
     // grr annoying but broadly I think subjects(/categoryCodes) and keywords are the same "axis" to search on
     val clausesJoinedWithOr =
       List(keywordsQuery, subjectsQuery, categoryCodesInclQuery).flatten match {

--- a/newswires/app/db/SearchParams.scala
+++ b/newswires/app/db/SearchParams.scala
@@ -2,6 +2,8 @@ package db
 
 case class SearchParams(
     text: Option[String],
+    start: Option[String] = None,
+    end: Option[String] = None,
     keywordIncl: List[String] = Nil,
     keywordExcl: List[String] = Nil,
     suppliersIncl: List[String] = Nil,

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -15,6 +15,7 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useSearch } from './context/SearchContext.tsx';
+import { isRestricted } from './dateMathHelpers.ts';
 import { Feed } from './Feed';
 import { Item } from './Item';
 import { SideNav } from './SideNav';
@@ -31,7 +32,7 @@ export function App() {
 		handlePreviousItem,
 	} = useSearch();
 
-	const { view, itemId: selectedItemId } = config;
+	const { view, itemId: selectedItemId, query } = config;
 	const { status } = state;
 
 	const isPoppedOut = !!window.opener;
@@ -74,9 +75,26 @@ export function App() {
 						</p>
 					</EuiToast>
 				)}
+				{isRestricted(query.dateRange?.end) && (
+					<EuiToast
+						title="Restricted"
+						iconType="warning"
+						css={css`
+							border-radius: 0;
+							background: #fdf6d8;
+							position: fixed;
+						`}
+					>
+						<p>
+							Your current filter settings exclude recent updates. Adjust the
+							filter to see the latest data.
+						</p>
+					</EuiToast>
+				)}
 				<div
 					css={css`
-						${status === 'offline' && 'padding-top: 84px;'}
+						${(status === 'offline' || isRestricted(query.dateRange?.end)) &&
+						'padding-top: 84px;'}
 						height: 100%;
 						${(status === 'loading' || status === 'error') &&
 						'display: flex; align-items: center;'}

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -21,6 +21,28 @@ import { Item } from './Item';
 import { SideNav } from './SideNav';
 import { configToUrl, defaultQuery } from './urlState';
 
+const Alert = ({
+	title,
+	icon = 'warning',
+	children,
+}: {
+	title: string;
+	icon?: string;
+	children: React.ReactNode;
+}) => (
+	<EuiToast
+		title={title}
+		iconType={icon}
+		css={css`
+			border-radius: 0;
+			background: #fdf6d8;
+			position: fixed;
+		`}
+	>
+		<p>{children}</p>
+	</EuiToast>
+);
+
 export function App() {
 	const {
 		config,
@@ -60,37 +82,19 @@ export function App() {
 				`}
 			>
 				{status === 'offline' && (
-					<EuiToast
-						title="You Are Currently Offline"
-						iconType="warning"
-						css={css`
-							border-radius: 0;
-							background: #fdf6d8;
-							position: fixed;
-						`}
-					>
-						<p>
-							The application is no longer retrieving updates. Data
-							synchronization will resume once connectivity is restored.
-						</p>
-					</EuiToast>
+					<Alert title="You Are Currently Offline">
+						The application is no longer retrieving updates. Data
+						synchronization will resume once connectivity is restored.
+					</Alert>
 				)}
-				{isRestricted(query.dateRange?.end) && (
-					<EuiToast
-						title="Restricted"
-						iconType="warning"
-						css={css`
-							border-radius: 0;
-							background: #fdf6d8;
-							position: fixed;
-						`}
-					>
-						<p>
+				{isRestricted(query.dateRange?.end) &&
+					status !== 'offline' &&
+					status !== 'error' && (
+						<Alert title="Restricted">
 							Your current filter settings exclude recent updates. Adjust the
 							filter to see the latest data.
-						</p>
-					</EuiToast>
-				)}
+						</Alert>
+					)}
 				<div
 					css={css`
 						${(status === 'offline' || isRestricted(query.dateRange?.end)) &&

--- a/newswires/client/src/DatePicker.tsx
+++ b/newswires/client/src/DatePicker.tsx
@@ -3,23 +3,27 @@
 import type { EuiQuickSelect } from '@elastic/eui';
 import { EuiSuperDatePicker } from '@elastic/eui';
 import type { EuiCommonlyUsedTimeRanges } from '@elastic/eui/src/components/date_picker/super_date_picker/quick_select_popover/commonly_used_time_ranges';
-import moment from 'moment';
 import type { ReactElement } from 'react';
 import { useSearch } from './context/SearchContext.tsx';
+import {
+	END_OF_TODAY,
+	LAST_TWO_WEEKS,
+	NOW,
+	TWO_WEEKS_AGO,
+} from './dateConstants.ts';
 import type { TimeRange } from './dateMathHelpers.ts';
 import { timeRangeOption } from './dateMathHelpers.ts';
 
 export const DatePicker = () => {
 	const { config, handleEnterQuery } = useSearch();
 
-	const minDate = moment().subtract(2, 'weeks');
-	const maxDate = moment().endOf('day');
-
 	const onTimeChange = ({ start, end }: TimeRange) => {
 		handleEnterQuery({
 			...config.query,
-			start,
-			end,
+			dateRange: {
+				start,
+				end,
+			},
 		});
 	};
 
@@ -40,13 +44,16 @@ export const DatePicker = () => {
 		<div style={{ paddingTop: 20, paddingBottom: 20 }}>
 			<EuiSuperDatePicker
 				width={'auto'}
-				start={config.query.start}
-				end={config.query.end}
-				minDate={minDate}
-				maxDate={maxDate}
+				start={
+					config.query.dateRange ? config.query.dateRange.start : LAST_TWO_WEEKS
+				}
+				end={config.query.dateRange ? config.query.dateRange.end : NOW}
+				minDate={TWO_WEEKS_AGO}
+				maxDate={END_OF_TODAY}
 				onTimeChange={onTimeChange}
-				showUpdateButton={true}
+				updateButtonProps={{ showTooltip: true, iconOnly: true }}
 				customQuickSelectRender={customQuickSelectRender}
+				dateFormat={'MMM D • HH:mm'}
 				commonlyUsedRanges={[
 					timeRangeOption('30m'),
 					timeRangeOption('1h'),

--- a/newswires/client/src/DatePicker.tsx
+++ b/newswires/client/src/DatePicker.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import type { EuiQuickSelect } from '@elastic/eui';
+import { EuiSuperDatePicker } from '@elastic/eui';
+import type { EuiCommonlyUsedTimeRanges } from '@elastic/eui/src/components/date_picker/super_date_picker/quick_select_popover/commonly_used_time_ranges';
+import moment from 'moment';
+import type { ReactElement } from 'react';
+import { useSearch } from './context/SearchContext.tsx';
+import type { TimeRange } from './dateMathHelpers.ts';
+import { timeRangeOption } from './dateMathHelpers.ts';
+
+export const DatePicker = () => {
+	const { config, handleEnterQuery } = useSearch();
+
+	const minDate = moment().subtract(2, 'weeks');
+	const maxDate = moment().endOf('day');
+
+	const onTimeChange = ({ start, end }: TimeRange) => {
+		handleEnterQuery({
+			...config.query,
+			start,
+			end,
+		});
+	};
+
+	const customQuickSelectRender = ({
+		quickSelect,
+		commonlyUsedRanges,
+	}: {
+		quickSelect: ReactElement<typeof EuiQuickSelect>;
+		commonlyUsedRanges: ReactElement<typeof EuiCommonlyUsedTimeRanges>;
+	}) => (
+		<>
+			{commonlyUsedRanges}
+			{quickSelect}
+		</>
+	);
+
+	return (
+		<div style={{ paddingTop: 20, paddingBottom: 20 }}>
+			<EuiSuperDatePicker
+				width={'auto'}
+				start={config.query.start}
+				end={config.query.end}
+				minDate={minDate}
+				maxDate={maxDate}
+				onTimeChange={onTimeChange}
+				showUpdateButton={false}
+				customQuickSelectRender={customQuickSelectRender}
+				commonlyUsedRanges={[
+					timeRangeOption('30m'),
+					timeRangeOption('1h'),
+					timeRangeOption('24h'),
+					timeRangeOption('today'),
+					timeRangeOption('1d'),
+					timeRangeOption('2d'),
+				]}
+			/>
+		</div>
+	);
+};

--- a/newswires/client/src/DatePicker.tsx
+++ b/newswires/client/src/DatePicker.tsx
@@ -45,7 +45,7 @@ export const DatePicker = () => {
 				minDate={minDate}
 				maxDate={maxDate}
 				onTimeChange={onTimeChange}
-				showUpdateButton={false}
+				showUpdateButton={true}
 				customQuickSelectRender={customQuickSelectRender}
 				commonlyUsedRanges={[
 					timeRangeOption('30m'),

--- a/newswires/client/src/Feed.tsx
+++ b/newswires/client/src/Feed.tsx
@@ -29,32 +29,44 @@ export const Feed = () => {
 			)}
 			{(status == 'success' || status == 'offline') &&
 				queryData.results.length === 0 && (
-					<EuiEmptyPrompt
-						body={
-							<>
-								<SearchSummary />
-								<p>Try another search or reset filters.</p>
-							</>
-						}
-						color="subdued"
-						layout="horizontal"
-						title={<h2>No results match your search criteria</h2>}
-						titleSize="s"
-					/>
-				)}
-			{(status == 'success' || status == 'offline') &&
-				queryData.results.length > 0 && (
 					<>
 						<EuiFlexGroup>
 							<EuiFlexItem
 								style={{ flex: 1, paddingTop: 20, paddingBottom: 20 }}
-							>
-								<SearchSummary />
-							</EuiFlexItem>
+							></EuiFlexItem>
 							<EuiFlexItem grow={false}>
 								<DatePicker />
 							</EuiFlexItem>
 						</EuiFlexGroup>
+						<EuiEmptyPrompt
+							body={
+								<>
+									<SearchSummary />
+									<p>Try another search or reset filters.</p>
+								</>
+							}
+							color="subdued"
+							layout="horizontal"
+							title={<h2>No results match your search criteria</h2>}
+							titleSize="s"
+						/>
+					</>
+				)}
+			{(status == 'success' || status == 'offline') &&
+				queryData.results.length > 0 && (
+					<>
+						<div>
+							<EuiFlexGroup>
+								<EuiFlexItem
+									style={{ flex: 1, paddingTop: 20, paddingBottom: 20 }}
+								>
+									<SearchSummary />
+								</EuiFlexItem>
+								<EuiFlexItem grow={false}>
+									<DatePicker />
+								</EuiFlexItem>
+							</EuiFlexGroup>
+						</div>
 
 						<WireItemList
 							wires={queryData.results}

--- a/newswires/client/src/Feed.tsx
+++ b/newswires/client/src/Feed.tsx
@@ -1,6 +1,13 @@
-import { EuiEmptyPrompt, EuiLoadingLogo, EuiPageTemplate } from '@elastic/eui';
+import {
+	EuiEmptyPrompt,
+	EuiFlexGroup,
+	EuiFlexItem,
+	EuiLoadingLogo,
+	EuiPageTemplate,
+} from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useSearch } from './context/SearchContext.tsx';
+import { DatePicker } from './DatePicker.tsx';
 import { SearchSummary } from './SearchSummary.tsx';
 import { WireItemList } from './WireItemList.tsx';
 
@@ -38,7 +45,17 @@ export const Feed = () => {
 			{(status == 'success' || status == 'offline') &&
 				queryData.results.length > 0 && (
 					<>
-						<SearchSummary />
+						<EuiFlexGroup>
+							<EuiFlexItem
+								style={{ flex: 1, paddingTop: 20, paddingBottom: 20 }}
+							>
+								<SearchSummary />
+							</EuiFlexItem>
+							<EuiFlexItem grow={false}>
+								<DatePicker />
+							</EuiFlexItem>
+						</EuiFlexGroup>
+
 						<WireItemList
 							wires={queryData.results}
 							totalCount={queryData.totalCount}

--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -2,10 +2,11 @@ import { EuiBadge, EuiText } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useEffect, useState } from 'react';
 import { useSearch } from './context/SearchContext.tsx';
+import { deriveDateMathRangeLabel } from './dateMathHelpers.ts';
 
 const Summary = ({ searchSummary }: { searchSummary: string }) => {
 	const { config, handleEnterQuery } = useSearch();
-	const { q, bucket, subjects, supplier: suppliers } = config.query;
+	const { q, bucket, subjects, supplier: suppliers, dateRange } = config.query;
 
 	const displaySubjects = (subjects ?? []).length > 0;
 	const displaySuppliers = (suppliers ?? []).length > 0;
@@ -20,6 +21,7 @@ const Summary = ({ searchSummary }: { searchSummary: string }) => {
 		handleEnterQuery({
 			...config.query,
 			q: label === 'Search term' ? '' : config.query.q,
+			dateRange: label === 'Time range' ? undefined : config.query.dateRange,
 			bucket: label === 'Bucket' ? undefined : config.query.bucket,
 			supplier:
 				label === 'Supplier'
@@ -43,7 +45,8 @@ const Summary = ({ searchSummary }: { searchSummary: string }) => {
 					handleBadgeClick(label, value);
 				}}
 			>
-				<strong>{label}</strong>: {value}
+				<strong>{label}</strong>
+				{value !== '' ? `: ${value}` : ''}
 			</EuiBadge>
 		) : null;
 
@@ -53,6 +56,11 @@ const Summary = ({ searchSummary }: { searchSummary: string }) => {
 				{searchSummary}
 				{displayFilters && ' for: '}
 			</span>
+			{dateRange &&
+				renderBadge(
+					'Time range',
+					deriveDateMathRangeLabel(dateRange.start, dateRange.end),
+				)}
 			{q && renderBadge('Search term', q)}
 			{bucket && renderBadge('Bucket', bucket)}
 			{displaySuppliers &&

--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -82,7 +82,7 @@ export const SearchSummary = () => {
 	return (
 		<EuiText
 			css={css`
-				margin-top: 12px;
+				margin-top: 6px;
 				margin-bottom: 18px;
 			`}
 		>

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -22,13 +22,14 @@ import type { Query } from './sharedTypes';
 import { recognisedSuppliers, supplierData } from './suppliers.ts';
 
 function decideLabelForQueryBadge(query: Query): string {
-	const { supplier, q, bucket, subjects, start, end } = query;
+	const { supplier, q, bucket, subjects, dateRange } = query;
 	const supplierLabel = supplier?.join(', ') ?? '';
 	const subjectsLabel = subjects?.join(', ') ?? '';
 	const qLabel = q.length > 0 ? `"${q}"` : '';
 	const bucketLabel = bucket ? `[${bucketName(bucket)}]` : '';
-	const dateRangeLabel =
-		start && end ? deriveDateMathRangeLabel(start, end) : '';
+	const dateRangeLabel = dateRange
+		? deriveDateMathRangeLabel(dateRange.start, dateRange.end)
+		: '';
 
 	const labels = [
 		bucketLabel,
@@ -49,6 +50,7 @@ const buckets = [
 	{ id: 'reuters-world', name: 'Reuters World' },
 	{ id: 'aap-world', name: 'AAP World' },
 ];
+
 function bucketName(bucketId: string): string | undefined {
 	return buckets.find((bucket) => bucket.id === bucketId)?.name;
 }

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -16,17 +16,28 @@ import {
 import { css } from '@emotion/react';
 import { useCallback, useMemo, useState } from 'react';
 import { useSearch } from './context/SearchContext.tsx';
+import { deriveDateMathRangeLabel } from './dateMathHelpers.ts';
 import { SearchBox } from './SearchBox';
 import type { Query } from './sharedTypes';
 import { recognisedSuppliers, supplierData } from './suppliers.ts';
 
 function decideLabelForQueryBadge(query: Query): string {
-	const { supplier, q, bucket, subjects } = query;
+	const { supplier, q, bucket, subjects, start, end } = query;
 	const supplierLabel = supplier?.join(', ') ?? '';
 	const subjectsLabel = subjects?.join(', ') ?? '';
 	const qLabel = q.length > 0 ? `"${q}"` : '';
 	const bucketLabel = bucket ? `[${bucketName(bucket)}]` : '';
-	const labels = [bucketLabel, supplierLabel, subjectsLabel, qLabel];
+	const dateRangeLabel =
+		start && end ? deriveDateMathRangeLabel(start, end) : '';
+
+	const labels = [
+		bucketLabel,
+		supplierLabel,
+		subjectsLabel,
+		qLabel,
+		dateRangeLabel,
+	];
+
 	return labels.filter((label) => label.length > 0).join(' ');
 }
 

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -87,6 +87,7 @@ const ActionSchema = z.discriminatedUnion('type', [
 	z.object({ type: z.literal('SELECT_ITEM'), item: z.string().optional() }),
 	z.object({
 		type: z.literal('UPDATE_RESULTS'),
+		query: QuerySchema,
 		data: WiresQueryResponseSchema,
 	}),
 	z.object({ type: z.literal('TOGGLE_AUTO_UPDATE') }),
@@ -205,7 +206,11 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 					fetchResults(currentConfig.query, { sinceId }, abortController)
 						.then((data) => {
 							if (!abortController.signal.aborted) {
-								dispatch({ type: 'UPDATE_RESULTS', data });
+								dispatch({
+									type: 'UPDATE_RESULTS',
+									data,
+									query: currentConfig.query,
+								});
 							}
 						})
 						.catch(handleFetchError);
@@ -227,7 +232,9 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 	]);
 
 	const handleEnterQuery = (query: Query) => {
-		dispatch({ type: 'ENTER_QUERY' });
+		dispatch({
+			type: 'ENTER_QUERY',
+		});
 
 		if (currentConfig.view === 'item') {
 			pushConfigState({

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -228,18 +228,19 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 
 	const handleEnterQuery = (query: Query) => {
 		dispatch({ type: 'ENTER_QUERY' });
+
 		if (currentConfig.view === 'item') {
 			pushConfigState({
 				...currentConfig,
 				query,
 			});
-			return;
+		} else {
+			pushConfigState({
+				...currentConfig,
+				view: 'feed',
+				query,
+			});
 		}
-		pushConfigState({
-			...currentConfig,
-			view: 'feed',
-			query,
-		});
 	};
 
 	const handleRetry = () => {

--- a/newswires/client/src/context/fetchResults.test.ts
+++ b/newswires/client/src/context/fetchResults.test.ts
@@ -24,7 +24,7 @@ describe('fetchResults', () => {
 		const mockQuery = { q: 'value' };
 		await fetchResults(mockQuery);
 
-		expect(paramsToQuerystring).toHaveBeenCalledWith(mockQuery, {});
+		expect(paramsToQuerystring).toHaveBeenCalledWith(mockQuery, true, {});
 		expect(pandaFetch).toHaveBeenCalledWith('/api/search?queryString', {
 			headers: { Accept: 'application/json' },
 		});
@@ -77,6 +77,7 @@ describe('fetchResults', () => {
 			{
 				...mockQuery,
 			},
+			true,
 			{ sinceId: '123' },
 		);
 	});
@@ -89,6 +90,7 @@ describe('fetchResults', () => {
 			{
 				...mockQuery,
 			},
+			true,
 			{ beforeId: '123' },
 		);
 	});

--- a/newswires/client/src/context/fetchResults.ts
+++ b/newswires/client/src/context/fetchResults.ts
@@ -11,7 +11,7 @@ export const fetchResults = async (
 	} = {},
 	abortController?: AbortController,
 ): Promise<WiresQueryResponse> => {
-	const queryString = paramsToQuerystring(query, additionalParams);
+	const queryString = paramsToQuerystring(query, true, additionalParams);
 	const response = await pandaFetch(`/api/search${queryString}`, {
 		headers: {
 			Accept: 'application/json',

--- a/newswires/client/src/dateConstants.ts
+++ b/newswires/client/src/dateConstants.ts
@@ -1,0 +1,7 @@
+import moment from 'moment';
+
+export const NOW = 'now';
+export const LAST_TWO_WEEKS = 'now-2w';
+
+export const TWO_WEEKS_AGO = moment().subtract(2, 'weeks');
+export const END_OF_TODAY = moment().endOf('day');

--- a/newswires/client/src/dateMathHelpers.test.ts
+++ b/newswires/client/src/dateMathHelpers.test.ts
@@ -3,6 +3,7 @@ import moment from 'moment';
 import {
 	dateMathRangeToDateRange,
 	deriveDateMathRangeLabel,
+	isValidDateValue,
 } from './dateMathHelpers.ts';
 
 jest.mock('@elastic/datemath', () => ({
@@ -11,6 +12,26 @@ jest.mock('@elastic/datemath', () => ({
 		parse: jest.fn(),
 	},
 }));
+
+describe('isValidDateValue', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	['now', 'now-3h', 'now-1M-3d', 'now-2w/d'].forEach((value) => {
+		it(`should validate ${value} value`, () => {
+			expect(isValidDateValue(value)).toBe(true);
+		});
+	});
+
+	it(`should validate a timestamp value`, () => {
+		expect(isValidDateValue('2024-02-24T16:17:36.295Z')).toBe(true);
+	});
+
+	it(`should invalidate invalid value`, () => {
+		expect(isValidDateValue('invalid')).toBe(false);
+	});
+});
 
 describe('dateMathRangeToDateRange', () => {
 	beforeEach(() => {

--- a/newswires/client/src/dateMathHelpers.test.ts
+++ b/newswires/client/src/dateMathHelpers.test.ts
@@ -1,0 +1,72 @@
+import dateMath from '@elastic/datemath';
+import moment from 'moment';
+import {
+	dateMathRangeToDateRange,
+	deriveDateMathRangeLabel,
+} from './dateMathHelpers.ts';
+
+jest.mock('@elastic/datemath', () => ({
+	__esModule: true,
+	default: {
+		parse: jest.fn(),
+	},
+}));
+
+describe('dateMathRangeToDateRange', () => {
+	it('should convert a date math range to a date/time range', () => {
+		(dateMath.parse as jest.Mock).mockImplementation(() =>
+			moment().startOf('day'),
+		);
+
+		const [start, end] = dateMathRangeToDateRange({
+			start: 'now/d',
+			end: 'now/d',
+		});
+
+		expect(start?.toISOString()).toBe(moment().startOf('day').toISOString());
+		expect(end?.toISOString()).toBe(moment().endOf('day').toISOString());
+	});
+});
+
+describe('deriveDateMathRangeLabel', () => {
+	it('should return "Last 1 minute" for "now-1m" to "now"', () => {
+		expect(deriveDateMathRangeLabel('now-1m', 'now')).toBe('Last 1 minute');
+	});
+
+	it('should return "Last 30 minutes" for "now-30m" to "now"', () => {
+		expect(deriveDateMathRangeLabel('now-30m', 'now')).toBe('Last 30 minutes');
+	});
+
+	it('should return "Last 1 hour" for "now-1h" to "now"', () => {
+		expect(deriveDateMathRangeLabel('now-1h', 'now')).toBe('Last 1 hour');
+	});
+
+	it('should return "Last 24 hours" for "now-24h" to "now"', () => {
+		expect(deriveDateMathRangeLabel('now-24h', 'now')).toBe('Last 24 hours');
+	});
+
+	it('should return "Today" for "now/d" to "now/d"', () => {
+		expect(deriveDateMathRangeLabel('now/d', 'now/d')).toBe('Today');
+	});
+
+	it('should return "Yesterday" for "now-1d/d" to "now-1d/d"', () => {
+		expect(deriveDateMathRangeLabel('now-1d/d', 'now-1d/d')).toBe('Yesterday');
+	});
+
+	it('should return the day name for "now-2d/d" to "now-2d/d"', () => {
+		const expectedDayName = moment()
+			.startOf('day')
+			.subtract(2, 'days')
+			.format('dddd');
+
+		expect(deriveDateMathRangeLabel('now-2d/d', 'now-2d/d')).toBe(
+			expectedDayName,
+		);
+	});
+
+	it('should return a formatted date range for absolute ISO dates when end date is not today', () => {
+		const start = '2025-02-23T00:20:43.493Z';
+		const end = '2025-02-25T00:20:51.294Z';
+		expect(deriveDateMathRangeLabel(start, end)).toBe('Feb 23 - Feb 25');
+	});
+});

--- a/newswires/client/src/dateMathHelpers.test.ts
+++ b/newswires/client/src/dateMathHelpers.test.ts
@@ -1,9 +1,9 @@
 import dateMath from '@elastic/datemath';
 import moment from 'moment';
 import {
-	dateMathRangeToDateRange,
 	deriveDateMathRangeLabel,
 	isValidDateValue,
+	relativeDateRangeToAbsoluteDateRange,
 } from './dateMathHelpers.ts';
 
 jest.mock('@elastic/datemath', () => ({
@@ -33,7 +33,7 @@ describe('isValidDateValue', () => {
 	});
 });
 
-describe('dateMathRangeToDateRange', () => {
+describe('relativeDateRangeToAbsoluteDateRange', () => {
 	beforeEach(() => {
 		jest.clearAllMocks();
 	});
@@ -43,7 +43,7 @@ describe('dateMathRangeToDateRange', () => {
 			moment().startOf('day'),
 		);
 
-		const [start, end] = dateMathRangeToDateRange({
+		const [start, end] = relativeDateRangeToAbsoluteDateRange({
 			start: 'now-1d/d',
 			end: 'now-1d/d',
 		});
@@ -57,7 +57,7 @@ describe('dateMathRangeToDateRange', () => {
 			moment().startOf('day'),
 		);
 
-		const [start, end] = dateMathRangeToDateRange({
+		const [start, end] = relativeDateRangeToAbsoluteDateRange({
 			start: 'now-1d/d',
 			end: 'now/d',
 		});
@@ -71,7 +71,7 @@ describe('dateMathRangeToDateRange', () => {
 			moment().startOf('day'),
 		);
 
-		const [start, end] = dateMathRangeToDateRange({
+		const [start, end] = relativeDateRangeToAbsoluteDateRange({
 			start: 'now-1d/d',
 			end: 'now/d',
 		});

--- a/newswires/client/src/dateMathHelpers.ts
+++ b/newswires/client/src/dateMathHelpers.ts
@@ -1,0 +1,48 @@
+import dateMath from '@elastic/datemath';
+import moment from 'moment';
+
+export interface TimeRange {
+	start?: string;
+	end?: string;
+}
+
+export const dateMathRangeToDateRange = ({ start, end }: TimeRange) => {
+	const startDate = start ? dateMath.parse(start) : undefined;
+	const endDate = end && end !== 'now' ? dateMath.parse(end) : undefined;
+
+	return [
+		startDate,
+		startDate?.isSame(endDate) ? endDate?.endOf('day') : endDate,
+	];
+};
+
+export const timeRangeOption = (start: string) => {
+	switch (start) {
+		case '30m':
+			return { start: `now-30m`, end: 'now', label: 'Last 30 minutes' };
+		case '1h':
+			return { start: `now-1h`, end: 'now', label: 'Last 1 hour' };
+		case '24h':
+			return { start: `now-24h`, end: 'now', label: 'Last 24 hours' };
+		case 'today':
+			return {
+				start: 'now/d',
+				end: 'now/d',
+				label: 'Today',
+			};
+		case '1d':
+			return {
+				start: `now-1d/d`,
+				end: `now-1d/d`,
+				label: 'Yesterday',
+			};
+		case '2d':
+			return {
+				start: `now-2d/d`,
+				end: `now-2d/d`,
+				label: moment().subtract(2, 'days').format('dddd'),
+			};
+		default:
+			return { start: `now-2w`, end: 'now', label: 'Last 14 days' };
+	}
+};

--- a/newswires/client/src/dateMathHelpers.ts
+++ b/newswires/client/src/dateMathHelpers.ts
@@ -75,7 +75,10 @@ export const deriveDateMathRangeLabel = (
 	return `${startMoment.format('MMM D')} - ${endMoment.format('MMM D')}`;
 };
 
-export const dateMathRangeToDateRange = ({ start, end }: TimeRange) => {
+export const relativeDateRangeToAbsoluteDateRange = ({
+	start,
+	end,
+}: TimeRange) => {
 	const startDate = start ? dateMath.parse(start) : undefined;
 	const endDate =
 		end && !isRelativeDateNow(end) ? dateMath.parse(end) : undefined;

--- a/newswires/client/src/dateMathHelpers.ts
+++ b/newswires/client/src/dateMathHelpers.ts
@@ -6,6 +6,9 @@ export interface TimeRange {
 	end: string;
 }
 
+export const isValidDateValue = (value: string) =>
+	/^now(?:[+-]\d+[smhdwMy])*(?:\/\w+)?$/.test(value) || moment(value).isValid();
+
 export const isRelativeDateNow = (relativeDate: string) =>
 	relativeDate === 'now' || relativeDate === 'now/d';
 

--- a/newswires/client/src/icons.ts
+++ b/newswires/client/src/icons.ts
@@ -17,6 +17,7 @@ import { icon as dot } from '@elastic/eui/es/components/icon/assets/dot';
 import { icon as doubleArrowLeft } from '@elastic/eui/es/components/icon/assets/doubleArrowLeft';
 import { icon as empty } from '@elastic/eui/es/components/icon/assets/empty';
 import { icon as faceSad } from '@elastic/eui/es/components/icon/assets/face_sad';
+import { icon as filter } from '@elastic/eui/es/components/icon/assets/filter';
 import { icon as heart } from '@elastic/eui/es/components/icon/assets/heart';
 import { icon as iInCircle } from '@elastic/eui/es/components/icon/assets/iInCircle';
 import { icon as kqlFunction } from '@elastic/eui/es/components/icon/assets/kql_function';
@@ -66,6 +67,7 @@ const icons = {
 	pin,
 	iInCircle,
 	kqlFunction,
+	filter,
 };
 
 // One or more icons are passed in as an object of iconKey (string): IconComponent

--- a/newswires/client/src/icons.ts
+++ b/newswires/client/src/icons.ts
@@ -19,6 +19,7 @@ import { icon as empty } from '@elastic/eui/es/components/icon/assets/empty';
 import { icon as faceSad } from '@elastic/eui/es/components/icon/assets/face_sad';
 import { icon as heart } from '@elastic/eui/es/components/icon/assets/heart';
 import { icon as iInCircle } from '@elastic/eui/es/components/icon/assets/iInCircle';
+import { icon as kqlFunction } from '@elastic/eui/es/components/icon/assets/kql_function';
 import { icon as launch } from '@elastic/eui/es/components/icon/assets/launch';
 import { icon as link } from '@elastic/eui/es/components/icon/assets/link';
 import { icon as menu } from '@elastic/eui/es/components/icon/assets/menu';
@@ -64,6 +65,7 @@ const icons = {
 	sortRight,
 	pin,
 	iInCircle,
+	kqlFunction,
 };
 
 // One or more icons are passed in as an object of iconKey (string): IconComponent

--- a/newswires/client/src/icons.ts
+++ b/newswires/client/src/icons.ts
@@ -8,6 +8,7 @@ import { icon as arrowEnd } from '@elastic/eui/es/components/icon/assets/arrowEn
 import { icon as arrowStart } from '@elastic/eui/es/components/icon/assets/arrowStart';
 import { icon as boxesHorizontal } from '@elastic/eui/es/components/icon/assets/boxes_horizontal';
 import { icon as boxesVertical } from '@elastic/eui/es/components/icon/assets/boxes_vertical';
+import { icon as calendar } from '@elastic/eui/es/components/icon/assets/calendar';
 import { icon as check } from '@elastic/eui/es/components/icon/assets/check';
 import { icon as clock } from '@elastic/eui/es/components/icon/assets/clock';
 import { icon as copyClipboard } from '@elastic/eui/es/components/icon/assets/copy_clipboard';
@@ -28,10 +29,12 @@ import { icon as popout } from '@elastic/eui/es/components/icon/assets/popout';
 import { icon as refresh } from '@elastic/eui/es/components/icon/assets/refresh';
 import { icon as returnKey } from '@elastic/eui/es/components/icon/assets/return_key';
 import { icon as search } from '@elastic/eui/es/components/icon/assets/search';
+import { icon as sortRight } from '@elastic/eui/es/components/icon/assets/sortRight';
 import { icon as warning } from '@elastic/eui/es/components/icon/assets/warning';
 import { appendIconComponentCache } from '@elastic/eui/es/components/icon/icon';
 
 const icons = {
+	calendar,
 	clock,
 	arrowDown,
 	arrowLeft,
@@ -58,6 +61,7 @@ const icons = {
 	link,
 	copyClipboard,
 	popout,
+	sortRight,
 	pin,
 	iInCircle,
 };

--- a/newswires/client/src/icons.ts
+++ b/newswires/client/src/icons.ts
@@ -31,6 +31,7 @@ import { icon as popout } from '@elastic/eui/es/components/icon/assets/popout';
 import { icon as refresh } from '@elastic/eui/es/components/icon/assets/refresh';
 import { icon as returnKey } from '@elastic/eui/es/components/icon/assets/return_key';
 import { icon as search } from '@elastic/eui/es/components/icon/assets/search';
+import { icon as sortLeft } from '@elastic/eui/es/components/icon/assets/sortLeft';
 import { icon as sortRight } from '@elastic/eui/es/components/icon/assets/sortRight';
 import { icon as warning } from '@elastic/eui/es/components/icon/assets/warning';
 import { appendIconComponentCache } from '@elastic/eui/es/components/icon/icon';
@@ -64,6 +65,7 @@ const icons = {
 	copyClipboard,
 	popout,
 	sortRight,
+	sortLeft,
 	pin,
 	iInCircle,
 	kqlFunction,

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -50,6 +50,11 @@ export const WiresQueryResponseSchema = z.object({
 
 export type WiresQueryResponse = z.infer<typeof WiresQueryResponseSchema>;
 
+const DateRange = z.object({
+	start: z.string(),
+	end: z.string(),
+});
+
 export const QuerySchema = z.object({
 	q: z.string(),
 	supplier: z.array(z.string()).optional(),
@@ -61,8 +66,7 @@ export const QuerySchema = z.object({
 	categoryCode: z.array(z.string()).optional(),
 	categoryCodeExcl: z.array(z.string()).optional(),
 	bucket: z.ostring(),
-	start: z.ostring(),
-	end: z.ostring(),
+	dateRange: DateRange.optional(),
 });
 
 export type Query = z.infer<typeof QuerySchema>;

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -61,6 +61,8 @@ export const QuerySchema = z.object({
 	categoryCode: z.array(z.string()).optional(),
 	categoryCodeExcl: z.array(z.string()).optional(),
 	bucket: z.ostring(),
+	start: z.ostring(),
+	end: z.ostring(),
 });
 
 export type Query = z.infer<typeof QuerySchema>;

--- a/newswires/client/src/urlState.test.ts
+++ b/newswires/client/src/urlState.test.ts
@@ -1,8 +1,8 @@
 import moment from 'moment';
 import {
-	dateMathRangeToDateRange,
 	isRelativeDateNow,
 	isValidDateValue,
+	relativeDateRangeToAbsoluteDateRange,
 } from './dateMathHelpers.ts';
 import {
 	defaultQuery,
@@ -18,7 +18,7 @@ function makeFakeLocation(url: string): { pathname: string; search: string } {
 }
 
 jest.mock('./dateMathHelpers', () => ({
-	dateMathRangeToDateRange: jest.fn(),
+	relativeDateRangeToAbsoluteDateRange: jest.fn(),
 	isValidDateValue: jest.fn().mockReturnValue(true),
 	isRelativeDateNow: jest.fn().mockReturnValue(false),
 }));
@@ -355,7 +355,7 @@ describe('paramsToQuerystring', () => {
 	});
 
 	it('keep relative date range', () => {
-		(dateMathRangeToDateRange as jest.Mock).mockReturnValue([
+		(relativeDateRangeToAbsoluteDateRange as jest.Mock).mockReturnValue([
 			moment('2025-02-21T00:00:00.000Z'),
 			moment('2025-02-21T23:59:59.000Z'),
 		]);
@@ -373,7 +373,7 @@ describe('paramsToQuerystring', () => {
 	});
 
 	it('converts relative date range to an absolute date range', () => {
-		(dateMathRangeToDateRange as jest.Mock).mockReturnValue([
+		(relativeDateRangeToAbsoluteDateRange as jest.Mock).mockReturnValue([
 			moment('2025-02-21T00:00:00.000Z'),
 			moment('2025-02-21T23:59:59.000Z'),
 		]);
@@ -393,7 +393,7 @@ describe('paramsToQuerystring', () => {
 	});
 
 	it('converts relative date range to a partial absolute date range', () => {
-		(dateMathRangeToDateRange as jest.Mock).mockReturnValue([
+		(relativeDateRangeToAbsoluteDateRange as jest.Mock).mockReturnValue([
 			moment('2025-02-21T00:00:00.000Z'),
 		]);
 

--- a/newswires/client/src/urlState.test.ts
+++ b/newswires/client/src/urlState.test.ts
@@ -1,4 +1,4 @@
-import * as moment from 'moment';
+import moment from 'moment';
 import { dateMathRangeToDateRange } from './dateMathHelpers.ts';
 import {
 	defaultQuery,

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -1,8 +1,8 @@
 import { LAST_TWO_WEEKS, NOW, TWO_WEEKS_AGO } from './dateConstants.ts';
 import {
-	dateMathRangeToDateRange,
 	isRelativeDateNow,
 	isValidDateValue,
+	relativeDateRangeToAbsoluteDateRange,
 } from './dateMathHelpers.ts';
 import type { Config, Query } from './sharedTypes';
 
@@ -99,11 +99,13 @@ export const configToUrl = (config: Config): string => {
 
 const processDateMathRange = (config: Query, useDateTimeValue: boolean) => {
 	if (useDateTimeValue) {
+		// Convert relative dates to ISO-formatted absolute UTC dates, as required by the backend API.
 		if (config.dateRange) {
-			const [maybeStartMoment, maybeEndMoment] = dateMathRangeToDateRange({
-				start: config.dateRange.start,
-				end: config.dateRange.end,
-			});
+			const [maybeStartMoment, maybeEndMoment] =
+				relativeDateRangeToAbsoluteDateRange({
+					start: config.dateRange.start,
+					end: config.dateRange.end,
+				});
 
 			return {
 				...config,

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -2,6 +2,7 @@ import { LAST_TWO_WEEKS, NOW, TWO_WEEKS_AGO } from './dateConstants.ts';
 import {
 	dateMathRangeToDateRange,
 	isRelativeDateNow,
+	isValidDateValue,
 } from './dateMathHelpers.ts';
 import type { Config, Query } from './sharedTypes';
 
@@ -36,8 +37,17 @@ export function urlToConfig(location: {
 
 	const urlSearchParams = new URLSearchParams(location.search);
 	const queryString = urlSearchParams.get('q');
-	const start = urlSearchParams.get('start') ?? LAST_TWO_WEEKS;
-	const end = urlSearchParams.get('end') ?? NOW;
+
+	const startParam = urlSearchParams.get('start');
+	const start =
+		!!startParam && isValidDateValue(startParam) ? startParam : LAST_TWO_WEEKS;
+
+	const endParam = urlSearchParams.get('end');
+	const end = !!endParam && isValidDateValue(endParam) ? endParam : NOW;
+
+	!!endParam &&
+		console.log('isValidDateValue(endParam)', isValidDateValue(endParam));
+
 	const supplier = urlSearchParams.getAll('supplier');
 	const supplierExcl = urlSearchParams.getAll('supplierExcl');
 	const keywords = urlSearchParams.get('keywords') ?? undefined;

--- a/newswires/client/tsconfig.json
+++ b/newswires/client/tsconfig.json
@@ -5,7 +5,7 @@
 		"lib": ["DOM", "DOM.Iterable", "ESNext"],
 		"allowJs": false,
 		"skipLibCheck": true,
-		"esModuleInterop": false,
+		"esModuleInterop": true,
 		"allowSyntheticDefaultImports": true,
 		"allowImportingTsExtensions": true,
 		"strict": true,

--- a/newswires/conf/routes
+++ b/newswires/conf/routes
@@ -7,7 +7,7 @@
 GET     /                           controllers.ViteController.index()
 GET     /feed                       controllers.ViteController.index()
 GET     /item/*id                   controllers.ViteController.item(id: String)
-GET     /api/search                 controllers.QueryController.query(q: Option[String], keywords: Option[String], supplier: List[String], subjects: List[String], subjectsExcl: List[String], categoryCode: List[String], categoryCodeExcl: List[String], beforeId: Option[Int], sinceId: Option[Int])
+GET     /api/search                 controllers.QueryController.query(q: Option[String], keywords: Option[String], supplier: List[String], subjects: List[String], subjectsExcl: List[String], categoryCode: List[String], categoryCodeExcl: List[String], start: Option[String], end: Option[String], beforeId: Option[Int], sinceId: Option[Int])
 GET     /api/keywords               controllers.QueryController.keywords(inLastHours: Option[Int], limit:Option[Int])
 GET     /api/item/:id               controllers.QueryController.item(id: Int, q: Option[String])
 PUT     /api/item/:id/composerId    controllers.QueryController.linkToComposer(id: Int)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Filter stories by date:
1. Provides a way to filter stories by date using relative or/and absolute dates.
2. By default, it only shows stories ingested during the past two weeks.
3. The URL get updated with only required information (e.g. when the end date is set to `now`, it is not necessary to include in the URL).

## How to test

### Date Time Component

1. Click on dropdown to get access to the `Quick select` and `Commonly used` menus.
2. Click on date button (showing `Today` in the screenshot) to get access to the advanced date time menu.

#### Select a relative date range
<img width="474" alt="select-relative-date" src="https://github.com/user-attachments/assets/00bcf496-afd4-476a-8442-57dbb81b3f7a" />

#### Select an advanced date range
<img width="442" alt="select-advanced-date" src="https://github.com/user-attachments/assets/1d68115d-17f0-48a7-8fb1-0c4ceccc6146" />

### Summary

Summarises the selected date range and allows to reset it.

#### Relative date range

Today:
<img width="1223" alt="summary-today" src="https://github.com/user-attachments/assets/08438cac-da38-4bdc-8e18-060afac2cdc3" />

Last 24 hours:
<img width="1221" alt="summary-last-24-hours" src="https://github.com/user-attachments/assets/31ec9303-f7d8-4716-8c48-f4026a8170af" />

#### Absolute date range

<img width="1221" alt="summary-absolute-date-range" src="https://github.com/user-attachments/assets/3b4e0a4e-1ac5-422d-90ba-d28047098e6f" />

### URL

The date range is reflected in the URL.

#### Relative date range

<img width="561" alt="url-relative-date-range" src="https://github.com/user-attachments/assets/24cb67c9-7708-422f-a306-80974e42b5d7" />

#### Partial date range

When the end date is set to `now`, it can be omitted from the URL.

<img width="441" alt="url-partial-relative-date-range" src="https://github.com/user-attachments/assets/24add2bc-cfb7-499d-84f4-60e53c6e9a85" />

#### Absolute date range

<img width="795" alt="url-absolute-date-range" src="https://github.com/user-attachments/assets/96744d92-5398-48ca-b008-2817b12a39f4" />

### History

Updates the history and can be combined with other filters.

#### Simple history
<img width="296" alt="history" src="https://github.com/user-attachments/assets/85e5c453-6903-4e09-9683-c8989764f07d" />

#### Combined history
<img width="297" alt="history-combined" src="https://github.com/user-attachments/assets/23de5676-fe84-4f50-b899-6168c38f02c9" />

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

#### Default date range

<img width="1703" alt="screenshot-last-2-weeks" src="https://github.com/user-attachments/assets/5be51749-7ccb-42a8-bb08-f44b606168c8" />

#### Today

<img width="1704" alt="screenshot-today" src="https://github.com/user-attachments/assets/a84a84a2-1290-4ce5-8497-f511f8b82038" />

#### Restricted

<img width="1705" alt="screenshot-restricted" src="https://github.com/user-attachments/assets/b0187446-626f-4b21-b685-df66aaf591f5" />

#### No results

<img width="1704" alt="screenshot-no-results" src="https://github.com/user-attachments/assets/7cd98233-6787-45ed-9c9f-a5a5f0ca3d94" />

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
