### PR TITLE
Enable monitoring in PROD

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -2,12 +2,8 @@ import 'source-map-support/register';
 import { RiffRaffYamlFile } from '@guardian/cdk/lib/riff-raff-yaml-file';
 import { App } from 'aws-cdk-lib';
 import { STACK } from '../../shared/constants';
-import type {
-	PollerId} from '../../shared/pollers';
-import {
-	pollerIdToLambdaAppName,
-	POLLERS_CONFIG,
-} from '../../shared/pollers';
+import type { PollerId } from '../../shared/pollers';
+import { pollerIdToLambdaAppName, POLLERS_CONFIG } from '../../shared/pollers';
 import { Newswires } from '../lib/newswires';
 import { WiresFeeds } from '../lib/wires-feeds';
 
@@ -44,7 +40,7 @@ new Newswires(app, 'Newswires-PROD', {
 	stack: STACK,
 	stage: 'PROD',
 	domainName: 'newswires.gutools.co.uk',
-	enableMonitoring: false,
+	enableMonitoring: true,
 	sourceQueue: prodWiresFeeds.sourceQueue,
 	fingerpostQueue: prodWiresFeeds.fingerpostQueue,
 }).addDependency(prodWiresFeeds);


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Enable GuCDK's default monitoring EC2 configuration for the PROD server.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
