### PR TITLE
UI: add elapsed time to story details

### DIFF
--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -17,12 +17,13 @@ import {
 	useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
+import type { Moment } from 'moment';
 import { useMemo } from 'react';
 import sanitizeHtml from 'sanitize-html';
 import { lookupCatCodesWideSearch } from './catcodes-lookup';
 import { ComposerConnection } from './ComposerConnection.tsx';
 import { useSearch } from './context/SearchContext.tsx';
-import { convertToLocalDate } from './dateHelpers.ts';
+import { convertToLocalDate, convertToLocalDateString } from './dateHelpers.ts';
 import { Disclosure } from './Disclosure.tsx';
 import type { WireData } from './sharedTypes';
 import { getSupplierInfo } from './suppliers.ts';
@@ -30,32 +31,33 @@ import { getSupplierInfo } from './suppliers.ts';
 function TitleContentForItem({
 	slug,
 	headline,
+	ingestedAt,
 	supplierDetails,
 }: {
 	slug?: string;
 	headline?: string;
+	ingestedAt: Moment;
 	supplierDetails?: {
 		label: string;
 		colour: string;
 	};
 }) {
-	if (headline && headline.length > 0) {
-		return (
-			<>
-				{slug && <EuiText size={'xs'}>{slug}</EuiText>}{' '}
-				{supplierDetails && (
-					<>
-						<EuiBadge color={supplierDetails.colour}>
-							{supplierDetails.label}
-						</EuiBadge>{' '}
-					</>
-				)}
-				{headline}
-			</>
-		);
-	}
-
-	return <>{slug ?? 'No title'}</>;
+	return (
+		<>
+			<EuiText size={'xs'}>
+				{slug && <>{slug} &#183; </>}
+				<span title={ingestedAt.format()}>{ingestedAt.fromNow()}</span>
+			</EuiText>{' '}
+			{supplierDetails && (
+				<>
+					<EuiBadge color={supplierDetails.colour}>
+						{supplierDetails.label}
+					</EuiBadge>{' '}
+				</>
+			)}
+			{headline && headline.length > 0 ? headline : (slug ?? 'No title')}
+		</>
+	);
 }
 
 type CategoryCodeTableItem = {
@@ -159,15 +161,19 @@ function MetaTable({ wire }: { wire: WireData }) {
 		},
 		{
 			title: 'Ingested at',
-			description: convertToLocalDate(ingestedAt),
+			description: convertToLocalDateString(ingestedAt),
 		},
 		{
 			title: 'First version',
-			description: firstVersion ? convertToLocalDate(firstVersion) : 'N/A',
+			description: firstVersion
+				? convertToLocalDateString(firstVersion)
+				: 'N/A',
 		},
 		{
 			title: 'This version created',
-			description: versionCreated ? convertToLocalDate(versionCreated) : 'N/A',
+			description: versionCreated
+				? convertToLocalDateString(versionCreated)
+				: 'N/A',
 		},
 		{
 			title: 'Version',
@@ -236,6 +242,7 @@ export const WireDetail = ({
 							<TitleContentForItem
 								headline={headline}
 								slug={slug}
+								ingestedAt={convertToLocalDate(wire.ingestedAt)}
 								supplierDetails={{
 									label: supplierLabel,
 									colour: supplierColour,

--- a/newswires/client/src/context/SearchReducer.ts
+++ b/newswires/client/src/context/SearchReducer.ts
@@ -1,7 +1,7 @@
 import dateMath from '@elastic/datemath';
 import { isEqual as deepIsEqual } from 'lodash';
 import moment from 'moment-timezone';
-import { convertToLocalDate } from '../dateHelpers.ts';
+import { convertToLocalDateString } from '../dateHelpers.ts';
 import type { Query, WireData, WiresQueryResponse } from '../sharedTypes.ts';
 import { defaultQuery } from '../urlState.ts';
 import type { Action, SearchHistory, State } from './SearchContext.tsx';
@@ -26,7 +26,7 @@ const transformQueryResults = (data: WireData[]) =>
 	data.map((item) => {
 		return {
 			...item,
-			ingestedAt: convertToLocalDate(item.ingestedAt),
+			ingestedAt: convertToLocalDateString(item.ingestedAt),
 		};
 	});
 

--- a/newswires/client/src/dateHelpers.ts
+++ b/newswires/client/src/dateHelpers.ts
@@ -6,14 +6,18 @@ export interface TimeRange {
 	end: string;
 }
 
-export const convertToLocalDate = (timestamp: string): string => {
+export const convertToLocalDate = (timestamp: string) => {
 	const localTime = moment.utc(timestamp).local();
 
 	if (!localTime.isValid()) {
 		throw new Error(`Invalid timestamp: ${timestamp}`);
 	}
 
-	return localTime.format();
+	return localTime;
+};
+
+export const convertToLocalDateString = (timestamp: string): string => {
+	return convertToLocalDate(timestamp).format();
 };
 
 export const isValidDateValue = (value: string) =>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Include the elapsed time at the top of the story details so users don’t need to scroll down to the metadata table.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="617" alt="Elapsed time" src="https://github.com/user-attachments/assets/19f16e3e-8423-4117-b859-ef65dba26529" />

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
