### PR TITLE
UI: move ticker button

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -166,6 +166,9 @@ export function App() {
 						<EuiHeader position="fixed">
 							<EuiHeaderSection>
 								<EuiHeaderSectionItem>
+									<SideNav />
+								</EuiHeaderSectionItem>
+								<EuiHeaderSectionItem>
 									<EuiTitle
 										size={'s'}
 										css={css`
@@ -194,29 +197,29 @@ export function App() {
 										</h1>
 									</EuiTitle>
 								</EuiHeaderSectionItem>
-								<EuiHeaderSectionItem>
-									<SideNav />
-								</EuiHeaderSectionItem>
 							</EuiHeaderSection>
+
 							<EuiHeaderSectionItem>
-								{
-									<EuiButton
-										iconType={'popout'}
-										onClick={() =>
-											window.open(
-												configToUrl({
-													...config,
-													view: 'feed',
-													itemId: undefined,
-												}),
-												'_blank',
-												'popout=true,width=400,height=800,top=200,location=no,menubar=no,toolbar=no',
-											)
-										}
-									>
-										New ticker
-									</EuiButton>
-								}
+								<EuiButton
+									css={css`
+										margin-left: 8px;
+									`}
+									size="s"
+									iconType={'popout'}
+									onClick={() =>
+										window.open(
+											configToUrl({
+												...config,
+												view: 'feed',
+												itemId: undefined,
+											}),
+											'_blank',
+											'popout=true,width=400,height=800,top=200,location=no,menubar=no,toolbar=no',
+										)
+									}
+								>
+									New ticker
+								</EuiButton>
 							</EuiHeaderSectionItem>
 						</EuiHeader>
 					)}

--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -1,8 +1,16 @@
-import { EuiBadge, EuiText } from '@elastic/eui';
+import {
+	EuiBadge,
+	EuiBeacon,
+	EuiButtonIcon,
+	EuiText,
+	useIsWithinBreakpoints,
+} from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useEffect, useState } from 'react';
 import { useSearch } from './context/SearchContext.tsx';
 import { deriveDateMathRangeLabel } from './dateHelpers.ts';
+import { Tooltip } from './Tooltip.tsx';
+import { configToUrl } from './urlState.ts';
 
 const Summary = ({ searchSummary }: { searchSummary: string }) => {
 	const { config, handleEnterQuery } = useSearch();
@@ -79,9 +87,12 @@ const Summary = ({ searchSummary }: { searchSummary: string }) => {
 
 export const SearchSummary = () => {
 	const {
-		state: { queryData },
+		state: { queryData, status },
+		config,
 	} = useSearch();
 	const [searchSummary, setSearchSummary] = useState('No results found');
+
+	const isSmallScreen = useIsWithinBreakpoints(['xs', 's']);
 
 	useEffect(() => {
 		if (queryData && queryData.totalCount > 0) {
@@ -92,6 +103,8 @@ export const SearchSummary = () => {
 			setSearchSummary('No results found');
 		}
 	}, [queryData]);
+
+	const isPoppedOut = !!window.opener;
 
 	return (
 		<EuiText
@@ -112,6 +125,53 @@ export const SearchSummary = () => {
 					padding: 0 8px;
 				`}
 			>
+				{!isPoppedOut && (
+					<Tooltip
+						tooltipContent="Open new ticker"
+						position={isSmallScreen ? 'right' : 'top'}
+					>
+						<EuiButtonIcon
+							css={css`
+								margin-right: 4px;
+							`}
+							iconType={'popout'}
+							color={'primary'}
+							onClick={() =>
+								window.open(
+									configToUrl({
+										...config,
+										view: 'feed',
+										itemId: undefined,
+									}),
+									'_blank',
+									'popout=true,width=400,height=800,top=200,location=no,menubar=no,toolbar=no',
+								)
+							}
+						/>
+					</Tooltip>
+				)}
+
+				{isPoppedOut && status === 'offline' && (
+					<div
+						style={{
+							width: '10px',
+							height: '10px',
+							backgroundColor: 'red',
+							borderRadius: '50%',
+							display: 'inline-block',
+							boxShadow: '0 0 4px red',
+						}}
+						title="Offline"
+					/>
+				)}
+
+				{isPoppedOut && status !== 'offline' && (
+					<EuiBeacon
+						css={css`
+							margin-right: 4px;
+						`}
+					/>
+				)}
 				<Summary searchSummary={searchSummary} />
 			</p>
 		</EuiText>

--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -134,6 +134,7 @@ export const SearchSummary = () => {
 							css={css`
 								margin-right: 4px;
 							`}
+							aria-label="Open new ticker in popout"
 							iconType={'popout'}
 							color={'primary'}
 							onClick={() =>

--- a/newswires/client/src/Tooltip.tsx
+++ b/newswires/client/src/Tooltip.tsx
@@ -1,7 +1,7 @@
 import type { SerializedStyles } from '@emotion/react';
 import { css, keyframes } from '@emotion/react';
 import type React from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useId, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 type TooltipPosition = 'top' | 'right' | 'bottom' | 'left';
@@ -118,6 +118,7 @@ export const Tooltip: React.FC<TooltipProps> = ({
 		left: 0,
 	});
 	const wrapperRef = useRef<HTMLDivElement>(null);
+	const tooltipId = useId();
 
 	useEffect(() => {
 		if (visible && wrapperRef.current) {
@@ -157,10 +158,26 @@ export const Tooltip: React.FC<TooltipProps> = ({
 		}
 	}, [visible, position]);
 
+	useEffect(() => {
+		if (!visible) return;
+
+		const handleKeyDown = (event: KeyboardEvent) => {
+			if (event.key === 'Escape') {
+				setVisible(false);
+			}
+		};
+
+		document.addEventListener('keydown', handleKeyDown);
+		return () => {
+			document.removeEventListener('keydown', handleKeyDown);
+		};
+	}, [visible]);
+
 	return (
 		<div
 			ref={wrapperRef}
 			css={tooltipWrapperStyle}
+			aria-describedby={visible ? tooltipId : undefined}
 			onMouseEnter={() => setVisible(true)}
 			onMouseLeave={() => setVisible(false)}
 			onFocus={() => setVisible(true)}
@@ -170,6 +187,8 @@ export const Tooltip: React.FC<TooltipProps> = ({
 			{visible &&
 				createPortal(
 					<div
+						id={tooltipId}
+						role="tooltip"
 						css={[
 							tooltipBaseStyle,
 							css`

--- a/newswires/client/src/Tooltip.tsx
+++ b/newswires/client/src/Tooltip.tsx
@@ -1,0 +1,192 @@
+import type { SerializedStyles } from '@emotion/react';
+import { css, keyframes } from '@emotion/react';
+import type React from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+type TooltipPosition = 'top' | 'right' | 'bottom' | 'left';
+
+interface TooltipProps {
+	children: React.ReactNode;
+	tooltipContent: React.ReactNode;
+	position?: TooltipPosition;
+}
+
+const tooltipWrapperStyle = css`
+	position: relative;
+	display: inline-block;
+`;
+
+const tooltipBaseStyle = css`
+	position: absolute;
+	background-color: #333;
+	color: #fff;
+	padding: 5px 8px;
+	border-radius: 4px;
+	font-size: 12px;
+	white-space: nowrap;
+	z-index: 9999; /* Ensures the tooltip appears above everything */
+`;
+
+/*
+  Define the final transforms for centering the tooltip relative to the computed coordinates.
+*/
+const finalTransform: Record<TooltipPosition, string> = {
+	top: 'translateX(-50%) translateY(-100%)',
+	bottom: 'translateX(-50%) translateY(0)',
+	left: 'translateX(-100%) translateY(-50%)',
+	right: 'translateX(0) translateY(-50%)',
+};
+
+/*
+  Define the initial transform values for a slight offset in the fade/slide animation.
+*/
+const initialTransform: Record<TooltipPosition, string> = {
+	top: 'translateX(-50%) translateY(calc(-100% + 2px))',
+	bottom: 'translateX(-50%) translateY(calc(0% - 2px))',
+	left: 'translateX(calc(-100% + 2px)) translateY(-50%)',
+	right: 'translateX(calc(0% - 2px)) translateY(-50%)',
+};
+
+const getFadeInAnimation = (position: TooltipPosition) =>
+	keyframes`
+        from {
+            opacity: 0;
+            transform: ${initialTransform[position]};
+        }
+        to {
+            opacity: 0.9;
+            transform: ${finalTransform[position]};
+        }
+    `;
+
+const arrowStyles: Record<TooltipPosition, SerializedStyles> = {
+	top: css`
+		position: absolute;
+		top: 100%;
+		left: 50%;
+		margin-left: -5px;
+		width: 0;
+		height: 0;
+		border-left: 5px solid transparent;
+		border-right: 5px solid transparent;
+		border-top: 5px solid #333;
+	`,
+	right: css`
+		position: absolute;
+		left: -5px;
+		top: 50%;
+		margin-top: -5px;
+		width: 0;
+		height: 0;
+		border-top: 5px solid transparent;
+		border-bottom: 5px solid transparent;
+		border-right: 5px solid #333;
+	`,
+	bottom: css`
+		position: absolute;
+		bottom: 100%;
+		left: 50%;
+		margin-left: -5px;
+		width: 0;
+		height: 0;
+		border-left: 5px solid transparent;
+		border-right: 5px solid transparent;
+		border-bottom: 5px solid #333;
+	`,
+	left: css`
+		position: absolute;
+		right: -5px;
+		top: 50%;
+		margin-top: -5px;
+		width: 0;
+		height: 0;
+		border-top: 5px solid transparent;
+		border-bottom: 5px solid transparent;
+		border-left: 5px solid #333;
+	`,
+};
+
+export const Tooltip: React.FC<TooltipProps> = ({
+	children,
+	tooltipContent,
+	position = 'top',
+}) => {
+	const [visible, setVisible] = useState<boolean>(false);
+	const [coords, setCoords] = useState<{ top: number; left: number }>({
+		top: 0,
+		left: 0,
+	});
+	const wrapperRef = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		if (visible && wrapperRef.current) {
+			const rect = wrapperRef.current.getBoundingClientRect();
+			const margin = 6; // margin between the element and tooltip
+			let newCoords = { top: 0, left: 0 };
+
+			switch (position) {
+				case 'top':
+					newCoords = {
+						left: rect.left + rect.width / 2,
+						top: rect.top - margin,
+					};
+					break;
+				case 'bottom':
+					newCoords = {
+						left: rect.left + rect.width / 2,
+						top: rect.bottom + margin,
+					};
+					break;
+				case 'left':
+					newCoords = {
+						left: rect.left - margin,
+						top: rect.top + rect.height / 2,
+					};
+					break;
+				case 'right':
+					newCoords = {
+						left: rect.right + margin,
+						top: rect.top + rect.height / 2,
+					};
+					break;
+				default:
+					break;
+			}
+			setCoords(newCoords);
+		}
+	}, [visible, position]);
+
+	return (
+		<div
+			ref={wrapperRef}
+			css={tooltipWrapperStyle}
+			onMouseEnter={() => setVisible(true)}
+			onMouseLeave={() => setVisible(false)}
+			onFocus={() => setVisible(true)}
+			onBlur={() => setVisible(false)}
+		>
+			{children}
+			{visible &&
+				createPortal(
+					<div
+						css={[
+							tooltipBaseStyle,
+							css`
+								animation: ${getFadeInAnimation(position)} 0.6s ease-in-out
+									forwards;
+							`,
+						]}
+						style={{
+							left: coords.left,
+							top: coords.top,
+						}}
+					>
+						{tooltipContent}
+						<span css={arrowStyles[position]} />
+					</div>,
+					document.body,
+				)}
+		</div>
+	);
+};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Add ticker buttons next to the supplier filter in the side nav (shows on hover)
- Add a ticker button in the search summary (include a tooltip)
- Add custom tooltip (as the Elastic UI tooltip doesn't work)
- Replace the ticker button in the search summary with a beacon in ticker windows (the beacon becomes red when the app goes offline)

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Supplier filter:
<img width="274" alt="Supplier filter" src="https://github.com/user-attachments/assets/c95d8e78-87c2-473b-b6e3-29f84105c62b" />

Hover state:
<img width="277" alt="Hover state" src="https://github.com/user-attachments/assets/e6291426-81e7-461c-8996-750a81135295" />


Search summary:
<img width="811" alt="Search summary" src="https://github.com/user-attachments/assets/0e0ed159-37b6-46f8-9978-d97ee5fe56bf" />

Ticker window:
<img width="1377" alt="Ticker window" src="https://github.com/user-attachments/assets/69ee5f72-a1ab-4be1-8795-103a35375884" />

Offline ticker window:
<img width="1383" alt="Offline ticker window" src="https://github.com/user-attachments/assets/5fa2c73e-e9b5-41b2-9264-9d5c28f592c3" />


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
