### PR TITLE
UI: fix date range display

### DIFF
--- a/newswires/client/src/urlState.test.ts
+++ b/newswires/client/src/urlState.test.ts
@@ -375,7 +375,7 @@ describe('paramsToQuerystring', () => {
 		};
 
 		const url = paramsToQuerystring(query);
-		expect(url).toBe('?q=abc&start=now%2Fd&end=now%2Fd');
+		expect(url).toBe('?q=abc&start=now%2Fd');
 	});
 
 	it('converts relative date range to an absolute date range', () => {

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -1,6 +1,5 @@
 import { DEFAULT_DATE_RANGE, START_OF_TODAY } from './dateConstants.ts';
 import {
-	isRelativeDateNow,
 	isValidDateValue,
 	relativeDateRangeToAbsoluteDateRange,
 } from './dateHelpers.ts';
@@ -47,9 +46,6 @@ export function urlToConfig(location: {
 		!!endParam && isValidDateValue(endParam)
 			? endParam
 			: DEFAULT_DATE_RANGE.end;
-
-	!!endParam &&
-		console.log('isValidDateValue(endParam)', isValidDateValue(endParam));
 
 	const supplier = urlSearchParams.getAll('supplier');
 	const supplierExcl = urlSearchParams.getAll('supplierExcl');
@@ -122,7 +118,7 @@ const processDateRange = (
 			...config,
 			start: config.dateRange?.start,
 			end:
-				config.dateRange?.end && !isRelativeDateNow(config.dateRange.end)
+				config.dateRange?.end && config.dateRange.end !== DEFAULT_DATE_RANGE.end
 					? config.dateRange.end
 					: undefined,
 		};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Fix the date range display by removing the end date query param only when it matches the default range’s end date.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
