### PR TITLE
Cover more cases when trying to parse error messages

### DIFF
--- a/poller-lambdas/src/index.ts
+++ b/poller-lambdas/src/index.ts
@@ -76,11 +76,13 @@ const pollerWrapper =
 							},
 						};
 						await sqs.send(new SendMessageCommand(message)).catch((error) => {
-							logger.error({
-								message: `Sending to queue failed for ${externalId}`,
-								error: error instanceof Error ? error.message : error,
-								queueMessage: JSON.stringify(message),
-							});
+							logger.error(
+								{
+									message: `Sending to queue failed for ${externalId}`,
+									queueMessage: JSON.stringify(message),
+								},
+								error,
+							);
 							throw error; // we still expect this to be terminal for the poller lambda
 						});
 					}
@@ -119,12 +121,17 @@ const pollerWrapper =
 					}
 				})
 				.catch((error) => {
-					logger.error({
-						message: `Poller lambda failed with message: ${error instanceof Error ? error.message : error}`,
-						sqsMessageId: Records.map((record) => record.messageId).join(', '),
-						eventType: POLLER_FAILURE_EVENT_TYPE,
-						pollerName: pollerFunction.name,
-					});
+					logger.error(
+						{
+							message: `Poller lambda failed with message: ${error instanceof Error ? error.message : error}`,
+							sqsMessageId: Records.map((record) => record.messageId).join(
+								', ',
+							),
+							eventType: POLLER_FAILURE_EVENT_TYPE,
+							pollerName: pollerFunction.name,
+						},
+						error,
+					);
 					// consider still queuing next (perhaps with default delay or 1min) to avoid the lambda from stopping entirely
 					throw error;
 				});

--- a/poller-lambdas/src/pollers/reuters/reutersPoller.ts
+++ b/poller-lambdas/src/pollers/reuters/reutersPoller.ts
@@ -278,6 +278,10 @@ export const reutersPoller = (async ({
 		searchData.push(...data.data.search.items);
 	}
 
+	logger.log({
+		message: `Search returned ${searchData.length} items; fetching details now`,
+	});
+
 	const itemsToFetch = searchData
 		.map((item) => item.versionedGuid)
 		.filter((guid): guid is string => guid !== undefined);
@@ -299,13 +303,16 @@ export const reutersPoller = (async ({
 				const retryResult = await fetchWithReauth(itemQuery(itemId));
 				const retryParsedItemResult = itemResponseSchema.safeParse(retryResult);
 				if (!retryParsedItemResult.success) {
-					logger.error({
-						externalId: itemId,
-						supplier: 'Reuters',
-						eventType: POLLER_FAILURE_EVENT_TYPE,
-						errors: retryParsedItemResult.error.errors,
-						message: `Failed to parse item response for ${itemId} on retry`,
-					});
+					logger.error(
+						{
+							externalId: itemId,
+							supplier: 'Reuters',
+							eventType: POLLER_FAILURE_EVENT_TYPE,
+							errors: parsedItemResult.error.errors,
+							message: `Failed to parse item response for ${itemId} on retry`,
+						},
+						retryParsedItemResult.error,
+					);
 					return;
 				}
 				return retryParsedItemResult.data;

--- a/shared/lambda-logging.ts
+++ b/shared/lambda-logging.ts
@@ -13,7 +13,7 @@ export interface Logger {
 	log: (line: LogLine) => void;
 	debug: (line: LogLine) => void;
 	warn: (line: LogLine) => void;
-	error: (line: LogLine) => void;
+	error: (line: LogLine, error: unknown) => void;
 }
 
 /**
@@ -33,8 +33,47 @@ export function createLogger(defaultFields: Omit<LogLine, 'message'>): Logger {
 		warn: (line: LogLine) => {
 			console.warn(JSON.stringify({ ...defaultFields, ...line }));
 		},
-		error: (line: LogLine) => {
-			console.error(JSON.stringify({ ...defaultFields, ...line }));
+		error: (line: LogLine, error: unknown) => {
+			console.error(
+				JSON.stringify({
+					...defaultFields,
+					error: { ...getErrorMessage(error) },
+					...line,
+				}),
+			);
 		},
 	};
+}
+
+/**
+ * Error parsing utilities, adapted from:
+ * https://kentcdodds.com/blog/get-a-catch-block-error-message-with-typescript
+ */
+type ErrorWithMessage = {
+	message: string;
+};
+
+function isErrorWithMessage(error: unknown): error is ErrorWithMessage {
+	return (
+		typeof error === 'object' &&
+		error !== null &&
+		'message' in error &&
+		typeof (error as Record<string, unknown>).message === 'string'
+	);
+}
+
+function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
+	if (isErrorWithMessage(maybeError)) return maybeError;
+
+	try {
+		return new Error(JSON.stringify(maybeError));
+	} catch {
+		// fallback in case there's an error stringifying the maybeError
+		// like with circular references for example.
+		return new Error(String(maybeError));
+	}
+}
+
+function getErrorMessage(error: unknown) {
+	return toErrorWithMessage(error);
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Try to serialise the whole error object in `logger.error`, rather than just the message.
- Cover more possible options for extracting a useful message from an error ([there are few guarantees about what might be thrown and caught, in js](https://kentcdodds.com/blog/get-a-catch-block-error-message-with-typescript)).

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
