### PR TITLE
UI: append slug to headline in wire list for AAP

### DIFF
--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -78,16 +78,21 @@ export const WireItemList = ({
 	);
 };
 
-function decideMainHeadingContent({
-	headline,
-	slug,
-}: WireData['content']): string {
+function decideMainHeadingContent(
+	supplier: string,
+	{ headline, slug }: WireData['content'],
+): string {
+	const prefix =
+		supplier === 'AAP' && slug && slug.length > 0 ? `${slug} - ` : '';
+
 	if (headline && headline.length > 0) {
-		return headline;
+		return `${prefix}${headline}`;
 	}
+
 	if (slug && slug.length > 0) {
 		return slug;
 	}
+
 	return 'No headline';
 }
 
@@ -180,7 +185,7 @@ const WirePreviewCard = ({
 	const supplierLabel = supplierInfo?.label ?? supplier;
 	const supplierColour = supplierInfo?.colour ?? theme.euiTheme.colors.text;
 
-	const mainHeadingContent = decideMainHeadingContent(content);
+	const mainHeadingContent = decideMainHeadingContent(supplier, content);
 
 	const hasBeenViewed = viewedItemIds.includes(id.toString());
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add more context to stories by appending the slug to story headline in wires list for AAP stories.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="1718" alt="Add slug to headline in wire list" src="https://github.com/user-attachments/assets/0f8ef5d6-cf4e-40c7-b432-f8fc887bbd9c" />

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
