### PR TITLE
UI: add abstract for AP stories

### DIFF
--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -26,7 +26,7 @@ import { useSearch } from './context/SearchContext.tsx';
 import { convertToLocalDate, convertToLocalDateString } from './dateHelpers.ts';
 import { Disclosure } from './Disclosure.tsx';
 import type { WireData } from './sharedTypes';
-import { getSupplierInfo } from './suppliers.ts';
+import { AP, getSupplierInfo } from './suppliers.ts';
 
 function TitleContentForItem({
 	slug,
@@ -207,7 +207,12 @@ export const WireDetail = ({
 }) => {
 	const theme = useEuiTheme();
 	const { categoryCodes } = wire;
-	const { byline, keywords, usage, ednote, headline, slug } = wire.content;
+	const { byline, keywords, usage, ednote, headline, slug, abstract } =
+		wire.content;
+
+	const safeAbstract = useMemo(() => {
+		return abstract ? sanitizeHtml(abstract) : undefined;
+	}, [abstract]);
 
 	const safeBodyText = useMemo(() => {
 		return wire.content.bodyText
@@ -299,6 +304,16 @@ export const WireDetail = ({
 									>
 										{byline}
 									</p>
+								</EuiDescriptionListDescription>
+							</>
+						)}
+						{safeAbstract && wire.supplier === AP && (
+							<>
+								<EuiScreenReaderOnly>
+									<EuiDescriptionListTitle>Abstract</EuiDescriptionListTitle>
+								</EuiScreenReaderOnly>
+								<EuiDescriptionListDescription>
+									<p>(abstract) {safeAbstract}</p>
 								</EuiDescriptionListDescription>
 							</>
 						)}

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -22,6 +22,7 @@ const FingerpostContentSchema = z
 		language: z.string(),
 		usage: z.string(),
 		location: z.string(),
+		abstract: z.string(),
 		bodyText: z.string(),
 		ednote: z.string(),
 	})

--- a/newswires/client/src/suppliers.ts
+++ b/newswires/client/src/suppliers.ts
@@ -6,6 +6,8 @@ export const AFPBrand = '#325aff';
 export const PABrand = '#6352ba';
 export const AAPBrand = '#013a81';
 
+export const AP = 'AP';
+
 const allSupplierData: Record<
 	string,
 	{


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add abstract to the story details for AP stories.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
