### PR TITLE
Fix mismatch between metric filter and logging

### DIFF
--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -1105,7 +1105,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
     },
     "IngestionSourceFeeds54B3095A": {
       "Properties": {
-        "FilterPattern": "{ $.message.eventType = "INGESTION_SUCCESS" }",
+        "FilterPattern": "{ $.eventType = "INGESTION_SUCCESS" }",
         "LogGroupName": {
           "Fn::Join": [
             "",
@@ -1121,8 +1121,8 @@ exports[`The Newswires stack matches the snapshot 1`] = `
           {
             "Dimensions": [
               {
-                "Key": "sourceFeed",
-                "Value": "$.message.sourceFeed",
+                "Key": "supplier",
+                "Value": "$.supplier",
               },
             ],
             "MetricName": "IngestionSourceFeeds",

--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -148,11 +148,11 @@ export class Newswires extends GuStack {
 			metricName: 'IngestionSourceFeeds',
 			metricValue: '1',
 			filterPattern: aws_logs.FilterPattern.stringValue(
-				'$.message.eventType',
+				'$.eventType',
 				'=',
 				SUCCESSFUL_INGESTION_EVENT_TYPE,
 			),
-			dimensions: { sourceFeed: '$.message.sourceFeed' },
+			dimensions: { supplier: '$.supplier' },
 		});
 
 		const scheduledCleanupLambda = new GuScheduledLambda(

--- a/ingestion-lambda/src/handler.ts
+++ b/ingestion-lambda/src/handler.ts
@@ -178,14 +178,6 @@ export const main = async (event: SQSEvent): Promise<SQSBatchResponse> => {
 								sqsMessageId,
 							});
 						} else {
-							// this logging format is for the Cloudwatch Metric Filter
-							console.log({
-								externalId,
-								supplier,
-								sourceFeed: snsMessageContent['source-feed'],
-								eventType: SUCCESSFUL_INGESTION_EVENT_TYPE,
-							});
-							// this logging format is for ELK
 							logger.log({
 								message: `Successfully processed message for ${sqsMessageId}`,
 								eventType: SUCCESSFUL_INGESTION_EVENT_TYPE,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The metric filter wasn't working, perhaps because we changed the logging format to work with ELK. Either way, currently the data we're logging for ELK is also parseable by Cloudwatch, but the field it was looking for in the metric filter wasn't on _that_ logging.

Solution: Adapt the metric filter to match the existing ELK logging (switching it over to care about supplier now, instead of source feed, as that's the more useful thing to graph) and delete the other logging as it was only there for the metric before.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Deploy to CODE, check it works

<img width="648" alt="image" src="https://github.com/user-attachments/assets/eb28fc86-8736-4f88-b43c-390a304e29fa" />


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
