### PR TITLE
Newswires backend: join search params with AND

### DIFF
--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -64,18 +64,14 @@ class QueryController(
       categoryCodesExcl = categoryCodeExcl
     )
 
-    val mergedParamList = bucket match {
-      case Some(queryParamList) => queryParamList.map(_ merge queryParams)
-      case None                 => List(queryParams)
-    }
-
     Ok(
       Json.toJson(
         FingerpostWireEntry.query(
-          mergedParamList,
-          maybeFreeTextQuery,
-          maybeBeforeId,
-          maybeSinceId,
+          searchParams = queryParams,
+          savedSearchParamList = bucket.getOrElse(Nil),
+          maybeTextSearch = maybeFreeTextQuery,
+          maybeBeforeId = maybeBeforeId,
+          maybeSinceId = maybeSinceId,
           pageSize = 30
         )
       )


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Join user defined search with bucket search with AND while querying stories.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
