### PR TITLE
Newswires UI fix body text

### DIFF
--- a/ingestion-lambda/src/handler.test.ts
+++ b/ingestion-lambda/src/handler.test.ts
@@ -53,7 +53,7 @@ describe('safeBodyParse', () => {
 			"firstVersion": "2025-03-13T15:45:04.000Z",
 			"versionCreated": "2025-03-13T15:45:04.000Z",
 			"keywords": "keyword1+keyword2",
-			"body_text": "\\n \\n test paragraph 1. \\n test paragraph 2. \\u00a0 \\n test paragraph 3."
+			"body_text": "\\n \\n   <p>test paragraph 1.</p>\\n\\n<p>test paragraph 2. \\u00a0 \\n</p>\\n\\n<p>test paragraph 3.<p>"
 		}`;
 
 		expect(safeBodyParse(body)).toEqual({
@@ -61,7 +61,7 @@ describe('safeBodyParse', () => {
 			imageIds: [],
 			keywords: ['keyword1', 'keyword2'],
 			body_text:
-				'<br /> <br /> test paragraph 1. <br /> test paragraph 2.   <br /> test paragraph 3.',
+				'<br /><p>test paragraph 1.</p><br /><p>test paragraph 2.   <br /></p><br /><p>test paragraph 3.<p>',
 			version: '1',
 			versionCreated: '2025-03-13T15:45:04.000Z',
 		});

--- a/ingestion-lambda/src/handler.ts
+++ b/ingestion-lambda/src/handler.ts
@@ -93,7 +93,7 @@ export const decodeBodyTextContent = (
 					return group1;
 			}
 		})
-		.replace(/\n/g, '<br />');
+		.replace(/(?:\n\s*)+/g, '<br />'); // Replaces consecutive newlines (and spaces) with one <br />.
 
 export const safeBodyParse = (body: string): IngestorInputBody => {
 	try {

--- a/newswires/app/conf/SearchBuckets.scala
+++ b/newswires/app/conf/SearchBuckets.scala
@@ -704,6 +704,7 @@ object SearchBuckets {
         "N2:US"
       ),
       categoryCodesExcl = List(
+        "MCC:OEC",
         "N2:GB",
         "N2:COM",
         "N2:ECI"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Replaces consecutive newlines (and spaces) with one `<br />` to reduce the spacing between paragraphs in the body text.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
