### PR TITLE
Fix behaviour based on feature switch

### DIFF
--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -48,8 +48,8 @@ class QueryController(
     val bucket = request.getQueryString("bucket").flatMap(SearchBuckets.get)
 
     val suppliersToExcludeByDefault =
-      if (FeatureSwitchProvider.ShowGuSuppliers.isOn) List("GuReuters", "GuAP")
-      else Nil
+      if (FeatureSwitchProvider.ShowGuSuppliers.isOn) Nil
+      else List("GuReuters", "GuAP")
 
     val queryParams = SearchParams(
       text = maybeFreeTextQuery,


### PR DESCRIPTION
We want to exclude feeds from our own pollers if the `showGuSuppliers` switch is _off_, not _on_ 🤦 