### PR TITLE
ingestion: fix bad control characters

### DIFF
--- a/ingestion-lambda/src/handler.test.ts
+++ b/ingestion-lambda/src/handler.test.ts
@@ -1,10 +1,10 @@
-import {processKeywords, safeBodyParse} from './handler';
+import { processKeywords, safeBodyParse } from './handler';
 
 describe('processKeywords', () => {
 	it('should return an empty array if provided with `undefined`', () => {
 		expect(
 			Array.isArray(processKeywords(undefined)) &&
-				processKeywords(undefined).length === 0,
+			processKeywords(undefined).length === 0,
 		).toBe(true);
 	});
 
@@ -62,6 +62,45 @@ describe('safeBodyParse', () => {
 			keywords: ['keyword1', 'keyword2'],
 			body_text:
 				'<br /> <br /> test paragraph 1. <br /> test paragraph 2.   <br /> test paragraph 3.',
+			version: '1',
+			versionCreated: '2025-03-13T15:45:04.000Z',
+		});
+	});
+
+	it('should fix incorrectly escaped curly quotes in json strings', () => {
+		const body = `{
+			"version": "1",
+			"firstVersion": "2025-03-13T15:45:04.000Z",
+			"versionCreated": "2025-03-13T15:45:04.000Z",
+			"keywords": "keyword1+keyword2",
+			"body_text": "bla \\“bla bla\\”."
+		}`;
+
+		expect(safeBodyParse(body)).toEqual({
+			firstVersion: '2025-03-13T15:45:04.000Z',
+			imageIds: [],
+			keywords: ['keyword1', 'keyword2'],
+			body_text: 'bla “bla bla”.',
+			version: '1',
+			versionCreated: '2025-03-13T15:45:04.000Z',
+		});
+	});
+
+
+	it('should fix unescaped tab literals in json strings', () => {
+		const body = `{
+			"version": "1",
+			"firstVersion": "2025-03-13T15:45:04.000Z",
+			"versionCreated": "2025-03-13T15:45:04.000Z",
+			"keywords": "keyword1+keyword2",
+			"body_text": "bla bla	bla."
+		}`; //             ^
+		// bad char here   |
+		expect(safeBodyParse(body)).toEqual({
+			firstVersion: '2025-03-13T15:45:04.000Z',
+			imageIds: [],
+			keywords: ['keyword1', 'keyword2'],
+			body_text: 'bla bla bla.', // note tab char is now space char
 			version: '1',
 			versionCreated: '2025-03-13T15:45:04.000Z',
 		});

--- a/ingestion-lambda/src/handler.test.ts
+++ b/ingestion-lambda/src/handler.test.ts
@@ -86,14 +86,13 @@ describe('safeBodyParse', () => {
 		});
 	});
 
-
 	it('should fix unescaped tab literals in json strings', () => {
 		const body = `{
 			"version": "1",
 			"firstVersion": "2025-03-13T15:45:04.000Z",
 			"versionCreated": "2025-03-13T15:45:04.000Z",
 			"keywords": "keyword1+keyword2",
-			"body_text": "bla bla	bla."
+			"body_text": "bla	bla bla."
 		}`; //             ^
 		// bad char here   |
 		expect(safeBodyParse(body)).toEqual({
@@ -101,6 +100,26 @@ describe('safeBodyParse', () => {
 			imageIds: [],
 			keywords: ['keyword1', 'keyword2'],
 			body_text: 'bla bla bla.', // note tab char is now space char
+			version: '1',
+			versionCreated: '2025-03-13T15:45:04.000Z',
+		});
+	});
+
+	it('should fix unescaped newline literals in json strings', () => {
+		const body = `{
+			"version": "1",
+			"firstVersion": "2025-03-13T15:45:04.000Z",
+			"versionCreated": "2025-03-13T15:45:04.000Z",
+			"keywords": "keyword1+keyword2",
+			"body_text": "bla
+bla
+bla."
+		}`;
+		expect(safeBodyParse(body)).toEqual({
+			firstVersion: '2025-03-13T15:45:04.000Z',
+			imageIds: [],
+			keywords: ['keyword1', 'keyword2'],
+			body_text: 'bla bla bla.', // note newline char is now space char
 			version: '1',
 			versionCreated: '2025-03-13T15:45:04.000Z',
 		});

--- a/ingestion-lambda/src/handler.ts
+++ b/ingestion-lambda/src/handler.ts
@@ -121,10 +121,11 @@ export const safeJsonParse = (body: string): Record<string, unknown> => {
 		if (e instanceof SyntaxError && isBadControlChar(e)) {
 			console.warn('Attempting to strip unescaped tab chars');
 			// technically, the bad control char warning could appear for any control char that remains unescaped
-			// inside a JSON string; but in practice we've only seen this for tab characters so far. If other control
-			// chars start appearing, this will start firing again, but we'll have to think carefully about how we strip
-			// since this replace will affect all locations in the JSON document, not just inside string literals.
-			return JSON.parse(body.replaceAll('\t', ' ')) as Record<string, unknown>;
+			// inside a JSON string; but in practice we've only seen this for tab and newline characters so far. If
+			// other control chars start appearing, this will start firing again, but we'll have to think carefully
+			// about how we strip since this replace will affect all locations in the JSON document, not just inside
+			// string literals.
+			return JSON.parse(body.replaceAll(/[\t\r\n]/g, ' ')) as Record<string, unknown>;
 		}
 		throw e;
 	}

--- a/ingestion-lambda/src/handler.ts
+++ b/ingestion-lambda/src/handler.ts
@@ -36,6 +36,10 @@ const isCurlyQuoteFailure = (e: SyntaxError): boolean => {
 	return !!e.message.match(/Unexpected token '[“‘”’]'/);
 };
 
+const isBadControlChar = (e: SyntaxError): boolean => {
+	return !!e.message.match(/Bad control character in string literal in JSON/);
+};
+
 function cleanAndDedupeKeywords(keywords: string[]): string[] {
 	return [
 		...new Set(
@@ -95,27 +99,13 @@ export const decodeBodyTextContent = (
 		})
 		.replace(/\n/g, '<br />');
 
-export const safeBodyParse = (body: string): IngestorInputBody => {
+export const safeJsonParse = (body: string): Record<string, unknown> => {
 	try {
-		const json = JSON.parse(body) as Record<string, unknown>;
-
-		const preprocessedKeywords = processKeywords(
-			json.keywords as string | string[] | undefined,
-		); // if it's not one of these, we probably want to throw an error
-
-		const preprocessedBodyTextContent = decodeBodyTextContent(
-			json.body_text as string | undefined,
-		);
-
-		return IngestorInputBodySchema.parse({
-			...json,
-			body_text: preprocessedBodyTextContent,
-			keywords: preprocessedKeywords,
-		});
+		return JSON.parse(body) as Record<string, unknown>;
 	} catch (e) {
 		if (e instanceof SyntaxError && isCurlyQuoteFailure(e)) {
 			console.warn('Stripping badly escaped curly quote');
-			// näive regex to delete a backslash before a curly quote - isn't a fully correct solution.
+			// naïve regex to delete a backslash before a curly quote - isn't a fully correct solution.
 			// what if a string had 2 backslashes then a curly quote? that would be a correct string, that
 			// we'd make incorrect by deleting the second backslash. We could fix that, but then what about
 			// 3 backslashes then a curly quote? etc. infinitely
@@ -126,12 +116,36 @@ export const safeBodyParse = (body: string): IngestorInputBody => {
 			//   .replaceAll(/(?<![^\\]\\(?:\\\\)*)\\(?!["\\/bfnrt]|u[0-9A-Fa-f]{4})/g, '')
 			//
 			// which looks like it should delete all illegal backslashes in a JSON string, but haven't rigorously tested it...
-			return IngestorInputBodySchema.parse(
-				JSON.parse(body.replaceAll(/\\([“‘”’])/g, '$1')),
-			);
+			return JSON.parse(body.replaceAll(/\\([“‘”’])/g, '$1')) as Record<string, unknown>;
+		}
+		if (e instanceof SyntaxError && isBadControlChar(e)) {
+			console.warn('Attempting to strip unescaped tab chars');
+			// technically, the bad control char warning could appear for any control char that remains unescaped
+			// inside a JSON string; but in practice we've only seen this for tab characters so far. If other control
+			// chars start appearing, this will start firing again, but we'll have to think carefully about how we strip
+			// since this replace will affect all locations in the JSON document, not just inside string literals.
+			return JSON.parse(body.replaceAll('\t', ' ')) as Record<string, unknown>;
 		}
 		throw e;
 	}
+};
+
+export const safeBodyParse = (body: string): IngestorInputBody => {
+	const json = safeJsonParse(body);
+
+	const preprocessedKeywords = processKeywords(
+		json.keywords as string | string[] | undefined,
+	); // if it's not one of these, we probably want to throw an error
+
+	const preprocessedBodyTextContent = decodeBodyTextContent(
+		json.body_text as string | undefined,
+	);
+
+	return IngestorInputBodySchema.parse({
+		...json,
+		body_text: preprocessedBodyTextContent,
+		keywords: preprocessedKeywords,
+	});
 };
 
 export const main = async (event: SQSEvent): Promise<SQSBatchResponse> => {


### PR DESCRIPTION
## What does this change?

We receive a bunch of input documents where the body text field contains a literal tab or newline character (rather than the usual "\t" or "\n" escaped versions), which are invalid in JSON. Make a best effort to fix them up, but this is a little tricky as these whitespace characters are valid outside of JSON strings (ie. as indentation around the object literal).

Fortunately they can be safely replaced with " "s, in both locations!

## How to test

Tested on CODE, where the remaining 234 messages on the DLQ were redriven through the lambda running this updated code with success.

## How can we measure success?

More messages make it onto newswires without parsing failures
