### PR TITLE
re-enable 'automatic minor version upgrades' for the postgres DB

### DIFF
--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -1411,7 +1411,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
       "DeletionPolicy": "Snapshot",
       "Properties": {
         "AllocatedStorage": "100",
-        "AutoMinorVersionUpgrade": false,
+        "AutoMinorVersionUpgrade": true,
         "CACertificateIdentifier": "rds-ca-rsa2048-g1",
         "CopyTagsToSnapshot": true,
         "DBInstanceClass": "db.t4g.small",

--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -78,7 +78,7 @@ export class Newswires extends GuStack {
 			storageType: StorageType.GP3,
 			iops: 3000, // the default for gp3 - not required but nice to declare
 			storageThroughput: 125, // the default for gp3
-			autoMinorVersionUpgrade: false, // FIXME temporary, until rds defaults version 16 to 16.4
+			autoMinorVersionUpgrade: true,
 		});
 
 		const feedsBucket = new GuS3Bucket(this, `feeds-bucket-${this.stage}`, {


### PR DESCRIPTION
We were meaning to do this anyway (see the TODO that are now gone) but it also address an FSBP finding. 

NOTE: Unfortunately we still need to leave the version explicitly set to 16.4 (since CFNs default is 16.3 and it can't downgrade), which kind of makes the autoMinorUpgrades problematic since they will force the CDK out of sync with reality 🙄 .