### PR TITLE
UI: make Alert messages smaller

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -66,6 +66,7 @@ const Alert = ({
 				border-radius: 0;
 				background: #fdf6d8;
 				position: fixed;
+				z-index: 1000;
 			`}
 		></EuiToast>
 	</div>
@@ -96,6 +97,11 @@ export function App() {
 		if (persist) {
 			saveToLocalStorage<boolean>('displayDisclaimer', false);
 		}
+	};
+
+	const breakpoints = {
+		sm: '@media (max-width: 600px)',
+		md: '@media (min-width: 900px)',
 	};
 
 	return (
@@ -170,7 +176,11 @@ export function App() {
 				<div
 					css={css`
 						${(status === 'offline' || isRestricted(query.dateRange?.end)) &&
-						'padding-top: 40px;'}
+						`padding-top: 40px;
+						  ${breakpoints.sm} {
+							padding-top: 72px;
+						  }
+						`}
 						height: 100%;
 						${(status === 'loading' || status === 'error') &&
 						'display: flex; align-items: center;'}

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -21,6 +21,7 @@ import {
 	EuiText,
 	EuiTitle,
 	EuiToast,
+	useIsWithinMinBreakpoint,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useState } from 'react';
@@ -44,33 +45,38 @@ const Alert = ({
 }: {
 	title: string;
 	icon?: string;
-}) => (
-	<div
-		css={css`
-			.euiToast.header-only span {
-				font-weight: 500;
-				font-size: 1rem;
-			}
+}) => {
+	const isOnLargerScreen = useIsWithinMinBreakpoint('l');
 
-			.euiToast.header-only svg {
-				top: 2px;
-			}
-		`}
-	>
-		<EuiToast
-			title={title}
-			iconType={icon}
-			className={'header-only'}
+	return (
+		<div
 			css={css`
-				padding: 8px;
-				border-radius: 0;
-				background: #fdf6d8;
-				position: fixed;
-				z-index: 1000;
+				.euiToast.header-only span {
+					font-weight: 500;
+					font-size: 1rem;
+				}
+
+				.euiToast.header-only svg {
+					top: 2px;
+				}
 			`}
-		></EuiToast>
-	</div>
-);
+		>
+			<EuiToast
+				title={title}
+				iconType={icon}
+				className={'header-only'}
+				css={css`
+					padding: 8px;
+					border-radius: 0;
+					background: #fdf6d8;
+					position: fixed;
+					z-index: 1000;
+					${isOnLargerScreen && 'width: calc(100% - 300px)'}
+				`}
+			></EuiToast>
+		</div>
+	);
+};
 
 export function App() {
 	const {

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -41,23 +41,34 @@ import { configToUrl, defaultQuery } from './urlState';
 const Alert = ({
 	title,
 	icon = 'warning',
-	children,
 }: {
 	title: string;
 	icon?: string;
-	children: React.ReactNode;
 }) => (
-	<EuiToast
-		title={title}
-		iconType={icon}
+	<div
 		css={css`
-			border-radius: 0;
-			background: #fdf6d8;
-			position: fixed;
+			.euiToast.header-only span {
+				font-weight: 500;
+				font-size: 1rem;
+			}
+
+			.euiToast.header-only svg {
+				top: 2px;
+			}
 		`}
 	>
-		<p>{children}</p>
-	</EuiToast>
+		<EuiToast
+			title={title}
+			iconType={icon}
+			className={'header-only'}
+			css={css`
+				padding: 8px;
+				border-radius: 0;
+				background: #fdf6d8;
+				position: fixed;
+			`}
+		></EuiToast>
+	</div>
 );
 
 export function App() {
@@ -143,23 +154,23 @@ export function App() {
 					</EuiModal>
 				)}
 				{status === 'offline' && (
-					<Alert title="You Are Currently Offline">
-						The application is no longer retrieving updates. Data
-						synchronization will resume once connectivity is restored.
-					</Alert>
+					<Alert
+						title="The application is no longer retrieving updates. Data
+                        synchronization will resume once connectivity is restored."
+					/>
 				)}
 				{isRestricted(query.dateRange?.end) &&
 					status !== 'offline' &&
 					status !== 'error' && (
-						<Alert title="Restricted">
-							Your current filter settings exclude recent updates. Adjust the
-							filter to see the latest data.
-						</Alert>
+						<Alert
+							title="Your current filter settings exclude recent updates. Adjust the
+							filter to see the latest data."
+						/>
 					)}
 				<div
 					css={css`
 						${(status === 'offline' || isRestricted(query.dateRange?.end)) &&
-						'padding-top: 84px;'}
+						'padding-top: 40px;'}
 						height: 100%;
 						${(status === 'loading' || status === 'error') &&
 						'display: flex; align-items: center;'}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Reduce the height of alert messages. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Restricted search:
<img width="1701" alt="Restricted search" src="https://github.com/user-attachments/assets/15740f13-e901-4999-838c-73561d6a67d1" />

Offline:
<img width="1714" alt="Offline" src="https://github.com/user-attachments/assets/31c723cb-49cd-4ceb-8fb1-8781cb4371a5" />


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
