### PR TITLE
UI: set default time range to Today

### DIFF
--- a/newswires/app/conf/SearchBuckets.scala
+++ b/newswires/app/conf/SearchBuckets.scala
@@ -684,18 +684,6 @@ object SearchBuckets {
 
   private val ReutersWorld = List(
     SearchParams(
-      text = Some("News Summary"),
-      suppliersIncl = List("REUTERS"),
-      categoryCodesIncl = List(
-        "MCC:OEC"
-      ),
-      categoryCodesExcl = List(
-        "N2:GB",
-        "N2:COM",
-        "N2:ECI"
-      )
-    ),
-    SearchParams(
       text = None,
       suppliersIncl = List("REUTERS"),
       categoryCodesIncl = List(
@@ -706,6 +694,18 @@ object SearchBuckets {
       ),
       categoryCodesExcl = List(
         "MCC:OEC",
+        "N2:GB",
+        "N2:COM",
+        "N2:ECI"
+      )
+    ),
+    SearchParams(
+      text = Some("News Summary"),
+      suppliersIncl = List("REUTERS"),
+      categoryCodesIncl = List(
+        "MCC:OEC"
+      ),
+      categoryCodesExcl = List(
         "N2:GB",
         "N2:COM",
         "N2:ECI"
@@ -730,5 +730,8 @@ object SearchBuckets {
     )
   )
 
-  private val AllWorld = ApWorld ::: ReutersWorld ::: AapWorld ::: AfpWorld
+  private val AllWorld = List(
+    ReutersWorld(1),
+    ApWorld.head merge ReutersWorld.head merge AapWorld.head merge AfpWorld.head
+  )
 }

--- a/newswires/client/src/DatePicker.tsx
+++ b/newswires/client/src/DatePicker.tsx
@@ -7,9 +7,8 @@ import moment from 'moment';
 import type { ReactElement } from 'react';
 import { useSearch } from './context/SearchContext.tsx';
 import {
+	DEFAULT_DATE_RANGE,
 	END_OF_TODAY,
-	LAST_TWO_WEEKS,
-	NOW,
 	TWO_WEEKS_AGO,
 } from './dateConstants.ts';
 import type { TimeRange } from './dateHelpers.ts';
@@ -50,9 +49,15 @@ export const DatePicker = () => {
 			<EuiSuperDatePicker
 				width={'auto'}
 				start={
-					config.query.dateRange ? config.query.dateRange.start : LAST_TWO_WEEKS
+					config.query.dateRange
+						? config.query.dateRange.start
+						: DEFAULT_DATE_RANGE.start
 				}
-				end={config.query.dateRange ? config.query.dateRange.end : NOW}
+				end={
+					config.query.dateRange
+						? config.query.dateRange.end
+						: DEFAULT_DATE_RANGE.end
+				}
 				minDate={TWO_WEEKS_AGO}
 				maxDate={END_OF_TODAY}
 				onTimeChange={onTimeChange}

--- a/newswires/client/src/dateConstants.ts
+++ b/newswires/client/src/dateConstants.ts
@@ -1,7 +1,13 @@
 import moment from 'moment';
 
-export const NOW = 'now';
-export const LAST_TWO_WEEKS = 'now-2w';
+const TODAY = 'now/d';
 
 export const TWO_WEEKS_AGO = moment().subtract(2, 'weeks');
+
+export const START_OF_TODAY = moment().startOf('day');
 export const END_OF_TODAY = moment().endOf('day');
+
+export const DEFAULT_DATE_RANGE = {
+	start: TODAY,
+	end: TODAY,
+};

--- a/newswires/client/src/urlState.test.ts
+++ b/newswires/client/src/urlState.test.ts
@@ -201,7 +201,7 @@ describe('urlToConfig', () => {
 				q: 'abc',
 				dateRange: {
 					start: 'now/d',
-					end: 'now',
+					end: 'now/d',
 				},
 			},
 		});
@@ -230,7 +230,7 @@ describe('configToUrl', () => {
 		(isRelativeDateNow as unknown as jest.Mock).mockReturnValue(true);
 
 		const url = configToUrl({ view: 'feed', query: defaultQuery });
-		expect(url).toBe('/feed?start=now-2w');
+		expect(url).toBe('/feed?start=now%2Fd');
 	});
 
 	it('converts item config to querystring', () => {

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -1,4 +1,4 @@
-import { LAST_TWO_WEEKS, NOW, TWO_WEEKS_AGO } from './dateConstants.ts';
+import { DEFAULT_DATE_RANGE, START_OF_TODAY } from './dateConstants.ts';
 import {
 	isRelativeDateNow,
 	isValidDateValue,
@@ -16,8 +16,8 @@ export const defaultQuery: Query = {
 	categoryCode: [],
 	categoryCodeExcl: [],
 	dateRange: {
-		start: 'now-2w',
-		end: 'now',
+		start: DEFAULT_DATE_RANGE.start,
+		end: DEFAULT_DATE_RANGE.end,
 	},
 };
 
@@ -38,10 +38,15 @@ export function urlToConfig(location: {
 
 	const startParam = urlSearchParams.get('start');
 	const start =
-		!!startParam && isValidDateValue(startParam) ? startParam : LAST_TWO_WEEKS;
+		!!startParam && isValidDateValue(startParam)
+			? startParam
+			: DEFAULT_DATE_RANGE.start;
 
 	const endParam = urlSearchParams.get('end');
-	const end = !!endParam && isValidDateValue(endParam) ? endParam : NOW;
+	const end =
+		!!endParam && isValidDateValue(endParam)
+			? endParam
+			: DEFAULT_DATE_RANGE.end;
 
 	!!endParam &&
 		console.log('isValidDateValue(endParam)', isValidDateValue(endParam));
@@ -110,7 +115,7 @@ const processDateRange = (
 				end: maybeEndMoment?.toISOString(),
 			};
 		} else {
-			return { ...config, start: TWO_WEEKS_AGO.toISOString() };
+			return { ...config, start: START_OF_TODAY.toISOString() };
 		}
 	} else {
 		return {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
 		}
 	},
 	"lint-staged": {
-		"*.{js,jsx,ts,tsx}": "jest --findRelatedTests"
+		"*.{js,jsx,ts,tsx}": "jest --findRelatedTests --passWithNoTests"
 	},
 	"dependencies": {
 		"zod": "3.23.8"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Reduce default time window to one day (Today) to improve `All World` saved search performance.
- Combine buckets into one to support `All World` saved search.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
