### PR TITLE
restore highlights in wire detail by sending the q param on item fetch

### DIFF
--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -143,7 +143,7 @@ object FingerpostWireEntry
 
   def get(
       id: Int,
-      maybeFreeTextQuery: Option[String] = Some("alpaca")
+      maybeFreeTextQuery: Option[String]
   ): Option[FingerpostWireEntry] = DB readOnly { implicit session =>
     val highlightsClause = maybeFreeTextQuery match {
       case Some(query) =>

--- a/newswires/client/src/ItemData.tsx
+++ b/newswires/client/src/ItemData.tsx
@@ -5,7 +5,7 @@ import { pandaFetch } from './panda-session';
 import { type WireData, WireDataSchema } from './sharedTypes';
 
 export const ItemData = ({ id }: { id: string }) => {
-	const { handleDeselectItem, handlePreviousItem, handleNextItem } =
+	const { handleDeselectItem, handlePreviousItem, handleNextItem, config } =
 		useSearch();
 
 	const [itemData, setItemData] = useState<WireData | undefined>(undefined);
@@ -13,7 +13,8 @@ export const ItemData = ({ id }: { id: string }) => {
 
 	useEffect(() => {
 		// fetch item data from /api/item/:id
-		pandaFetch(`/api/item/${id}`)
+		const q = config.query.q ? `?q=${config.query.q}` : '';
+		pandaFetch(`/api/item/${id}${q}`)
 			.then((res) => {
 				if (res.status === 404) {
 					throw new Error('Item not found');
@@ -42,7 +43,7 @@ export const ItemData = ({ id }: { id: string }) => {
 							: 'unknown error',
 				);
 			});
-	}, [id]);
+	}, [id, config.query.q]);
 
 	return (
 		<Item


### PR DESCRIPTION
I think this used to work, but was lost along the way somewhere. The item fetch endpoint will include a highlight if the text query is included, but it's currently not being included so is not being returned. Update the client to include the current text query (if there is one) in the request, so the highlight can be generated, returned and displayed by existing code.