### PR TITLE
UI: add supplier badge to story details

### DIFF
--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -25,18 +25,32 @@ import { useSearch } from './context/SearchContext.tsx';
 import { convertToLocalDate } from './dateHelpers.ts';
 import { Disclosure } from './Disclosure.tsx';
 import type { WireData } from './sharedTypes';
+import { getSupplierInfo } from './suppliers.ts';
 
 function TitleContentForItem({
 	slug,
 	headline,
+	supplierDetails,
 }: {
 	slug?: string;
 	headline?: string;
+	supplierDetails?: {
+		label: string;
+		colour: string;
+	};
 }) {
 	if (headline && headline.length > 0) {
 		return (
 			<>
-				{slug && <EuiText size={'xs'}>{slug}</EuiText>} {headline}
+				{slug && <EuiText size={'xs'}>{slug}</EuiText>}{' '}
+				{supplierDetails && (
+					<>
+						<EuiBadge color={supplierDetails.colour}>
+							{supplierDetails.label}
+						</EuiBadge>{' '}
+					</>
+				)}
+				{headline}
 			</>
 		);
 	}
@@ -208,17 +222,31 @@ export const WireDetail = ({
 		[keywords],
 	);
 
+	const supplierInfo = getSupplierInfo(wire.supplier);
+
+	const supplierLabel = supplierInfo?.label ?? wire.supplier;
+	const supplierColour = supplierInfo?.colour ?? theme.euiTheme.colors.text;
+
 	return (
 		<>
 			<EuiFlexGroup justifyContent="spaceBetween">
 				<EuiFlexItem grow={true}>
 					<EuiTitle size="xs">
 						<h2>
-							<TitleContentForItem headline={headline} slug={slug} />
+							<TitleContentForItem
+								headline={headline}
+								slug={slug}
+								supplierDetails={{
+									label: supplierLabel,
+									colour: supplierColour,
+								}}
+							/>
 						</h2>
 					</EuiTitle>
 				</EuiFlexItem>
 			</EuiFlexGroup>
+			<EuiSpacer size="s" />
+
 			<EuiSpacer size="s" />
 			{isShowingJson ? (
 				<EuiCodeBlock language="json">
@@ -245,6 +273,7 @@ export const WireDetail = ({
 								position: relative;
 								border: 3px solid ${theme.euiTheme.colors.highlight};
 							}
+
 							display: flex;
 							flex-direction: column;
 							gap: ${theme.euiTheme.size.s};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Include a supplier badge in the story details, as the supplier information isn't displayed clearly on small screens.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="751" alt="Supplier Badge" src="https://github.com/user-attachments/assets/9949dfbc-f6b6-47c3-b991-d9ada98feb2f" />



## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
