### PR TITLE
Add basic SQL generation tests

### DIFF
--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -326,7 +326,6 @@ object FingerpostWireEntry
       sourceFeedsQuery,
       sourceFeedsExclQuery,
       dateRangeQuery,
-      categoryCodesInclQuery,
       categoryCodesExclQuery
     ).flatten ++ dataOnlyWhereClauses match {
       case Nil        => sqls""

--- a/newswires/build.sbt
+++ b/newswires/build.sbt
@@ -19,6 +19,7 @@ libraryDependencies += "org.scalikejdbc" %% "scalikejdbc" % "3.5.0"
 libraryDependencies += "org.postgresql" % "postgresql" % "42.7.5"
 libraryDependencies += "software.amazon.jdbc" % "aws-advanced-jdbc-wrapper" % "2.3.7"
 
+libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.8" % "test"
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % Test
 
 lazy val root = (project in file(".")).enablePlugins(

--- a/newswires/test/db/FingerpostWireEntrySpec.scala
+++ b/newswires/test/db/FingerpostWireEntrySpec.scala
@@ -1,0 +1,82 @@
+package db
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers {
+
+  behavior of "FingerpostWireEntry.generateWhereClause"
+
+  it should "generate an empty where clause for a empty set of search params" in {
+    val searchParams = SearchParams(
+      text = None,
+      start = None,
+      end = None,
+      keywordIncl = Nil,
+      keywordExcl = Nil,
+      suppliersIncl = Nil,
+      suppliersExcl = Nil,
+      subjectsIncl = Nil,
+      subjectsExcl = Nil
+    )
+
+    val whereClause =
+      FingerpostWireEntry.buildWhereClause(searchParams, None, None)
+    whereClause.value should be(
+      ""
+    )
+    whereClause.parameters should be(Nil)
+  }
+
+  it should "generate a where clause for a single field" in {
+    val searchParams =
+      SearchParams(
+        text = Some("text1"),
+        start = None,
+        end = None,
+        keywordIncl = Nil,
+        keywordExcl = Nil,
+        suppliersIncl = Nil,
+        suppliersExcl = Nil,
+        subjectsIncl = Nil,
+        subjectsExcl = Nil
+      )
+
+    val whereClause =
+      FingerpostWireEntry.buildWhereClause(searchParams, None, None)
+    whereClause.value should be(
+      "WHERE websearch_to_tsquery('english', ?) @@ fm.combined_textsearch"
+    )
+    whereClause.parameters should be(List("text1"))
+  }
+
+  it should "concatenate keywords and subjects with 'or'" in {
+    val searchParams =
+      SearchParams(
+        text = None,
+        start = None,
+        end = None,
+        keywordIncl = List("keyword1", "keyword2"),
+        keywordExcl = Nil,
+        suppliersExcl = Nil,
+        subjectsIncl = List("subject1", "subject2"),
+        subjectsExcl = Nil,
+        categoryCodesIncl = List("category1", "category2")
+      )
+
+    val whereClause =
+      FingerpostWireEntry.buildWhereClause(searchParams, None, None)
+    whereClause.value should be(
+      "WHERE ((fm.content -> 'keywords') ??| ? or (fm.content -> 'subjects' -> 'code') ??| ? or fm.category_codes && ?) and fm.category_codes && ?"
+    )
+    whereClause.parameters should be(
+      List(
+        List("keyword1", "keyword2"),
+        List("subject1", "subject2"),
+        List("category1", "category2"),
+        List("category1", "category2")
+      )
+    )
+  }
+
+}

--- a/newswires/test/db/FingerpostWireEntrySpec.scala
+++ b/newswires/test/db/FingerpostWireEntrySpec.scala
@@ -67,13 +67,12 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers {
     val whereClause =
       FingerpostWireEntry.buildWhereClause(searchParams, None, None)
     whereClause.value should be(
-      "WHERE ((fm.content -> 'keywords') ??| ? or (fm.content -> 'subjects' -> 'code') ??| ? or fm.category_codes && ?) and fm.category_codes && ?"
+      "WHERE ((fm.content -> 'keywords') ??| ? or (fm.content -> 'subjects' -> 'code') ??| ? or fm.category_codes && ?)"
     )
     whereClause.parameters should be(
       List(
         List("keyword1", "keyword2"),
         List("subject1", "subject2"),
-        List("category1", "category2"),
         List("category1", "category2")
       )
     )


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Our SQL query building is getting sufficiently complex that it feels sensible to have some unit tests documenting the way we expect a given set of `SearchParams` to be rendered in SQL.

There's a risk of over-testing implementation details, so I've just added a couple of basic tests for now. One of them has already caught a small bug (the category codes inclusion clause being added twice) which I've fixed here too.

Having some level of test coverage here will hopefully help us document changes and catch accidental regressions.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
