### PR TITLE
Minor agencies world

### DIFF
--- a/ingestion-lambda/package.json
+++ b/ingestion-lambda/package.json
@@ -13,7 +13,8 @@
 	"dependencies": {
 		"@aws-sdk/client-s3": "3.637.0",
 		"@aws-sdk/rds-signer": "3.637.0",
-		"postgres": "3.4.4"
+		"postgres": "3.4.4",
+		"compromise": "^14.14.4"
 	},
 	"devDependencies": {
 		"@types/aws-lambda": "8.10.145",

--- a/ingestion-lambda/src/categoryCodes.test.ts
+++ b/ingestion-lambda/src/categoryCodes.test.ts
@@ -1,4 +1,5 @@
 import {
+	inferRegionCategoryFromText,
 	processFingerpostAAPCategoryCodes,
 	processFingerpostAFPCategoryCodes,
 	processFingerpostAPCategoryCodes,
@@ -239,5 +240,46 @@ describe('processUnknownFingerpostCategoryCodes', () => {
 		expect(
 			processUnknownFingerpostCategoryCodes(['qCode:value+value1'], 'supplier'),
 		).toEqual(['qCode:value', 'qCode:value1']);
+	});
+});
+
+describe('inferRegionCategoryFromText', () => {
+	it('should return undefined if provided with an string', () => {
+		expect(inferRegionCategoryFromText('')).toEqual(undefined);
+	});
+
+	it('should return N2:GB when a UK country is mentioned', () => {
+		const content = 'Prime Minister visits Scotland to address economic concerns in rural areas.';
+		expect(inferRegionCategoryFromText(content)).toEqual('N2:GB');
+	});
+
+	it('should return N2:GB for a UK city is mentioned', () => {
+		const content = 'Manchester sees surge in tech sector jobs as new startups attract global investment.';
+		expect(inferRegionCategoryFromText(content)).toEqual('N2:GB');
+	});
+
+	it('should return N2:GB for a UK region is mentioned', () => {
+		const content = 'Heavy rainfall causes flooding in the Lake District, prompting emergency response.';
+		expect(inferRegionCategoryFromText(content)).toEqual('N2:GB');
+	});
+
+	it('should return N2:GB even with varied casing and punctuation in text', () => {
+		const content = 'BREAKING: london officials respond to transportation delays across the city.';
+		expect(inferRegionCategoryFromText(content)).toEqual('N2:GB');
+	});
+
+	it('should return N2:GB when a London borough is mentioned', () => {
+		const content = 'Hackney council launches initiative to support local small businesses amid rising rents.';
+		expect(inferRegionCategoryFromText(content)).toEqual('N2:GB');
+	});
+
+	it('should return N2:GB when a UK landmark is mentioned', () => {
+		const content = 'Thousands of tourists expected at Stonehenge for the summer solstice celebrations.';
+		expect(inferRegionCategoryFromText(content)).toEqual('N2:GB');
+	});
+
+	it('should return undefined when only non-UK places are mentioned', () => {
+		const content = 'US and EU leaders meet in Paris to discuss international trade agreements.';
+		expect(inferRegionCategoryFromText(content)).toEqual(undefined);
 	});
 });

--- a/ingestion-lambda/src/categoryCodes.test.ts
+++ b/ingestion-lambda/src/categoryCodes.test.ts
@@ -244,42 +244,42 @@ describe('processUnknownFingerpostCategoryCodes', () => {
 });
 
 describe('inferRegionCategoryFromText', () => {
-	it('should return undefined if provided with an string', () => {
-		expect(inferRegionCategoryFromText('')).toEqual(undefined);
+	it('should return undefined if provided with an string', async () => {
+		expect(await inferRegionCategoryFromText('')).toEqual(undefined);
 	});
 
-	it('should return N2:GB when a UK country is mentioned', () => {
+	it('should return N2:GB when a UK country is mentioned', async () => {
 		const content = 'Prime Minister visits Scotland to address economic concerns in rural areas.';
-		expect(inferRegionCategoryFromText(content)).toEqual('N2:GB');
+		expect(await inferRegionCategoryFromText(content)).toEqual('N2:GB');
 	});
 
-	it('should return N2:GB for a UK city is mentioned', () => {
+	it('should return N2:GB for a UK city is mentioned', async () => {
 		const content = 'Manchester sees surge in tech sector jobs as new startups attract global investment.';
-		expect(inferRegionCategoryFromText(content)).toEqual('N2:GB');
+		expect(await inferRegionCategoryFromText(content)).toEqual('N2:GB');
 	});
 
-	it('should return N2:GB for a UK region is mentioned', () => {
+	it('should return N2:GB for a UK region is mentioned', async () => {
 		const content = 'Heavy rainfall causes flooding in the Lake District, prompting emergency response.';
-		expect(inferRegionCategoryFromText(content)).toEqual('N2:GB');
+		expect(await inferRegionCategoryFromText(content)).toEqual('N2:GB');
 	});
 
-	it('should return N2:GB even with varied casing and punctuation in text', () => {
+	it('should return N2:GB even with varied casing and punctuation in text', async () => {
 		const content = 'BREAKING: london officials respond to transportation delays across the city.';
-		expect(inferRegionCategoryFromText(content)).toEqual('N2:GB');
+		expect(await inferRegionCategoryFromText(content)).toEqual('N2:GB');
 	});
 
-	it('should return N2:GB when a London borough is mentioned', () => {
+	it('should return N2:GB when a London borough is mentioned', async () => {
 		const content = 'Hackney council launches initiative to support local small businesses amid rising rents.';
-		expect(inferRegionCategoryFromText(content)).toEqual('N2:GB');
+		expect(await inferRegionCategoryFromText(content)).toEqual('N2:GB');
 	});
 
-	it('should return N2:GB when a UK landmark is mentioned', () => {
+	it('should return N2:GB when a UK landmark is mentioned', async () => {
 		const content = 'Thousands of tourists expected at Stonehenge for the summer solstice celebrations.';
-		expect(inferRegionCategoryFromText(content)).toEqual('N2:GB');
+		expect(await inferRegionCategoryFromText(content)).toEqual('N2:GB');
 	});
 
-	it('should return undefined when only non-UK places are mentioned', () => {
+	it('should return undefined when only non-UK places are mentioned', async () => {
 		const content = 'US and EU leaders meet in Paris to discuss international trade agreements.';
-		expect(inferRegionCategoryFromText(content)).toEqual(undefined);
+		expect(await inferRegionCategoryFromText(content)).toEqual(undefined);
 	});
 });

--- a/ingestion-lambda/src/categoryCodes.ts
+++ b/ingestion-lambda/src/categoryCodes.ts
@@ -1,4 +1,3 @@
-import nlp from 'compromise';
 import {lexicon, ukPlaces} from "./ukPlaces";
 
 interface CategoryCode {
@@ -114,10 +113,12 @@ export function processUnknownFingerpostCategoryCodes(
 	return deduped;
 }
 
-export function inferRegionCategoryFromText(content: string | undefined): string | undefined {
+export async function inferRegionCategoryFromText(content: string | undefined): Promise<string | undefined> {
 	if (!content) {
 		return undefined;
 	}
+
+	const { default: nlp } = await import('compromise');
 
 	const doc = nlp(content, lexicon) as {
 		places: () => { out: (format: string) => unknown };

--- a/ingestion-lambda/src/handler.ts
+++ b/ingestion-lambda/src/handler.ts
@@ -9,6 +9,7 @@ import { createDbConnection } from '../../shared/rds';
 import type { IngestorInputBody } from '../../shared/types';
 import { IngestorInputBodySchema } from '../../shared/types';
 import {
+	inferRegionCategoryFromText,
 	processFingerpostAAPCategoryCodes,
 	processFingerpostAFPCategoryCodes,
 	processFingerpostAPCategoryCodes,
@@ -70,7 +71,7 @@ export const processKeywords = (
 	return cleanAndDedupeKeywords(keywords.split('+'));
 };
 
-const processCategoryCodes = (supplier: string, subjectCodes: string[]) => {
+const processCategoryCodes = (supplier: string, subjectCodes: string[], bodyText: string | undefined) => {
 	switch (supplier) {
 		case 'AP':
 			return processFingerpostAPCategoryCodes(subjectCodes);
@@ -80,6 +81,10 @@ const processCategoryCodes = (supplier: string, subjectCodes: string[]) => {
 			return processFingerpostAFPCategoryCodes(subjectCodes);
 		case 'PA':
 			return processFingerpostPACategoryCodes(subjectCodes);
+		case 'MINOR_AGENCIES': {
+			const region = inferRegionCategoryFromText(bodyText);
+			return region ? [...subjectCodes, region] : subjectCodes;
+		}
 		default:
 			return processUnknownFingerpostCategoryCodes(subjectCodes, supplier);
 	}
@@ -216,6 +221,7 @@ export const main = async (event: SQSEvent): Promise<SQSBatchResponse> => {
 						const categoryCodes = processCategoryCodes(
 							supplier,
 							snsMessageContent.subjects?.code ?? [],
+							snsMessageContent.body_text
 						);
 
 						const result = await sql`

--- a/ingestion-lambda/src/handler.ts
+++ b/ingestion-lambda/src/handler.ts
@@ -71,7 +71,7 @@ export const processKeywords = (
 	return cleanAndDedupeKeywords(keywords.split('+'));
 };
 
-const processCategoryCodes = (supplier: string, subjectCodes: string[], bodyText: string | undefined) => {
+const processCategoryCodes = async (supplier: string, subjectCodes: string[], bodyText: string | undefined) => {
 	switch (supplier) {
 		case 'AP':
 			return processFingerpostAPCategoryCodes(subjectCodes);
@@ -82,7 +82,7 @@ const processCategoryCodes = (supplier: string, subjectCodes: string[], bodyText
 		case 'PA':
 			return processFingerpostPACategoryCodes(subjectCodes);
 		case 'MINOR_AGENCIES': {
-			const region = inferRegionCategoryFromText(bodyText);
+			const region = await inferRegionCategoryFromText(bodyText);
 			return region ? [...subjectCodes, region] : subjectCodes;
 		}
 		default:
@@ -218,7 +218,7 @@ export const main = async (event: SQSEvent): Promise<SQSBatchResponse> => {
 						const supplier =
 							lookupSupplier(snsMessageContent['source-feed']) ?? 'Unknown';
 
-						const categoryCodes = processCategoryCodes(
+						const categoryCodes = await processCategoryCodes(
 							supplier,
 							snsMessageContent.subjects?.code ?? [],
 							snsMessageContent.body_text

--- a/ingestion-lambda/src/ukPlaces.ts
+++ b/ingestion-lambda/src/ukPlaces.ts
@@ -1,0 +1,99 @@
+export const ukPlaces = [
+    // Countries and regions
+    "united kingdom", "great britain", "uk", "britain",
+    "england", "scotland", "wales", "northern ireland",
+    // England counties
+    "bedfordshire", "berkshire", "buckinghamshire", "cambridgeshire",
+    "cheshire", "city of london", "cornwall", "cumbria", "derbyshire", "devon",
+    "dorset", "east riding of yorkshire", "east sussex", "essex",
+    "gloucestershire", "greater london", "greater manchester", "hampshire",
+    "herefordshire", "hertfordshire", "isle of wight", "kent", "lancashire",
+    "leicestershire", "lincolnshire", "merseyside", "norfolk", "north east somerset",
+    "north lincolnshire", "north yorkshire", "northamptonshire",
+    "northumberland", "nottinghamshire", "oxfordshire", "rutland",
+    "shropshire", "somerset", "south yorkshire", "staffordshire", "suffolk",
+    "surrey", "tyne and wear", "warwickshire", "west midlands", "west sussex",
+    "west yorkshire", "wiltshire",
+    // Wales counties
+    "clwyd", "dyfed", "gwent", "gwynedd", "mid glamorgan", "powys", "south glamorgan", "west glamorgan",
+    // Scotland counties
+    "aberdeenshire", "angus", "argyll", "ayrshire", "banffshire", "berwickshire", "buteshire",
+    "caithness", "clackmannanshire", "cromartyshire", "dumfriesshire", "dunbartonshire",
+    "east lothian", "fife", "inverness-shire", "kincardineshire", "kinross-shire", "kirkcudbrightshire",
+    "lanarkshire", "midlothian", "moray", "nairnshire", "orkney", "peeblesshire", "perth and kinross", "renfrewshire",
+    "ross-shire", "roxburghshire", "selkirkshire", "shetland", "stirlingshire", "sutherland",
+    "west lothian", "wigtownshire",
+    // Northern Ireland counties
+    "antrim", "armagh", "down", "fermanagh", "londonderry", "tyrone",
+    // England areas
+    "north east england", "north west england", "yorkshire dales",
+    "east midlands", "west midlands", "east of england",
+    "south east england", "south west england", "south downs", "south coast",
+    "cotswolds", "peak district", "lake district",
+    // Wales areas
+    "north wales", "mid wales", "south wales", "pembrokeshire coast",
+    "snowdonia", "brecon beacons",
+    // Scotland areas
+    "highlands and islands", "central belt", "east scotland", "west scotland",
+    "scottish borders", "grampian mountains", "cairngorms",
+    // London boroughs
+    "barking and dagenham", "barnet", "bexley", "brent", "bromley",
+    "camden", "croydon", "ealing", "enfield", "greenwich", "hackney",
+    "hammersmith and fulham", "haringey", "harrow", "havering",
+    "hillingdon", "hounslow", "islington", "kensington and chelsea",
+    "kingston upon thames", "lambeth", "lewisham", "merton", "newham",
+    "redbridge", "richmond upon thames", "southwark", "sutton",
+    "tower hamlets", "waltham forest", "wandsworth", "westminster",
+    // Major cities
+    "london", "birmingham", "manchester", "glasgow", "liverpool", "leeds",
+    "sheffield", "edinburgh", "bristol", "cardiff", "belfast", "newcastle",
+    "nottingham", "leicester", "coventry", "kingston upon hull", "aberdeen",
+    "brighton", "cambridge", "canterbury", "carlisle", "chester", "derby",
+    "dundee", "durham", "exeter", "gloucester", "inverness", "lancaster",
+    "lincoln", "norwich", "oxford", "peterborough", "plymouth", "portsmouth",
+    "preston", "salford", "salisbury", "southampton", "stirling",
+    "stoke-on-trent", "sunderland", "swansea", "wakefield", "winchester",
+    "wolverhampton", "worcester", "york",
+    // England towns
+    "bournemouth", "bath", "bedford", "blackpool", "bolton", "bradford",
+    "maidstone", "newbury", "reading", "slough", "maidenhead", "basingstoke",
+    "guildford", "st albans", "royal tunbridge wells", "wokingham", "chichester",
+    "darlington", "doncaster", "dudley", "gateshead", "grimsby", "halifax",
+    "harrogate", "hastings", "huddersfield", "ipswich", "middlesbrough",
+    "milton keynes", "northampton", "oldham", "poole", "rochdale", "rotherham",
+    "scarborough", "shrewsbury", "southend-on-sea", "southport", "stevenage",
+    "stockport", "stratford-upon-avon", "swindon", "telford", "torquay",
+    "warrington", "watford", "wigan", "windsor", "worthing", "st austell",
+    "canvey island", "hatfield", "guiseley", "oulton", "filching", "everleigh",
+    "tutbury", "elmer", "ironbridge", "wembley", "portland", "kings lynn",
+    // Wales towns and smaller cities
+    "aberdare", "bridgend", "caernarfon", "conwy", "merthyr tydfil", "wrexham",
+    "llantrisant", "neath", "port talbot", "newport", "st davids", "llandudno",
+    "barry", "cwmbran", "llanelli", "aberystwyth", "bangor", "haverfordwest", "rhyl",
+    // Scotland towns
+    "stornoway", "campbeltown", "dunoon", "cumbernauld", "linlithgow", "dalkeith",
+    "cupar", "glenrothes", "elgin", "anstruther", "pitlochry", "dumfries", "largs",
+    "east kilbride", "falkirk", "greenock", "hamilton", "irvine", "kilmarnock",
+    "motherwell", "paisley", "perth", "st andrews", "airdrie", "dunfermline", "ayr",
+    "coatbridge", "livingston", "rutherglen", "oban", "fort william", "peebles", "galashiels",
+    // Northern Ireland towns
+    "limavady", "coleraine", "dungannon", "omagh", "larne", "ballymena",
+    "newtownabbey", "magherafelt", "ballymoney", "enniskillen", "carrickfergus",
+    "newry", "newtownards", "bangor", "lisburn", "portadown", "derry",
+    // Islands & Regions
+    "channel islands", "guernsey", "inner hebrides", "isle of man", "isles of scilly",
+    "jersey", "outer hebrides", "western isles", "skye", "anglesey", "barra",
+    "lewis", "mull", "iona", "arran", "bute", "jura", "islay", "sark", "alderney", "herm",
+    // Landmarks
+    "thames", "loch ness", "ben nevis", "snowdon", "giant's causeway", "hadrian's wall",
+    "stonehenge", "cheddar gorge", "dover white cliffs", "tower bridge", "tower of london",
+    "buckingham palace", "windsor castle", "edinburgh castle", "holyrood palace", "balmoral castle",
+];
+
+/**
+ * Provide UK places to help compromise extract both well-known landmarks
+ * (e.g. "Stonehenge") and less commonly detected locations (e.g. "Hackney").
+ */
+export const lexicon: Record<string, string> = Object.fromEntries(
+    ukPlaces.map((_) => [_, 'Place'])
+);

--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -639,12 +639,13 @@ object Categories {
 
 object SearchPresets {
   def get(name: String): Option[List[SearchParams]] = name match {
-    case "reuters-world" => Some(ReutersWorld)
-    case "ap-world"      => Some(ApWorld)
-    case "aap-world"     => Some(AapWorld)
-    case "all-world"     => Some(AllWorld)
-    case "afp-world"     => Some(AfpWorld)
-    case _               => None
+    case "reuters-world"        => Some(ReutersWorld)
+    case "ap-world"             => Some(ApWorld)
+    case "aap-world"            => Some(AapWorld)
+    case "all-world"            => Some(AllWorld)
+    case "afp-world"            => Some(AfpWorld)
+    case "minor-agencies-world" => Some(MinorAgenciesWorld)
+    case _                      => None
   }
 
   // format: off
@@ -730,5 +731,14 @@ object SearchPresets {
     )
   )
 
-  private val AllWorld = ApWorld ::: ReutersWorld ::: AapWorld ::: AfpWorld
+  private val MinorAgenciesWorld = List(
+    SearchParams(
+      text = None,
+      suppliersIncl = List("MINOR_AGENCIES"),
+      categoryCodesExcl = List("N2:GB")
+    )
+  )
+
+  private val AllWorld =
+    ApWorld ::: ReutersWorld ::: AapWorld ::: AfpWorld ::: MinorAgenciesWorld
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,7 @@
 			"dependencies": {
 				"@aws-sdk/client-s3": "3.637.0",
 				"@aws-sdk/rds-signer": "3.637.0",
+				"compromise": "^14.14.4",
 				"postgres": "3.4.4"
 			},
 			"devDependencies": {
@@ -9248,6 +9249,20 @@
 				"node": "^12.20.0 || >=14"
 			}
 		},
+		"node_modules/compromise": {
+			"version": "14.14.4",
+			"resolved": "https://registry.npmjs.org/compromise/-/compromise-14.14.4.tgz",
+			"integrity": "sha512-QdbJwronwxeqb7a5KFK/+Y5YieZ4PE1f7ai0vU58Pp4jih+soDCBMuKVbhDEPQ+6+vI3vSiG4UAAjTAXLJw1Qw==",
+			"license": "MIT",
+			"dependencies": {
+				"efrt": "2.7.0",
+				"grad-school": "0.0.5",
+				"suffix-thumb": "5.0.2"
+			},
+			"engines": {
+				"node": ">=12.0.0"
+			}
+		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -9788,6 +9803,15 @@
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/efrt": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/efrt/-/efrt-2.7.0.tgz",
+			"integrity": "sha512-/RInbCy1d4P6Zdfa+TMVsf/ufZVotat5hCw3QXmWtjU+3pFEOvOQ7ibo3aIxyCJw2leIeAMjmPj+1SLJiCpdrQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12.0.0"
+			}
 		},
 		"node_modules/ejs": {
 			"version": "3.1.10",
@@ -11520,6 +11544,15 @@
 			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/grad-school": {
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/grad-school/-/grad-school-0.0.5.tgz",
+			"integrity": "sha512-rXunEHF9M9EkMydTBux7+IryYXEZinRk6g8OBOGDBzo/qWJjhTxy86i5q7lQYpCLHN8Sqv1XX3OIOc7ka2gtvQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=8.0.0"
+			}
 		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
@@ -17144,6 +17177,12 @@
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
 			"integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw==",
+			"license": "MIT"
+		},
+		"node_modules/suffix-thumb": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/suffix-thumb/-/suffix-thumb-5.0.2.tgz",
+			"integrity": "sha512-I5PWXAFKx3FYnI9a+dQMWNqTxoRt6vdBdb0O+BJ1sxXCWtSoQCusc13E58f+9p4MYx/qCnEMkD5jac6K2j3dgA==",
 			"license": "MIT"
 		},
 		"node_modules/supports-color": {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add minor agencies world: since minor agencies don’t have category codes, infer the UK region category code using known UK locations, and exclude the category code from the search preset.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
