### PR TITLE
Add metadata table for wire item

### DIFF
--- a/newswires/client/src/Disclosure.stories.tsx
+++ b/newswires/client/src/Disclosure.stories.tsx
@@ -1,0 +1,67 @@
+import { EuiProvider, EuiText } from '@elastic/eui';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Disclosure } from './Disclosure';
+import { setUpIcons } from './icons';
+
+export default { component: Disclosure };
+const meta = {
+	title: 'Components/Disclosure',
+	component: Disclosure,
+	parameters: {
+		layout: 'padded',
+	},
+	tags: ['autodocs'],
+	decorators: [
+		(Story) => (
+			<EuiProvider colorMode="light">
+				<div style={{ maxWidth: '400px', margin: '10px auto' }}>
+					<Story />
+				</div>
+			</EuiProvider>
+		),
+	],
+} satisfies Meta<typeof Disclosure>;
+
+type Story = StoryObj<typeof meta>;
+
+setUpIcons();
+
+export const Default: Story = {
+	args: {
+		title: 'Click to expand',
+		children: (
+			<EuiText>
+				<p>This is the content that appears when expanded.</p>
+				<p>It can contain multiple paragraphs or any other content.</p>
+			</EuiText>
+		),
+	},
+};
+
+export const WithLongContent: Story = {
+	args: {
+		title: 'Long content example',
+		children: (
+			<EuiText>
+				<p>
+					This is the content that appears when expanded. It can contain
+					multiple paragraphs or any other content. This is the content that
+					appears when expanded. It can contain multiple paragraphs or any other
+					content. This is the content that appears when expanded. It can
+					contain multiple paragraphs or any other content. This is the content
+					that appears when expanded. It can contain multiple paragraphs or any
+					other content.
+				</p>
+				<p>
+					This is the content that appears when expanded. It can contain
+					multiple paragraphs or any other content. This is the content that
+					appears when expanded. It can contain multiple paragraphs or any other
+					content. This is the content that appears when expanded. It can
+					contain multiple paragraphs or any other content. This is the content
+					that appears when expanded. It can contain multiple paragraphs or any
+					other content.
+				</p>
+			</EuiText>
+		),
+	},
+};

--- a/newswires/client/src/Disclosure.tsx
+++ b/newswires/client/src/Disclosure.tsx
@@ -1,0 +1,52 @@
+import { EuiIcon } from '@elastic/eui';
+import { css } from '@emotion/react';
+
+export const Disclosure = ({
+	title,
+	children,
+}: {
+	title: string;
+	children: React.ReactNode;
+}) => {
+	return (
+		<div
+			css={css`
+				summary::-webkit-details-marker {
+					display: none;
+				}
+				summary {
+					list-style: none;
+				}
+				details summary {
+					display: flex;
+					align-items: center;
+					gap: 0.5rem;
+					cursor: pointer;
+
+					& svg {
+						transition: transform 0.3s;
+					}
+				}
+				details[open] summary svg {
+					/* rotate 90 degrees */
+					transform: rotate(90deg);
+				}
+			`}
+		>
+			<details>
+				<summary>
+					<EuiIcon type="arrowRight" />
+					<span>{title}</span>
+				</summary>
+				<div
+					css={css`
+						margin-top: 1rem;
+						padding-left: 1rem;
+					`}
+				>
+					{children}
+				</div>
+			</details>
+		</div>
+	);
+};

--- a/newswires/client/src/Disclosure.tsx
+++ b/newswires/client/src/Disclosure.tsx
@@ -3,9 +3,11 @@ import { css } from '@emotion/react';
 
 export const Disclosure = ({
 	title,
+	defaultOpen,
 	children,
 }: {
 	title: string;
+	defaultOpen?: boolean;
 	children: React.ReactNode;
 }) => {
 	return (
@@ -33,7 +35,7 @@ export const Disclosure = ({
 				}
 			`}
 		>
-			<details>
+			<details open={defaultOpen}>
 				<summary>
 					<EuiIcon type="arrowRight" />
 					<span>{title}</span>

--- a/newswires/client/src/Item.stories.tsx
+++ b/newswires/client/src/Item.stories.tsx
@@ -15,7 +15,7 @@ const sampleItemData = {
 		usage: 'No restrictions',
 		ednote: 'This is an editorial note',
 		subjects: {
-			code: ['politics', 'technology', 'science'],
+			code: ['iptccat:SPO', 'technology'],
 		},
 		slug: 'SAMPLE-WIRE',
 		headline: 'This is a sample headline',

--- a/newswires/client/src/Item.stories.tsx
+++ b/newswires/client/src/Item.stories.tsx
@@ -19,6 +19,9 @@ const sampleItemData = {
 		},
 		slug: 'SAMPLE-WIRE',
 		headline: 'This is a sample headline',
+		firstVersion: '2025-02-26T09:56:22.000Z',
+		versionCreated: '2025-02-26T09:57:22.000Z',
+		version: '2',
 	},
 	highlight:
 		'<p>This is a sample news wire story.</p><p>It contains multiple paragraphs, <a href="#">a link</a>, and some <mark>highlighted</mark> text.</p>',

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -118,6 +118,54 @@ function SubjectTable({ subjects }: { subjects: string[] }) {
 	);
 }
 
+function MetaTable({ wire }: { wire: WireData }) {
+	const { externalId, ingestedAt } = wire;
+	const { firstVersion, status, versionCreated, version } = wire.content;
+
+	const metaItems = [
+		{
+			title: 'Status',
+			description: status ?? 'N/A',
+		},
+		{
+			title: 'External ID',
+			description: externalId,
+		},
+		{
+			title: 'Ingested at',
+			description: ingestedAt,
+		},
+		{
+			title: 'First version',
+			description: firstVersion ?? 'N/A',
+		},
+		{
+			title: 'This version created',
+			description: versionCreated ?? 'N/A',
+		},
+		{
+			title: 'Version',
+			description: version ?? 'N/A',
+		},
+	];
+
+	return (
+		<Disclosure title="General" defaultOpen={true}>
+			<EuiBasicTable
+				columns={[
+					{ field: 'title', name: '' },
+					{ field: 'description', name: 'Description' },
+				]}
+				items={metaItems.map(({ title, description }) => ({
+					title,
+					description,
+				}))}
+				tableLayout="auto"
+			/>
+		</Disclosure>
+	);
+}
+
 export const WireDetail = ({
 	wire,
 	isShowingJson,
@@ -254,6 +302,8 @@ export const WireDetail = ({
 						</EuiDescriptionListDescription>
 						<EuiDescriptionListTitle>Metadata</EuiDescriptionListTitle>
 						<EuiDescriptionListDescription>
+							<MetaTable wire={wire} />
+							<EuiSpacer />
 							<SubjectTable subjects={subjects?.code ?? []} />
 							<EuiSpacer />
 						</EuiDescriptionListDescription>

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -1,5 +1,8 @@
+import type { EuiBasicTableColumn } from '@elastic/eui';
 import {
 	EuiBadge,
+	EuiBasicTable,
+	EuiButtonIcon,
 	EuiCallOut,
 	EuiCodeBlock,
 	EuiDescriptionList,
@@ -7,8 +10,6 @@ import {
 	EuiDescriptionListTitle,
 	EuiFlexGroup,
 	EuiFlexItem,
-	EuiListGroupItem,
-	EuiPanel,
 	EuiScreenReaderOnly,
 	EuiSpacer,
 	EuiText,
@@ -21,6 +22,7 @@ import sanitizeHtml from 'sanitize-html';
 import { lookupCatCodesWideSearch } from './catcodes-lookup';
 import { ComposerConnection } from './ComposerConnection.tsx';
 import { useSearch } from './context/SearchContext.tsx';
+import { Disclosure } from './Disclosure.tsx';
 import type { WireData } from './sharedTypes';
 
 function TitleContentForItem({
@@ -41,20 +43,34 @@ function TitleContentForItem({
 	return <>{slug ?? 'No title'}</>;
 }
 
-export const WireDetail = ({
-	wire,
-	isShowingJson,
-}: {
-	wire: WireData;
-	isShowingJson: boolean;
-}) => {
+type SubjectTableItem = {
+	code: string;
+	labels: string;
+	isSelected: boolean;
+};
+
+function SubjectTable({ subjects }: { subjects: string[] }) {
 	const { handleEnterQuery, config } = useSearch();
-	const theme = useEuiTheme();
-	const { byline, keywords, usage, ednote, subjects, headline, slug } =
-		wire.content;
+
+	const isSubjectInSearch = (subject: string) => {
+		const subjects = config.query.subjects ?? [];
+		return subjects.includes(subject);
+	};
+
+	const nonEmptySubjects = subjects.filter(
+		(subject) => subject.trim().length > 0,
+	);
+	const subjectTableItems: SubjectTableItem[] = nonEmptySubjects.map(
+		(subject) => ({
+			code: subject,
+			labels: lookupCatCodesWideSearch(subject).join('; '),
+			isSelected: isSubjectInSearch(subject),
+		}),
+	);
 
 	const handleSubjectClick = (subject: string) => {
 		const subjects = config.query.subjects ?? [];
+		console.log('handleSubjectClick', subject, subjects);
 		handleEnterQuery({
 			...config.query,
 			subjects: subjects.includes(subject)
@@ -63,10 +79,55 @@ export const WireDetail = ({
 		});
 	};
 
-	const isSubjectInSearch = (subject: string) => {
-		const subjects = config.query.subjects ?? [];
-		return subjects.includes(subject);
-	};
+	const columns: Array<EuiBasicTableColumn<SubjectTableItem>> = [
+		{
+			field: 'code',
+			name: 'Subject code',
+		},
+		{
+			field: 'labels',
+			name: 'Subject label(s)',
+		},
+		{
+			field: 'isSelected',
+			name: 'Filter by?',
+			align: 'right',
+			render: (isSelected, item) => (
+				<EuiButtonIcon
+					color={isSelected ? 'primary' : 'accent'}
+					onClick={() => handleSubjectClick(item.code)}
+					iconType={isSelected ? 'check' : 'plusInCircle'}
+					aria-label="Toggle selection"
+				/>
+			),
+		},
+	];
+
+	return (
+		<Disclosure title={`Subjects (${subjectTableItems.length})`}>
+			{subjectTableItems.length === 0 ? (
+				'No subject information available'
+			) : (
+				<EuiBasicTable
+					items={subjectTableItems}
+					columns={columns}
+					tableLayout="auto"
+				/>
+			)}
+		</Disclosure>
+	);
+}
+
+export const WireDetail = ({
+	wire,
+	isShowingJson,
+}: {
+	wire: WireData;
+	isShowingJson: boolean;
+}) => {
+	const theme = useEuiTheme();
+	const { byline, keywords, usage, ednote, subjects, headline, slug } =
+		wire.content;
 
 	const safeBodyText = useMemo(() => {
 		return wire.content.bodyText
@@ -85,11 +146,6 @@ export const WireDetail = ({
 	const nonEmptyKeywords = useMemo(
 		() => keywords?.filter((keyword) => keyword.trim().length > 0) ?? [],
 		[keywords],
-	);
-
-	const nonEmptySubjects = useMemo(
-		() => subjects?.code.filter((subject) => subject.trim().length > 0) ?? [],
-		[subjects],
 	);
 
 	return (
@@ -168,70 +224,6 @@ export const WireDetail = ({
 								</EuiDescriptionListDescription>
 							</>
 						)}
-						{nonEmptySubjects.length > 0 && (
-							<>
-								<EuiDescriptionListTitle>Subjects</EuiDescriptionListTitle>
-								<EuiDescriptionListDescription>
-									<EuiPanel>
-										<section
-											css={css`
-												max-height: 200px;
-												overflow-y: auto;
-											`}
-										>
-											<EuiDescriptionList>
-												{nonEmptySubjects.map((subject) => (
-													<>
-														<EuiDescriptionListTitle>
-															<EuiText size="s">
-																<EuiBadge
-																	iconType={
-																		isSubjectInSearch(subject)
-																			? 'cross'
-																			: undefined
-																	}
-																	color={
-																		!isSubjectInSearch(subject)
-																			? 'hollow'
-																			: undefined
-																	}
-																	iconSide="right"
-																	onClickAriaLabel={`Filter search by "${subject}" subjects`}
-																	onClick={() => handleSubjectClick(subject)}
-																>
-																	{subject}
-																</EuiBadge>
-															</EuiText>
-														</EuiDescriptionListTitle>
-														<EuiDescriptionListDescription key={subject}>
-															{lookupCatCodesWideSearch(subject).length > 0 ? (
-																<>
-																	{lookupCatCodesWideSearch(subject).map(
-																		(category) => (
-																			<EuiListGroupItem
-																				key={category}
-																				label={category}
-																				size="xs"
-																				iconType={'dot'}
-																				wrapText={true}
-																			></EuiListGroupItem>
-																		),
-																	)}
-																</>
-															) : (
-																<EuiText color="danger" key={subject} size="xs">
-																	No category label found
-																</EuiText>
-															)}
-														</EuiDescriptionListDescription>
-													</>
-												))}
-											</EuiDescriptionList>
-										</section>
-									</EuiPanel>
-								</EuiDescriptionListDescription>
-							</>
-						)}
 						{nonEmptyKeywords.length > 0 && (
 							<>
 								<EuiDescriptionListTitle>Keywords</EuiDescriptionListTitle>
@@ -259,6 +251,11 @@ export const WireDetail = ({
 						<EuiDescriptionListTitle>Composer</EuiDescriptionListTitle>
 						<EuiDescriptionListDescription>
 							<ComposerConnection itemData={wire} key={wire.id} />
+						</EuiDescriptionListDescription>
+						<EuiDescriptionListTitle>Metadata</EuiDescriptionListTitle>
+						<EuiDescriptionListDescription>
+							<SubjectTable subjects={subjects?.code ?? []} />
+							<EuiSpacer />
 						</EuiDescriptionListDescription>
 					</EuiDescriptionList>
 				</>

--- a/newswires/client/src/icons.ts
+++ b/newswires/client/src/icons.ts
@@ -27,6 +27,7 @@ import { icon as menu } from '@elastic/eui/es/components/icon/assets/menu';
 import { icon as menuLeft } from '@elastic/eui/es/components/icon/assets/menuLeft';
 import { icon as menuRight } from '@elastic/eui/es/components/icon/assets/menuRight';
 import { icon as pin } from '@elastic/eui/es/components/icon/assets/pin_filled';
+import { icon as plusInCircle } from '@elastic/eui/es/components/icon/assets/plus_in_circle';
 import { icon as popout } from '@elastic/eui/es/components/icon/assets/popout';
 import { icon as refresh } from '@elastic/eui/es/components/icon/assets/refresh';
 import { icon as returnKey } from '@elastic/eui/es/components/icon/assets/return_key';
@@ -70,6 +71,7 @@ const icons = {
 	iInCircle,
 	kqlFunction,
 	filter,
+	plusInCircle,
 };
 
 // One or more icons are passed in as an object of iconKey (string): IconComponent


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Add a simple 'Disclosure' component (12a310b67c2b628239e360cb9ae4a73b356cad6a)
- Add a 'Metadata' section to the wire Item view:
  - Move 'subjects' to a table in this section (collapsed by default -- some items have 80+ subjects!) (bb1ccd6511709046c3cddb292428de92daefbcd1)
  - Also add a 'general metadata' table, open by default (7f8373db59a16ee27056c53f3f8b1a1be0e80479)

**nb.** Currently showing 'content.subjects', but I'm planning to switch this over to the top-level 'categoryCodes' list once all the suppliers are having this set properly.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- `npm run storybook`
- or `./scripts/start --use-CODE`

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

Hopefully interested parties will be able to find what they want, whereas uninterested parties won't be distracted by long lists of subjects etc.

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="554" alt="image" src="https://github.com/user-attachments/assets/200ea031-115f-4b0d-9eda-9b5d546d457d" />


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
