### PR TITLE
Deprecate subjects in favour of category codes

### DIFF
--- a/newswires/app/conf/SearchBuckets.scala
+++ b/newswires/app/conf/SearchBuckets.scala
@@ -2,49 +2,49 @@ package conf
 
 import db.SearchParams
 
-object Subjects {
+object Categories {
   val sportsRelated = List(
     "MCC:SPO",
     "N2:TEN",
     "a1312cat:s",
-    "iptccat:GXX", // maybe, or maybe advertising "Tequila brand announces partnership with Fulham Football Club"
-    "iptccat:RDR",
-    "iptccat:RFC",
-    "iptccat:RRB",
-    "iptccat:RRF",
-    "iptccat:RRG",
-    "iptccat:RRR",
-    "iptccat:RSF",
-    "iptccat:RSR",
-    "iptccat:SCN",
-    "iptccat:SCR",
-    "iptccat:SDA",
-    "iptccat:SDB",
-    "iptccat:SDP",
-    "iptccat:SDQ",
-    "iptccat:SDR",
-    "iptccat:SDS",
-    "iptccat:SFF",
-    "iptccat:SJA",
-    "iptccat:SJB",
-    "iptccat:SOD",
-    "iptccat:SOS",
-    "iptccat:SPO",
-    "iptccat:SRD",
-    "iptccat:SRN",
-    "iptccat:SRR",
-    "iptccat:SRS",
-    "iptccat:SRZ",
-    "iptccat:SSD",
-    "iptccat:SSF",
-    "iptccat:SSO",
-    "iptccat:SSS",
-    "iptccat:SST",
-    "iptccat:STA",
-    "iptccat:STB",
-    "iptccat:STC",
-    "iptccat:STD",
-    "iptccat:STR",
+    "paCat:GXX", // maybe, or maybe advertising "Tequila brand announces partnership with Fulham Football Club"
+    "paCat:RDR",
+    "paCat:RFC",
+    "paCat:RRB",
+    "paCat:RRF",
+    "paCat:RRG",
+    "paCat:RRR",
+    "paCat:RSF",
+    "paCat:RSR",
+    "paCat:SCN",
+    "paCat:SCR",
+    "paCat:SDA",
+    "paCat:SDB",
+    "paCat:SDP",
+    "paCat:SDQ",
+    "paCat:SDR",
+    "paCat:SDS",
+    "paCat:SFF",
+    "paCat:SJA",
+    "paCat:SJB",
+    "paCat:SOD",
+    "paCat:SOS",
+    "paCat:SPO",
+    "paCat:SRD",
+    "paCat:SRN",
+    "paCat:SRR",
+    "paCat:SRS",
+    "paCat:SRZ",
+    "paCat:SSD",
+    "paCat:SSF",
+    "paCat:SSO",
+    "paCat:SSS",
+    "paCat:SST",
+    "paCat:STA",
+    "paCat:STB",
+    "paCat:STC",
+    "paCat:STD",
+    "paCat:STR",
     "medtop:15000000"
   )
 
@@ -637,53 +637,6 @@ object Subjects {
   )
 }
 
-object Categories {
-  val sportsRelated = List(
-    "MCC:SPO",
-    "N2:TEN",
-    "a1312cat:s",
-    "paCat:GXX", // maybe, or maybe advertising "Tequila brand announces partnership with Fulham Football Club"
-    "paCat:RDR",
-    "paCat:RFC",
-    "paCat:RRB",
-    "paCat:RRF",
-    "paCat:RRG",
-    "paCat:RRR",
-    "paCat:RSF",
-    "paCat:RSR",
-    "paCat:SCN",
-    "paCat:SCR",
-    "paCat:SDA",
-    "paCat:SDB",
-    "paCat:SDP",
-    "paCat:SDQ",
-    "paCat:SDR",
-    "paCat:SDS",
-    "paCat:SFF",
-    "paCat:SJA",
-    "paCat:SJB",
-    "paCat:SOD",
-    "paCat:SOS",
-    "paCat:SPO",
-    "paCat:SRD",
-    "paCat:SRN",
-    "paCat:SRR",
-    "paCat:SRS",
-    "paCat:SRZ",
-    "paCat:SSD",
-    "paCat:SSF",
-    "paCat:SSO",
-    "paCat:SSS",
-    "paCat:SST",
-    "paCat:STA",
-    "paCat:STB",
-    "paCat:STC",
-    "paCat:STD",
-    "paCat:STR",
-    "medtop:15000000"
-  )
-}
-
 object SearchBuckets {
   def get(name: String): Option[List[SearchParams]] = name match {
     case "reuters-world" => Some(ReutersWorld)
@@ -732,10 +685,10 @@ object SearchBuckets {
     SearchParams(
       text = Some("News Summary"),
       suppliersIncl = List("REUTERS"),
-      subjectsIncl = List(
+      categoryCodesIncl = List(
         "MCC:OEC"
       ),
-      subjectsExcl = List(
+      categoryCodesExcl = List(
         "N2:GB",
         "N2:COM",
         "N2:ECI"
@@ -744,13 +697,13 @@ object SearchBuckets {
     SearchParams(
       text = None,
       suppliersIncl = List("REUTERS"),
-      subjectsIncl = List(
+      categoryCodesIncl = List(
         "MCC:OVR",
         "MCCL:OVR",
         "MCCL:OSM",
         "N2:US"
       ),
-      subjectsExcl = List(
+      categoryCodesExcl = List(
         "N2:GB",
         "N2:COM",
         "N2:ECI"
@@ -763,7 +716,7 @@ object SearchBuckets {
       text = None,
       suppliersIncl = List("AAP"),
       keywordExcl = List("Sports"),
-      subjectsExcl = Subjects.sportsRelatedNewsCodes
+      categoryCodesExcl = Categories.sportsRelatedNewsCodes
     )
   )
 

--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -36,8 +36,6 @@ class QueryController(
       maybeFreeTextQuery: Option[String],
       maybeKeywords: Option[String],
       suppliers: List[String],
-      subjects: List[String],
-      subjectsExcl: List[String],
       categoryCode: List[String],
       categoryCodeExcl: List[String],
       maybeStart: Option[String],
@@ -62,8 +60,6 @@ class QueryController(
         .get("supplierExcl")
         .map(_.toList)
         .getOrElse(Nil) ++ suppliersToExcludeByDefault,
-      subjectsIncl = subjects,
-      subjectsExcl = subjectsExcl,
       categoryCodesIncl = categoryCode,
       categoryCodesExcl = categoryCodeExcl
     )

--- a/newswires/app/db/SearchParams.scala
+++ b/newswires/app/db/SearchParams.scala
@@ -8,8 +8,6 @@ case class SearchParams(
     keywordExcl: List[String] = Nil,
     suppliersIncl: List[String] = Nil,
     suppliersExcl: List[String] = Nil,
-    subjectsIncl: List[String] = Nil,
-    subjectsExcl: List[String] = Nil,
     categoryCodesIncl: List[String] = Nil,
     categoryCodesExcl: List[String] = Nil
 ) {
@@ -24,8 +22,6 @@ case class SearchParams(
       keywordExcl = keywordExcl ++ o.keywordExcl,
       suppliersIncl = suppliersIncl ++ o.suppliersIncl,
       suppliersExcl = suppliersExcl ++ o.suppliersExcl,
-      subjectsIncl = subjectsIncl ++ o.subjectsIncl,
-      subjectsExcl = subjectsExcl ++ o.subjectsExcl,
       categoryCodesIncl = categoryCodesIncl ++ o.categoryCodesIncl,
       categoryCodesExcl = categoryCodesExcl ++ o.categoryCodesExcl
     )

--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -6,17 +6,23 @@ import { deriveDateMathRangeLabel } from './dateHelpers.ts';
 
 const Summary = ({ searchSummary }: { searchSummary: string }) => {
 	const { config, handleEnterQuery } = useSearch();
-	const { q, bucket, supplier: suppliers, dateRange, subjects } = config.query;
+	const {
+		q,
+		bucket,
+		supplier: suppliers,
+		dateRange,
+		categoryCode,
+	} = config.query;
 
-	const displaySubjects = (subjects ?? []).length > 0;
+	const displayCategoryCodes = (categoryCode ?? []).length > 0;
 	const displaySuppliers = (suppliers ?? []).length > 0;
 
 	const displayFilters: boolean =
-		!!q || !!bucket || displaySubjects || displaySuppliers;
+		!!q || !!bucket || displayCategoryCodes || displaySuppliers;
 
 	const handleBadgeClick = (label: string, value?: string) => {
 		const supplier = config.query.supplier ?? [];
-		const subjects = config.query.subjects ?? [];
+		const categoryCodes = config.query.categoryCode ?? [];
 
 		handleEnterQuery({
 			...config.query,
@@ -27,10 +33,10 @@ const Summary = ({ searchSummary }: { searchSummary: string }) => {
 				label === 'Supplier'
 					? supplier.filter((s: string) => s !== value)
 					: supplier,
-			subjects:
-				label === 'Subject'
-					? subjects.filter((s: string) => s !== value)
-					: subjects,
+			categoryCode:
+				label === 'Category code'
+					? categoryCodes.filter((s: string) => s !== value)
+					: categoryCodes,
 		});
 	};
 
@@ -65,8 +71,8 @@ const Summary = ({ searchSummary }: { searchSummary: string }) => {
 			{bucket && renderBadge('Bucket', bucket)}
 			{displaySuppliers &&
 				suppliers!.map((supplier) => renderBadge('Supplier', supplier))}
-			{displaySubjects &&
-				subjects!.map((subject) => renderBadge('Subject', subject))}
+			{displayCategoryCodes &&
+				categoryCode!.map((code) => renderBadge('Category code', code))}
 		</>
 	);
 };

--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -6,7 +6,7 @@ import { deriveDateMathRangeLabel } from './dateHelpers.ts';
 
 const Summary = ({ searchSummary }: { searchSummary: string }) => {
 	const { config, handleEnterQuery } = useSearch();
-	const { q, bucket, subjects, supplier: suppliers, dateRange } = config.query;
+	const { q, bucket, supplier: suppliers, dateRange, subjects } = config.query;
 
 	const displaySubjects = (subjects ?? []).length > 0;
 	const displaySuppliers = (suppliers ?? []).length > 0;

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -22,9 +22,9 @@ import type { Query } from './sharedTypes';
 import { recognisedSuppliers, supplierData } from './suppliers.ts';
 
 function decideLabelForQueryBadge(query: Query): string {
-	const { supplier, q, bucket, subjects, dateRange } = query;
+	const { supplier, q, bucket, categoryCode, dateRange } = query;
 	const supplierLabel = supplier?.join(', ') ?? '';
-	const subjectsLabel = subjects?.join(', ') ?? '';
+	const categoryCodesLabel = categoryCode?.join(', ') ?? '';
 	const qLabel = q.length > 0 ? `"${q}"` : '';
 	const bucketLabel = bucket ? `[${bucketName(bucket)}]` : '';
 	const dateRangeLabel = dateRange
@@ -34,7 +34,7 @@ function decideLabelForQueryBadge(query: Query): string {
 	const labels = [
 		bucketLabel,
 		supplierLabel,
-		subjectsLabel,
+		categoryCodesLabel,
 		qLabel,
 		dateRangeLabel,
 	];
@@ -272,72 +272,3 @@ export const SideNav = () => {
 		</>
 	);
 };
-
-/** 
- * Feels worth leaving this code here but commented out for a while.
- * I wrote it when adding keywords but we're removing this for the time being.
- * Feels worth having in the code, rather than keeping it in a separate branch, to
- * make it easier to discover. If it's not been used by, say, the end of October 2024
- * then let's delete it.
- * 
-const SingleSearchAsListOfBadges = ({
-	title,
-	query,
-}: {
-	title: string;
-	query: Query;
-}) => {
-	return (
-		<EuiCollapsibleNavGroup title={title}>
-			<SearchQueryBadges query={query} />
-		</EuiCollapsibleNavGroup>
-	);
-};
-
-const SearchQueryBadges = ({ query }: { query: Query }) => {
-	const { handleEnterQuery } = useSearch();
-	const { q, subject } = query;
-
-	if (q.length === 0 && subject.length === 0) {
-		return <EuiText size="s">No filters applied</EuiText>;
-	}
-
-	return (
-		<EuiFlexGroup wrap responsive={false} gutterSize="s">
-			{q.length > 0 && (
-				<EuiFlexItem grow={false}>
-					<EuiBadge
-						color="secondary"
-						iconType="cross"
-						iconSide="right"
-						iconOnClick={() => {
-							handleEnterQuery({ ...query, q: '' });
-						}}
-						iconOnClickAriaLabel="Remove text query filter"
-					>
-						{`"${q}"`}
-					</EuiBadge>
-				</EuiFlexItem>
-			)}
-			{subject.map((s) => (
-				<EuiFlexItem grow={false} key={s}>
-					<EuiBadge
-						color="accent"
-						iconType="cross"
-						iconSide="right"
-						iconOnClick={() => {
-							handleEnterQuery({
-								...query,
-								subject: subject.filter((sub) => sub !== s),
-							});
-						}}
-						iconOnClickAriaLabel={`Remove ${s} filter`}
-					>
-						{s}
-					</EuiBadge>
-				</EuiFlexItem>
-			))}
-		</EuiFlexGroup>
-	);
-};
-*/

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -43,50 +43,46 @@ function TitleContentForItem({
 	return <>{slug ?? 'No title'}</>;
 }
 
-type SubjectTableItem = {
+type CategoryCodeTableItem = {
 	code: string;
 	labels: string;
 	isSelected: boolean;
 };
 
-function SubjectTable({ subjects }: { subjects: string[] }) {
+function CategoryCodeTable({ categoryCodes }: { categoryCodes: string[] }) {
 	const { handleEnterQuery, config } = useSearch();
 
-	const isSubjectInSearch = (subject: string) => {
-		const subjects = config.query.subjects ?? [];
-		return subjects.includes(subject);
+	const isCodeInSearch = (code: string) => {
+		const categoryCodesInSearch = config.query.categoryCode ?? [];
+		return categoryCodesInSearch.includes(code);
 	};
 
-	const nonEmptySubjects = subjects.filter(
-		(subject) => subject.trim().length > 0,
-	);
-	const subjectTableItems: SubjectTableItem[] = nonEmptySubjects.map(
-		(subject) => ({
-			code: subject,
-			labels: lookupCatCodesWideSearch(subject).join('; '),
-			isSelected: isSubjectInSearch(subject),
+	const categoryCodeTableItems: CategoryCodeTableItem[] = categoryCodes.map(
+		(code) => ({
+			code: code,
+			labels: lookupCatCodesWideSearch(code).join('; '),
+			isSelected: isCodeInSearch(code),
 		}),
 	);
 
-	const handleSubjectClick = (subject: string) => {
-		const subjects = config.query.subjects ?? [];
-		console.log('handleSubjectClick', subject, subjects);
+	const handleCategoryClick = (categoryCode: string) => {
+		const codes = config.query.categoryCode ?? [];
 		handleEnterQuery({
 			...config.query,
-			subjects: subjects.includes(subject)
-				? subjects.filter((s) => s !== subject)
-				: [...subjects, subject],
+			categoryCode: codes.includes(categoryCode)
+				? codes.filter((s) => s !== categoryCode)
+				: [...codes, categoryCode],
 		});
 	};
 
-	const columns: Array<EuiBasicTableColumn<SubjectTableItem>> = [
+	const columns: Array<EuiBasicTableColumn<CategoryCodeTableItem>> = [
 		{
 			field: 'code',
-			name: 'Subject code',
+			name: 'Category code',
 		},
 		{
 			field: 'labels',
-			name: 'Subject label(s)',
+			name: 'Category label(s)*',
 		},
 		{
 			field: 'isSelected',
@@ -95,7 +91,7 @@ function SubjectTable({ subjects }: { subjects: string[] }) {
 			render: (isSelected, item) => (
 				<EuiButtonIcon
 					color={isSelected ? 'primary' : 'accent'}
-					onClick={() => handleSubjectClick(item.code)}
+					onClick={() => handleCategoryClick(item.code)}
 					iconType={isSelected ? 'check' : 'plusInCircle'}
 					aria-label="Toggle selection"
 				/>
@@ -104,15 +100,30 @@ function SubjectTable({ subjects }: { subjects: string[] }) {
 	];
 
 	return (
-		<Disclosure title={`Subjects (${subjectTableItems.length})`}>
-			{subjectTableItems.length === 0 ? (
-				'No subject information available'
+		<Disclosure title={`Category Codes (${categoryCodeTableItems.length})`}>
+			{categoryCodeTableItems.length === 0 ? (
+				'No category code information available'
 			) : (
-				<EuiBasicTable
-					items={subjectTableItems}
-					columns={columns}
-					tableLayout="auto"
-				/>
+				<figure>
+					<EuiBasicTable
+						items={categoryCodeTableItems}
+						columns={columns}
+						tableLayout="auto"
+					/>
+					<EuiSpacer size={'s'} />
+					<figcaption>
+						<EuiText size={'xs'}>
+							<p>
+								Category codes associated with this item. Many of these are
+								agency-specific.
+							</p>
+							<p>
+								* nb. Category labels are a best approximation, please let us
+								know if you spot any that don&apos;t look right!
+							</p>
+						</EuiText>
+					</figcaption>
+				</figure>
 			)}
 		</Disclosure>
 	);
@@ -174,8 +185,8 @@ export const WireDetail = ({
 	isShowingJson: boolean;
 }) => {
 	const theme = useEuiTheme();
-	const { byline, keywords, usage, ednote, subjects, headline, slug } =
-		wire.content;
+	const { categoryCodes } = wire;
+	const { byline, keywords, usage, ednote, headline, slug } = wire.content;
 
 	const safeBodyText = useMemo(() => {
 		return wire.content.bodyText
@@ -304,7 +315,7 @@ export const WireDetail = ({
 						<EuiDescriptionListDescription>
 							<MetaTable wire={wire} />
 							<EuiSpacer />
-							<SubjectTable subjects={subjects?.code ?? []} />
+							<CategoryCodeTable categoryCodes={categoryCodes} />
 							<EuiSpacer />
 						</EuiDescriptionListDescription>
 					</EuiDescriptionList>

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -61,8 +61,6 @@ export const QuerySchema = z.object({
 	supplierExcl: z.array(z.string()).optional(),
 	keywords: z.ostring(),
 	keywordsExcl: z.ostring(),
-	subjects: z.array(z.string()).optional(),
-	subjectsExcl: z.array(z.string()).optional(),
 	categoryCode: z.array(z.string()).optional(),
 	categoryCodeExcl: z.array(z.string()).optional(),
 	bucket: z.ostring(),

--- a/newswires/client/src/urlState.test.ts
+++ b/newswires/client/src/urlState.test.ts
@@ -121,9 +121,9 @@ describe('urlToConfig', () => {
 		});
 	});
 
-	it('can pass subjects', () => {
+	it('can pass categoryCode', () => {
 		const url = makeFakeLocation(
-			'/feed?q=abc&subjects=medtop%3A08000000&subjects=medtop%3A20001340',
+			'/feed?q=abc&categoryCode=medtop%3A08000000&categoryCode=medtop%3A20001340',
 		);
 		const config = urlToConfig(url);
 		expect(config).toEqual({
@@ -131,14 +131,14 @@ describe('urlToConfig', () => {
 			query: {
 				...defaultQuery,
 				q: 'abc',
-				subjects: ['medtop:08000000', 'medtop:20001340'],
+				categoryCode: ['medtop:08000000', 'medtop:20001340'],
 			},
 		});
 	});
 
-	it('can exclude subjects', () => {
+	it('can exclude categoryCode', () => {
 		const url = makeFakeLocation(
-			'/feed?q=abc&subjectsExcl=medtop%3A08000000&subjectsExcl=medtop%3A20001340',
+			'/feed?q=abc&categoryCodeExcl=medtop%3A08000000&categoryCodeExcl=medtop%3A20001340',
 		);
 		const config = urlToConfig(url);
 		expect(config).toEqual({
@@ -146,7 +146,7 @@ describe('urlToConfig', () => {
 			query: {
 				...defaultQuery,
 				q: 'abc',
-				subjectsExcl: ['medtop:08000000', 'medtop:20001340'],
+				categoryCodeExcl: ['medtop:08000000', 'medtop:20001340'],
 			},
 		});
 	});
@@ -318,25 +318,28 @@ describe('configToUrl', () => {
 		expect(url).toBe('/feed?q=abc&keywordsExcl=Sports%2CPolitics');
 	});
 
-	it('converts config with many subjects to querystring', () => {
+	it('converts config with many categoryCode to querystring', () => {
 		const config = {
 			view: 'feed' as const,
-			query: { q: 'abc', subjects: ['medtop:08000000', 'medtop:20001340'] },
+			query: { q: 'abc', categoryCode: ['medtop:08000000', 'medtop:20001340'] },
 		};
 		const url = configToUrl(config);
 		expect(url).toBe(
-			'/feed?q=abc&subjects=medtop%3A08000000&subjects=medtop%3A20001340',
+			'/feed?q=abc&categoryCode=medtop%3A08000000&categoryCode=medtop%3A20001340',
 		);
 	});
 
-	it('converts config with many excluded subjects to querystring', () => {
+	it('converts config with many excluded categoryCode to querystring', () => {
 		const config = {
 			view: 'feed' as const,
-			query: { q: 'abc', subjectsExcl: ['medtop:08000000', 'medtop:20001340'] },
+			query: {
+				q: 'abc',
+				categoryCodeExcl: ['medtop:08000000', 'medtop:20001340'],
+			},
 		};
 		const url = configToUrl(config);
 		expect(url).toBe(
-			'/feed?q=abc&subjectsExcl=medtop%3A08000000&subjectsExcl=medtop%3A20001340',
+			'/feed?q=abc&categoryCodeExcl=medtop%3A08000000&categoryCodeExcl=medtop%3A20001340',
 		);
 	});
 });

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -12,8 +12,6 @@ export const defaultQuery: Query = {
 	supplierExcl: [],
 	keywords: undefined,
 	keywordsExcl: undefined,
-	subjects: [],
-	subjectsExcl: [],
 	bucket: undefined,
 	categoryCode: [],
 	categoryCodeExcl: [],
@@ -52,8 +50,6 @@ export function urlToConfig(location: {
 	const supplierExcl = urlSearchParams.getAll('supplierExcl');
 	const keywords = urlSearchParams.get('keywords') ?? undefined;
 	const keywordsExcl = urlSearchParams.get('keywordsExcl') ?? undefined;
-	const subjects = urlSearchParams.getAll('subjects');
-	const subjectsExcl = urlSearchParams.getAll('subjectsExcl');
 	const categoryCode = urlSearchParams.getAll('categoryCode');
 	const categoryCodeExcl = urlSearchParams.getAll('categoryCodeExcl');
 	const bucket = urlSearchParams.get('bucket') ?? undefined;
@@ -67,8 +63,6 @@ export function urlToConfig(location: {
 		supplierExcl,
 		keywords,
 		keywordsExcl,
-		subjects,
-		subjectsExcl,
 		categoryCode,
 		categoryCodeExcl,
 		bucket,

--- a/newswires/conf/routes
+++ b/newswires/conf/routes
@@ -7,7 +7,7 @@
 GET     /                           controllers.ViteController.index()
 GET     /feed                       controllers.ViteController.index()
 GET     /item/*id                   controllers.ViteController.item(id: String)
-GET     /api/search                 controllers.QueryController.query(q: Option[String], keywords: Option[String], supplier: List[String], subjects: List[String], subjectsExcl: List[String], categoryCode: List[String], categoryCodeExcl: List[String], start: Option[String], end: Option[String], beforeId: Option[Int], sinceId: Option[Int])
+GET     /api/search                 controllers.QueryController.query(q: Option[String], keywords: Option[String], supplier: List[String], categoryCode: List[String], categoryCodeExcl: List[String], start: Option[String], end: Option[String], beforeId: Option[Int], sinceId: Option[Int])
 GET     /api/keywords               controllers.QueryController.keywords(inLastHours: Option[Int], limit:Option[Int])
 GET     /api/item/:id               controllers.QueryController.item(id: Int, q: Option[String])
 PUT     /api/item/:id/composerId    controllers.QueryController.linkToComposer(id: Int)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Use Category Codes instead of Subjects in the UI, and in search.

As of #200 the intention is for all useful subject data to be captured in the 'categoryCodes' field, which is more standardised and easier/quicker to search given that it's not wrapped in a JSON column.

Unless there are serious issues we should aim to fix forward any issues with categoryCode search that come up.

I'm leaving subject info in the API response at it could be helpful for debugging, but in theory we shouldn't have any need for this field after ingestion.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="784" alt="image" src="https://github.com/user-attachments/assets/e94bbe6e-d7af-465b-b716-89c3ba228753" />

<img width="484" alt="image" src="https://github.com/user-attachments/assets/af9b788b-e49e-4ab7-a8b5-3063118e3d08" />



<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
