### PR TITLE
Put comet and wirefast into 'minor agencies' supplier, update PA sourcefeed list

### DIFF
--- a/ingestion-lambda/src/suppliers.ts
+++ b/ingestion-lambda/src/suppliers.ts
@@ -92,13 +92,14 @@ const supplierLookupMap: Record<string, string[]> = {
 		'PA PRESSWIRE',
 		'PA EDREAMS ODIGEO',
 		'PA TRUSSEL',
-		'PA ACCESS NEWSWIRE'
+		'PA ACCESS NEWSWIRE',
 	],
-	COMET: ['COMET'],
-	WIREFAST: ['WIREFAST'],
+	MINOR_AGENCIES: ['COMET', 'WIREFAST'],
 };
 
-export const lookupSupplier = (supplier: string | undefined ): string | undefined => {
+export const lookupSupplier = (
+	supplier: string | undefined,
+): string | undefined => {
 	if (!supplier) {
 		return undefined;
 	}
@@ -106,4 +107,4 @@ export const lookupSupplier = (supplier: string | undefined ): string | undefine
 	return Object.keys(supplierLookupMap).find((key) =>
 		supplierLookupMap[key]?.includes(supplier),
 	);
-}
+};

--- a/ingestion-lambda/src/suppliers.ts
+++ b/ingestion-lambda/src/suppliers.ts
@@ -88,8 +88,14 @@ const supplierLookupMap: Record<string, string[]> = {
 		'PA HSL',
 		'PA JUST GROUP',
 		'PA BROOKE ACTION FOR WORKING HORSES AND DONKEYS',
+		'PA ZEN INTERNET',
+		'PA PRESSWIRE',
+		'PA EDREAMS ODIGEO',
+		'PA TRUSSEL',
+		'PA ACCESS NEWSWIRE'
 	],
 	COMET: ['COMET'],
+	WIREFAST: ['WIREFAST'],
 };
 
 export const lookupSupplier = (supplier: string | undefined ): string | undefined => {

--- a/newswires/client/src/suppliers.ts
+++ b/newswires/client/src/suppliers.ts
@@ -38,13 +38,9 @@ const allSupplierData: Record<
 		label: 'Reuters (Gu)',
 		colour: reutersBrand,
 	},
-	COMET: {
-		label: 'Comet',
+	MINOR_AGENCIES: {
+		label: 'Minor agencies',
 		colour: '#39756a',
-	},
-	WIREFAST: {
-		label: 'Wirefast',
-		colour: '#f2d600',
 	},
 };
 

--- a/newswires/client/src/suppliers.ts
+++ b/newswires/client/src/suppliers.ts
@@ -42,6 +42,10 @@ const allSupplierData: Record<
 		label: 'Comet',
 		colour: '#39756a',
 	},
+	WIREFAST: {
+		label: 'Wirefast',
+		colour: '#f2d600',
+	},
 };
 
 export function getSupplierInfo(


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

```
newswires=> select distinct(content->>'source-feed') from fingerpost_wire_entry where supplier='Unknown';
      ?column?      
--------------------
 WIREFAST
 PA ZEN INTERNET
 PA PRESSWIRE
 PA EDREAMS ODIGEO
 PA TRUSSEL
 PA ACCESS NEWSWIRE
(6 rows)
```

Looks like Wirefast is sticking around for the time being. The rest look like they're clearly from PA.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
