### PR TITLE
Update Reuters World preset

### DIFF
--- a/ingestion-lambda/src/categoryCodes.test.ts
+++ b/ingestion-lambda/src/categoryCodes.test.ts
@@ -4,9 +4,17 @@ import {
 	processFingerpostAFPCategoryCodes,
 	processFingerpostAPCategoryCodes,
 	processFingerpostPACategoryCodes,
+	processReutersCategoryCodes,
 	processUnknownFingerpostCategoryCodes,
 } from './categoryCodes';
 import {processCategoryCodes} from "./handler";
+
+
+describe('processReutersCategoryCodes', () => {
+	it('should return formatted custom cat codes for known destinations and ignores the rest', () => {
+		expect(processReutersCategoryCodes(['RWSA','RNP'])).toEqual(['REUTERS:RWSA']);
+	});
+});
 
 describe('processFingerpostAPCategoryCodes', () => {
 	it('should return an empty array if provided with an empty array', () => {

--- a/ingestion-lambda/src/categoryCodes.ts
+++ b/ingestion-lambda/src/categoryCodes.ts
@@ -39,6 +39,15 @@ function replacePrefixesFromLookup(
 	const newPrefix = lookup[prefix] ?? prefix;
 	return { prefix: newPrefix, code };
 }
+
+export function processReutersCategoryCodes(original: string[]): string[] {
+	const supportedDestinations: string[] = ['RWS', 'RNA', 'RWSA', 'REULB', 'RBN'];
+
+	return original
+		.filter((_) => supportedDestinations.includes(_))
+		.map((_) => `REUTERS:${_}`);
+}
+
 export function processFingerpostAPCategoryCodes(original: string[]): string[] {
 	const notServiceCodes = original.filter((_) => !_.includes('service:')); // we aren't interested in keeping the service codes here
 	const transformedCategoryCodes = notServiceCodes

--- a/ingestion-lambda/src/handler.ts
+++ b/ingestion-lambda/src/handler.ts
@@ -13,7 +13,7 @@ import {
 	processFingerpostAAPCategoryCodes,
 	processFingerpostAFPCategoryCodes,
 	processFingerpostAPCategoryCodes,
-	processFingerpostPACategoryCodes,
+	processFingerpostPACategoryCodes, processReutersCategoryCodes,
 	processUnknownFingerpostCategoryCodes,
 } from './categoryCodes';
 import { tableName } from './database';
@@ -73,6 +73,8 @@ export const processKeywords = (
 
 export const processCategoryCodes = async (supplier: string, subjectCodes: string[], bodyText: string | undefined) => {
 	switch (supplier) {
+		case 'REUTERS':
+			return processReutersCategoryCodes(subjectCodes)
 		case 'AP':
 			return processFingerpostAPCategoryCodes(subjectCodes);
 		case 'AAP':
@@ -221,7 +223,10 @@ export const main = async (event: SQSEvent): Promise<SQSBatchResponse> => {
 
 						const categoryCodes = await processCategoryCodes(
 							supplier,
-							snsMessageContent.subjects?.code ?? [],
+							[
+								...(snsMessageContent.subjects?.code ?? []),
+								...(snsMessageContent.destination ?? [])
+							],
 							`${snsMessageContent.headline ?? ''} ${snsMessageContent.abstract ?? ''} ${snsMessageContent.body_text}`
 						);
 

--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -688,7 +688,16 @@ object SearchPresets {
       text = None,
       suppliersIncl = List("REUTERS"),
       categoryCodesIncl = List(
+        "REUTERS:RWS",
+        "REUTERS:RNA"
+      )
+    ),
+    SearchParams(
+      text = None,
+      suppliersIncl = List("REUTERS"),
+      categoryCodesIncl = List(
         "MCC:OVR",
+        "MCC:QFE",
         "MCCL:OVR",
         "MCCL:OSM",
         "N2:US"

--- a/newswires/client/src/category-code-lookup-tables.ts
+++ b/newswires/client/src/category-code-lookup-tables.ts
@@ -6760,4 +6760,14 @@ export const lookupTables: Array<{
 			'M:1QK': 'Corporate Taxation',
 		},
 	},
+	{
+		name: 'Reuters Destination Codes',
+		lookup: {
+			'REUTERS:RWS': 'Reuters World Service',
+			'REUTERS:RNA': 'Reuters North America',
+			'REUTERS:RWSA': 'Reuters World Service America',
+			'REUTERS:REULB': 'Reuters UK/London Business',
+			'REUTERS:RBN': 'Reuters Business News',
+		},
+	},
 ];

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -34,6 +34,7 @@ export const WireDataSchema = z.object({
 	externalId: z.string(),
 	ingestedAt: z.string(),
 	categoryCodes: z.array(z.string()),
+	destination: z.array(z.string()).optional(),
 	content: FingerpostContentSchema,
 	composerId: z.string().optional(),
 	composerSentBy: z.string().optional(),

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -35,6 +35,7 @@ const FingerpostFeedPayloadSchema = z.object({
 			code: OptionalStringOrArrayAsArrayOfStrings,
 		})
 		.optional(),
+	destination:  z.array(z.string()).optional().nullable(),
 	mediaCatCodes: z.string().optional(),
 	keywords: OptionalStringOrArrayAsArrayOfStrings,
 	organisation: z


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Ingest destination codes for Reuters stories. Reuters destination codes are saved as custom cat codes and used for routing stories (e.g., RWS, which stands for Reuters World Story).

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
