### PR TITLE
Newswires UI: make timestamps consistent

### DIFF
--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -5,7 +5,7 @@ import play.api.Logging
 import play.api.libs.json._
 import scalikejdbc._
 
-import java.time.ZonedDateTime
+import java.time.{Instant, ZonedDateTime}
 
 case class FingerpostWireSubjects(
     code: List[String]
@@ -67,7 +67,7 @@ case class FingerpostWireEntry(
     id: Long,
     supplier: String,
     externalId: String,
-    ingestedAt: ZonedDateTime,
+    ingestedAt: Instant,
     content: FingerpostWire,
     composerId: Option[String],
     composerSentBy: Option[String],
@@ -125,7 +125,7 @@ object FingerpostWireEntry
       id = rs.long(fm.id),
       supplier = rs.string(fm.supplier),
       externalId = rs.string(fm.externalId),
-      ingestedAt = rs.zonedDateTime(fm.ingestedAt),
+      ingestedAt = rs.zonedDateTime(fm.ingestedAt).toInstant,
       content = fingerpostContent,
       composerId = rs.stringOpt(fm.composerId),
       composerSentBy = rs.stringOpt(fm.composerSentBy),

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -22,6 +22,7 @@ import sanitizeHtml from 'sanitize-html';
 import { lookupCatCodesWideSearch } from './catcodes-lookup';
 import { ComposerConnection } from './ComposerConnection.tsx';
 import { useSearch } from './context/SearchContext.tsx';
+import { convertToLocalDate } from './dateHelpers.ts';
 import { Disclosure } from './Disclosure.tsx';
 import type { WireData } from './sharedTypes';
 
@@ -144,15 +145,15 @@ function MetaTable({ wire }: { wire: WireData }) {
 		},
 		{
 			title: 'Ingested at',
-			description: ingestedAt,
+			description: convertToLocalDate(ingestedAt),
 		},
 		{
 			title: 'First version',
-			description: firstVersion ?? 'N/A',
+			description: firstVersion ? convertToLocalDate(firstVersion) : 'N/A',
 		},
 		{
 			title: 'This version created',
-			description: versionCreated ?? 'N/A',
+			description: versionCreated ? convertToLocalDate(versionCreated) : 'N/A',
 		},
 		{
 			title: 'Version',

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -47,18 +47,21 @@ export const WireItemList = ({
 	return (
 		<>
 			<ul>
-				{wires.map(({ id, content, supplier, highlight, isFromRefresh }) => (
-					<li key={id}>
-						<WirePreviewCard
-							id={id}
-							supplier={supplier}
-							content={content}
-							isFromRefresh={isFromRefresh}
-							highlight={highlight}
-							selected={selectedWireId == id.toString()}
-						/>
-					</li>
-				))}
+				{wires.map(
+					({ id, content, supplier, highlight, isFromRefresh, ingestedAt }) => (
+						<li key={id}>
+							<WirePreviewCard
+								id={id}
+								ingestedAt={ingestedAt}
+								supplier={supplier}
+								content={content}
+								isFromRefresh={isFromRefresh}
+								highlight={highlight}
+								selected={selectedWireId == id.toString()}
+							/>
+						</li>
+					),
+				)}
 			</ul>
 			{wires.length < totalCount && (
 				<EuiButton
@@ -142,12 +145,14 @@ function MaybeSecondaryCardContent({
 const WirePreviewCard = ({
 	id,
 	supplier,
+	ingestedAt,
 	content,
 	highlight,
 	selected,
 }: {
 	id: number;
 	supplier: string;
+	ingestedAt: string;
 	content: WireData['content'];
 	highlight: string | undefined;
 	selected: boolean;
@@ -199,6 +204,7 @@ const WirePreviewCard = ({
 							background-color: ${theme.euiTheme.colors.lightestShade};
 							border-left: 4px solid ${theme.euiTheme.colors.accent};
 						}
+
 						border-left: 4px solid
 							${selected ? theme.euiTheme.colors.primary : 'transparent'};
 						border-bottom: 1px solid ${theme.euiTheme.colors.mediumShade};
@@ -233,24 +239,22 @@ const WirePreviewCard = ({
 						text-align: right;
 					`}
 				>
-					{content.versionCreated
-						? formatTimestamp(content.versionCreated)
-								.split(', ')
-								.map((part) => (
-									<EuiText
-										size="xs"
-										key={part}
-										css={css`
-											padding-left: 5px;
-											font-weight: ${hasBeenViewed
-												? theme.euiTheme.font.weight.regular
-												: theme.euiTheme.font.weight.medium};
-										`}
-									>
-										{part}
-									</EuiText>
-								))
-						: ''}
+					{formatTimestamp(ingestedAt)
+						.split(', ')
+						.map((part) => (
+							<EuiText
+								size="xs"
+								key={part}
+								css={css`
+									padding-left: 5px;
+									font-weight: ${hasBeenViewed
+										? theme.euiTheme.font.weight.regular
+										: theme.euiTheme.font.weight.medium};
+								`}
+							>
+								{part}
+							</EuiText>
+						))}
 					<EuiSpacer size="xs" />
 					<EuiBadge
 						color={

--- a/newswires/client/src/context/SearchReducer.test.ts
+++ b/newswires/client/src/context/SearchReducer.test.ts
@@ -160,12 +160,12 @@ describe('SearchReducer', () => {
 					{
 						...sampleWireData,
 						id: 4,
-						ingestedAt: '2025-01-01T02:07:00.00000Z[UTC]',
+						ingestedAt: '2025-01-01T02:07:00.00000Z',
 					},
 					{
 						...sampleWireData,
 						id: 3,
-						ingestedAt: '2025-01-01T02:06:00.00000Z[UTC]',
+						ingestedAt: '2025-01-01T02:06:00.00000Z',
 					},
 				],
 				totalCount: 2,

--- a/newswires/client/src/dateHelpers.ts
+++ b/newswires/client/src/dateHelpers.ts
@@ -7,12 +7,7 @@ export interface TimeRange {
 }
 
 export const convertToLocalDate = (timestamp: string): string => {
-	if (!timestamp.toLowerCase().includes('utc')) {
-		throw new Error(`Incoming timestamps must be in UTC format: ${timestamp}`);
-	}
-
-	const cleanedTimestamp = timestamp.replace(/\[.*]$/, '');
-	const localTime = moment.utc(cleanedTimestamp).local();
+	const localTime = moment.utc(timestamp).local();
 
 	if (!localTime.isValid()) {
 		throw new Error(`Invalid timestamp: ${timestamp}`);

--- a/newswires/client/src/tests/fixtures/wireData.ts
+++ b/newswires/client/src/tests/fixtures/wireData.ts
@@ -28,7 +28,7 @@ export const sampleWireData: WireData = {
 	id: 1,
 	supplier: 'TestSupplier',
 	externalId: 'external-123',
-	ingestedAt: '2025-01-01T00:00:00.00000Z[UTC]', // UTC dates to make sure the reducer is converting dates to the local timezone.
+	ingestedAt: '2025-01-01T00:00:00.00000Z', // UTC dates to make sure the reducer is converting dates to the local timezone.
 	categoryCodes: ['category1', 'category2'],
 	content: sampleFingerpostContent,
 	highlight: 'Sample Highlight',


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Make timestamps consistent in UI:

- Convert timestamps to `Instant` objects on the backend to ensure compatibility with MomentJS.  
- Display `ingestedAt` instead of `versionCreated` in the story list for consistency with sorting and filtering, which use `ingestedAt`.  
- Display timestamps in local time on the story details component.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
