### PR TITLE
More consistent highlight

### DIFF
--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -130,7 +130,11 @@ object FingerpostWireEntry
       composerId = rs.stringOpt(fm.composerId),
       composerSentBy = rs.stringOpt(fm.composerSentBy),
       categoryCodes = categoryCodes,
-      highlight = rs.stringOpt(fm.column("highlight"))
+      highlight = rs
+        .stringOpt(fm.column("highlight"))
+        .filter(
+          _.contains("<mark>")
+        ) // sometimes PG will return some unmarked text, and sometimes will return NULL - I can't figure out which and when
     )
   }
 
@@ -349,7 +353,7 @@ object FingerpostWireEntry
 
     val highlightsClause = search.text match {
       case Some(query) =>
-        sqls", ts_headline('english', ${syn.content}->>'body_text', websearch_to_tsquery('english', $query)) AS ${syn.resultName.highlight}"
+        sqls", ts_headline('english', ${syn.content}->>'body_text', websearch_to_tsquery('english', $query), 'StartSel=<mark>, StopSel=</mark>') AS ${syn.resultName.highlight}"
       case None => sqls", '' AS ${syn.resultName.highlight}"
     }
 

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -184,7 +184,7 @@ export const WireDetail = ({
 	}, [wire]);
 
 	const safeHighlightText = useMemo(() => {
-		return wire.highlight.trim().length > 0
+		return wire.highlight && wire.highlight.trim().length > 0
 			? sanitizeHtml(wire.highlight)
 			: undefined;
 	}, [wire]);

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -107,6 +107,13 @@ function MaybeSecondaryCardContent({
 					padding: 0.1rem 0.5rem;
 					background-color: ${theme.euiTheme.colors.highlight};
 					justify-self: start;
+
+					& mark {
+						background-color: ${theme.euiTheme.colors.highlight};
+						font-weight: bold;
+						position: relative;
+						border: 3px solid ${theme.euiTheme.colors.highlight};
+					}
 				`}
 			>
 				<p dangerouslySetInnerHTML={{ __html: sanitizeHtml(highlight) }} />

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -149,7 +149,7 @@ const WirePreviewCard = ({
 	id: number;
 	supplier: string;
 	content: WireData['content'];
-	highlight: string;
+	highlight: string | undefined;
 	selected: boolean;
 	isFromRefresh: boolean;
 }) => {

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -36,7 +36,7 @@ export const WireDataSchema = z.object({
 	content: FingerpostContentSchema,
 	composerId: z.string().optional(),
 	composerSentBy: z.string().optional(),
-	highlight: z.string(),
+	highlight: z.string().optional(),
 	isFromRefresh: z.boolean().default(false),
 });
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We return highlights in two slightly different ways - the item endpoint will return them enclosed in `<mark>`, and the search endpoint will return them in the default `<b>`. 

Separately, the backend considers the highlight to be optional, and may not be returned (under a few circumstances, but importantly if the text query appears in one of the [fields other than the body copy in the combined textsearch index](https://github.com/guardian/newswires/blob/main/db/migrations/V3__tsvector_indices.sql#L4-L9), but a few parts of the frontend considered it to be mandatory, causing validation errors when parsing. Normalise it into being optional everywhere.

## How to test

Make some searches that would return items without a highlight - searching for common keyword terms should do it. Try "government" for example (several stories have government in keywords, but not in the body)

## How can we measure success?

Less validation errors displayed to users.
