### PR TITLE
Newswires ingestor: fix stories body text

### DIFF
--- a/ingestion-lambda/src/handler.test.ts
+++ b/ingestion-lambda/src/handler.test.ts
@@ -1,4 +1,4 @@
-import { decodeBodyTextContent, processKeywords } from './handler';
+import {processKeywords, safeBodyParse} from './handler';
 
 describe('processKeywords', () => {
 	it('should return an empty array if provided with `undefined`', () => {
@@ -46,12 +46,24 @@ describe('processKeywords', () => {
 	});
 });
 
-describe('decodeBodyTextContent', () => {
+describe('safeBodyParse', () => {
 	it('should fix over-escaped characters', () => {
-		const content =
-			'\\n \\n test paragraph 1. \\n test paragraph 2. \\u00a0 \\n test paragraph 3.';
-		expect(decodeBodyTextContent(content)).toEqual(
-			'<br /> <br /> test paragraph 1. <br /> test paragraph 2.   <br /> test paragraph 3.',
-		);
+		const body = `{
+			"version": "1",
+			"firstVersion": "2025-03-13T15:45:04.000Z",
+			"versionCreated": "2025-03-13T15:45:04.000Z",
+			"keywords": "keyword1+keyword2",
+			"body_text": "\\n \\n test paragraph 1. \\n test paragraph 2. \\u00a0 \\n test paragraph 3."
+		}`;
+
+		expect(safeBodyParse(body)).toEqual({
+			firstVersion: '2025-03-13T15:45:04.000Z',
+			imageIds: [],
+			keywords: ['keyword1', 'keyword2'],
+			body_text:
+				'<br /> <br /> test paragraph 1. <br /> test paragraph 2.   <br /> test paragraph 3.',
+			version: '1',
+			versionCreated: '2025-03-13T15:45:04.000Z',
+		});
 	});
 });

--- a/ingestion-lambda/src/handler.ts
+++ b/ingestion-lambda/src/handler.ts
@@ -95,7 +95,7 @@ export const decodeBodyTextContent = (
 		})
 		.replace(/\n/g, '<br />');
 
-const safeBodyParse = (body: string): IngestorInputBody => {
+export const safeBodyParse = (body: string): IngestorInputBody => {
 	try {
 		const json = JSON.parse(body) as Record<string, unknown>;
 
@@ -104,7 +104,7 @@ const safeBodyParse = (body: string): IngestorInputBody => {
 		); // if it's not one of these, we probably want to throw an error
 
 		const preprocessedBodyTextContent = decodeBodyTextContent(
-			json.body_Text as string | undefined,
+			json.body_text as string | undefined,
 		);
 
 		return IngestorInputBodySchema.parse({


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Fix bug that omits body text from stories when saving them to the DB.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
