### PR TITLE
Newswires backend: improve Reuters World filtering

### DIFF
--- a/newswires/app/conf/SearchBuckets.scala
+++ b/newswires/app/conf/SearchBuckets.scala
@@ -638,7 +638,7 @@ object Subjects {
 }
 
 object SearchBuckets {
-  def get(name: String): Option[SearchParams] = name match {
+  def get(name: String): Option[List[SearchParams]] = name match {
     case "reuters-world" => Some(ReutersWorld)
     case "ap-world"      => Some(ApWorld)
     case "aap-world"     => Some(AapWorld)
@@ -671,36 +671,54 @@ object SearchBuckets {
     * However, we should remain open to changing this in response to user feedback.
     */
   // format: on
-  private val ApWorld = SearchParams(
-    text = None,
-    suppliersIncl = List("AP"),
-    keywordIncl = List("World news"),
-    categoryCodesIncl = List("apCat:i", "apCat:a", "apCat:w"),
-    categoryCodesExcl = List("apCat:s", "apCat:e", "apCat:f")
-  )
-
-  private val ReutersWorld = SearchParams(
-    text = None,
-    subjectsIncl = List(
-      "MCC:OVR",
-      "MCC:OEC",
-      "MCCL:OVR",
-      "MCCL:OSM",
-      "N2:US"
-    ),
-    subjectsExcl = List(
-      "N2:GB",
-      "N2:COM",
-      "N2:ECI"
+  private val ApWorld = List(
+    SearchParams(
+      text = None,
+      suppliersIncl = List("AP"),
+      keywordIncl = List("World news"),
+      categoryCodesIncl = List("apCat:i", "apCat:a", "apCat:w"),
+      categoryCodesExcl = List("apCat:s", "apCat:e", "apCat:f")
     )
   )
 
-  private val AapWorld = SearchParams(
-    text = None,
-    suppliersIncl = List("AAP"),
-    keywordExcl = List("Sports"),
-    subjectsExcl = Subjects.sportsRelatedNewsCodes
+  private val ReutersWorld = List(
+    SearchParams(
+      text = Some("News Summary"),
+      suppliersIncl = List("REUTERS"),
+      subjectsIncl = List(
+        "MCC:OEC"
+      ),
+      subjectsExcl = List(
+        "N2:GB",
+        "N2:COM",
+        "N2:ECI"
+      )
+    ),
+    SearchParams(
+      text = None,
+      suppliersIncl = List("REUTERS"),
+      subjectsIncl = List(
+        "MCC:OVR",
+        "MCCL:OVR",
+        "MCCL:OSM",
+        "N2:US"
+      ),
+      subjectsExcl = List(
+        "N2:GB",
+        "N2:COM",
+        "N2:ECI"
+      )
+    )
   )
 
-  private val AllWorld = ApWorld merge ReutersWorld merge AapWorld
+  private val AapWorld = List(
+    SearchParams(
+      text = None,
+      suppliersIncl = List("AAP"),
+      keywordExcl = List("Sports"),
+      subjectsExcl = Subjects.sportsRelatedNewsCodes
+    )
+  )
+
+  private val AllWorld = ApWorld ::: ReutersWorld ::: AapWorld
 }

--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -68,12 +68,16 @@ class QueryController(
       categoryCodesExcl = categoryCodeExcl
     )
 
-    val mergedParams = bucket.map(_ merge queryParams).getOrElse(queryParams)
+    val mergedParamList = bucket match {
+      case Some(queryParamList) => queryParamList.map(_ merge queryParams)
+      case None                 => List(queryParams)
+    }
 
     Ok(
       Json.toJson(
         FingerpostWireEntry.query(
-          mergedParams,
+          mergedParamList,
+          maybeFreeTextQuery,
           maybeBeforeId,
           maybeSinceId,
           pageSize = 30

--- a/newswires/test/db/FingerpostWireEntrySpec.scala
+++ b/newswires/test/db/FingerpostWireEntrySpec.scala
@@ -1,5 +1,6 @@
 package db
 
+import helpers.WhereClauseMatcher.matchWhereClause
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -21,55 +22,43 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers {
     )
 
     val whereClause =
-      FingerpostWireEntry.buildWhereClause(searchParams, None, None)
-    whereClause.value should be(
-      ""
+      FingerpostWireEntry.buildWhereClause(List(searchParams), None, None)
+
+    whereClause should matchWhereClause(
+      expectedClause = "",
+      expectedParams = Nil
     )
-    whereClause.parameters should be(Nil)
   }
 
   it should "generate a where clause for a single field" in {
     val searchParams =
       SearchParams(
-        text = Some("text1"),
-        start = None,
-        end = None,
-        keywordIncl = Nil,
-        keywordExcl = Nil,
-        suppliersIncl = Nil,
-        suppliersExcl = Nil,
-        subjectsIncl = Nil,
-        subjectsExcl = Nil
+        text = Some("text1")
       )
 
     val whereClause =
-      FingerpostWireEntry.buildWhereClause(searchParams, None, None)
-    whereClause.value should be(
-      "WHERE websearch_to_tsquery('english', ?) @@ fm.combined_textsearch"
+      FingerpostWireEntry.buildWhereClause(List(searchParams), None, None)
+
+    whereClause should matchWhereClause(
+      "WHERE websearch_to_tsquery('english', ?) @@ fm.combined_textsearch",
+      expectedParams = List("text1")
     )
-    whereClause.parameters should be(List("text1"))
   }
 
   it should "concatenate keywords, subjects and category codes with 'or'" in {
     val searchParams =
       SearchParams(
         text = None,
-        start = None,
-        end = None,
         keywordIncl = List("keyword1", "keyword2"),
-        keywordExcl = Nil,
-        suppliersExcl = Nil,
         subjectsIncl = List("subject1", "subject2"),
-        subjectsExcl = Nil,
         categoryCodesIncl = List("category1", "category2")
       )
 
     val whereClause =
-      FingerpostWireEntry.buildWhereClause(searchParams, None, None)
-    whereClause.value should be(
-      "WHERE ((fm.content -> 'keywords') ??| ? or (fm.content -> 'subjects' -> 'code') ??| ? or fm.category_codes && ?)"
-    )
-    whereClause.parameters should be(
+      FingerpostWireEntry.buildWhereClause(List(searchParams), None, None)
+
+    whereClause should matchWhereClause(
+      "WHERE ((fm.content -> 'keywords') ??| ? or (fm.content -> 'subjects' -> 'code') ??| ? or fm.category_codes && ?)",
       List(
         List("keyword1", "keyword2"),
         List("subject1", "subject2"),
@@ -82,27 +71,126 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers {
     val searchParams =
       SearchParams(
         text = Some("text1"),
-        keywordExcl = List("keyword1")
+        start = Some("2025-03-10T00:00:00.000Z"),
+        end = Some("2025-03-10T23:59:59.999Z"),
+        suppliersExcl = List("supplier1", "supplier2"),
+        keywordExcl = List("keyword1"),
+        categoryCodesExcl = List("category1", "category2")
       )
 
     val whereClause =
-      FingerpostWireEntry.buildWhereClause(searchParams, Some(1), None)
+      FingerpostWireEntry.buildWhereClause(List(searchParams), Some(1), None)
 
-    whereClause.value.replaceAll("\\s*", " ") should be(
-      """WHERE NOT EXISTS (
-        SELECT FROM fingerpost_wire_entry keywordsExcl
-        WHERE fm.id = keywordsExcl.id
-          AND (keywordsExcl.content->'keywords') ??| ?
-      ) and websearch_to_tsquery('english', ?) @@ fm.combined_textsearch and fm.id < ?"""
-        .replaceAll("\\s*", " ")
-    )
-    whereClause.parameters should be(
+    whereClause should matchWhereClause(
+      """WHERE fm.id < ? and NOT EXISTS (
+        |  SELECT FROM fingerpost_wire_entry keywordsExcl
+        |  WHERE fm.id = keywordsExcl.id
+        |    AND (keywordsExcl.content->'keywords') ??| ?
+        |) and websearch_to_tsquery('english', ?) @@ fm.combined_textsearch and NOT EXISTS (
+        |  SELECT FROM fingerpost_wire_entry sourceFeedsExcl
+        |  WHERE fm.id = sourceFeedsExcl.id
+        |    AND  upper(sourceFeedsExcl.supplier) in (upper(?), upper(?))
+        |) and (fm.ingested_at BETWEEN CAST(? AS timestamptz) AND CAST(? AS timestamptz)) and NOT EXISTS (
+        |  SELECT FROM fingerpost_wire_entry categoryCodesExcl
+        |  WHERE fm.id = categoryCodesExcl.id
+        |    AND categoryCodesExcl.category_codes && ?
+        |)""".stripMargin,
       List(
+        1,
         List("keyword1"),
         "text1",
-        1
+        "supplier1",
+        "supplier2",
+        "2025-03-10T00:00:00.000Z",
+        "2025-03-10T23:59:59.999Z",
+        List("category1", "category2")
       )
     )
   }
 
+  it should "Should cast a lower bound date only" in {
+    val searchParams = SearchParams(
+      text = None,
+      start = Some("2025-03-10T00:00:00.000Z")
+    )
+
+    val whereClause =
+      FingerpostWireEntry.buildWhereClause(List(searchParams), None, None)
+
+    whereClause should matchWhereClause(
+      "WHERE fm.ingested_at >= CAST(? AS timestamptz)",
+      List("2025-03-10T00:00:00.000Z")
+    )
+  }
+
+  it should "Should cast an upper bound date only" in {
+    val searchParams = SearchParams(
+      text = None,
+      end = Some("2025-03-10T23:59:59.999Z")
+    )
+
+    val whereClause =
+      FingerpostWireEntry.buildWhereClause(List(searchParams), None, None)
+
+    whereClause should matchWhereClause(
+      "WHERE fm.ingested_at <= CAST(? AS timestamptz)",
+      List("2025-03-10T23:59:59.999Z")
+    )
+  }
+
+  it should "should join complex bucket presets using 'or'" in {
+    val searchParamList = List(
+      SearchParams(
+        text = Some("News Summary"),
+        suppliersIncl = List("REUTERS"),
+        subjectsIncl = List(
+          "MCC:OEC"
+        ),
+        subjectsExcl = List(
+          "N2:GB",
+          "N2:COM",
+          "N2:ECI"
+        )
+      ),
+      SearchParams(
+        text = None,
+        suppliersIncl = List("REUTERS"),
+        subjectsIncl = List(
+          "MCC:OVR",
+          "MCCL:OVR",
+          "MCCL:OSM",
+          "N2:US"
+        ),
+        subjectsExcl = List(
+          "N2:GB",
+          "N2:COM",
+          "N2:ECI"
+        )
+      )
+    )
+
+    val whereClause =
+      FingerpostWireEntry.buildWhereClause(searchParamList, None, None)
+
+    whereClause should matchWhereClause(
+      """WHERE ((fm.content -> 'subjects' -> 'code') ??| ? and NOT EXISTS (
+        |  SELECT FROM fingerpost_wire_entry subjectsExcl
+        |  WHERE fm.id = subjectsExcl.id
+        |    AND (subjectsExcl.content->'subjects'->'code') ??| ?
+        |) and websearch_to_tsquery('english', ?) @@ fm.combined_textsearch and  upper(fm.supplier) in (upper(?))) or ((fm.content -> 'subjects' -> 'code') ??| ? and NOT EXISTS (
+        |  SELECT FROM fingerpost_wire_entry subjectsExcl
+        |  WHERE fm.id = subjectsExcl.id
+        |    AND (subjectsExcl.content->'subjects'->'code') ??| ?
+        |) and  upper(fm.supplier) in (upper(?)))""".stripMargin,
+      List(
+        List("MCC:OEC"),
+        List("N2:GB", "N2:COM", "N2:ECI"),
+        "News Summary",
+        "REUTERS",
+        List("MCC:OVR", "MCCL:OVR", "MCCL:OSM", "N2:US"),
+        List("N2:GB", "N2:COM", "N2:ECI"),
+        "REUTERS"
+      )
+    )
+  }
 }

--- a/newswires/test/helpers/WhereClauseMatcher.scala
+++ b/newswires/test/helpers/WhereClauseMatcher.scala
@@ -1,0 +1,27 @@
+package helpers
+
+import org.scalatest.matchers.{MatchResult, Matcher}
+import scalikejdbc.SQLSyntax
+
+object WhereClauseMatcher {
+  def matchWhereClause(
+      expectedClause: String,
+      expectedParams: List[Any]
+  ): Matcher[SQLSyntax] =
+    (left: SQLSyntax) => {
+      // Standardise the SQL strings by removing whitespace.
+      val standardise: String => String = _.replaceAll("\\s*", " ")
+
+      val standardisedActual = standardise(left.value)
+      val standardisedExpected = standardise(expectedClause)
+
+      val clauseMatches = standardisedActual == standardisedExpected
+      val paramsMatch = left.parameters == expectedParams
+
+      MatchResult(
+        clauseMatches && paramsMatch,
+        s"WHERE clause did not match:\nExpected clause: [$expectedClause] with parameters: [$expectedParams]\nActual clause: [${left.value}] with parameters: [${left.parameters}]",
+        "WHERE clause matched as expected."
+      )
+    }
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Only include the Economic news subject code (MCC:OEC) when the headline includes "News Summary".

Reference: https://github.com/guardian/newswires/pull/154

Buckets can now have a multiple search params in order to only filter `MCC:OEC` stories by headline.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
