### PR TITLE
Add AFP World bucket

### DIFF
--- a/newswires/app/conf/SearchBuckets.scala
+++ b/newswires/app/conf/SearchBuckets.scala
@@ -643,6 +643,7 @@ object SearchBuckets {
     case "ap-world"      => Some(ApWorld)
     case "aap-world"     => Some(AapWorld)
     case "all-world"     => Some(AllWorld)
+    case "afp-world"     => Some(AfpWorld)
     case _               => None
   }
 
@@ -720,5 +721,12 @@ object SearchBuckets {
     )
   )
 
-  private val AllWorld = ApWorld ::: ReutersWorld ::: AapWorld
+  private val AfpWorld = List(
+    SearchParams(
+      text = None,
+      suppliersIncl = List("AFP")
+    )
+  )
+
+  private val AllWorld = ApWorld ::: ReutersWorld ::: AapWorld ::: AfpWorld
 }

--- a/newswires/app/conf/SearchBuckets.scala
+++ b/newswires/app/conf/SearchBuckets.scala
@@ -724,7 +724,8 @@ object SearchBuckets {
   private val AfpWorld = List(
     SearchParams(
       text = None,
-      suppliersIncl = List("AFP")
+      suppliersIncl = List("AFP"),
+      categoryCodesExcl = List("afpCat:SPO")
     )
   )
 

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -47,6 +47,7 @@ const buckets = [
 	{ id: 'ap-world', name: 'AP World' },
 	{ id: 'reuters-world', name: 'Reuters World' },
 	{ id: 'aap-world', name: 'AAP World' },
+	{ id: 'afp-world', name: 'AFP World' },
 ];
 
 function bucketName(bucketId: string): string | undefined {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a new bucket for 'AFP World'. It represents the existing Fip logic, as I understand it: everything goes into 'world' from AFP, except items with the `SPO` category.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- `./scripts/start --use-CODE`, check that the bucket loads and contains nothing with the sport category code

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
