### PR TITLE
Ingestion: fix reuters cat codes

### DIFF
--- a/ingestion-lambda/src/categoryCodes.test.ts
+++ b/ingestion-lambda/src/categoryCodes.test.ts
@@ -4,15 +4,15 @@ import {
 	processFingerpostAFPCategoryCodes,
 	processFingerpostAPCategoryCodes,
 	processFingerpostPACategoryCodes,
-	processReutersCategoryCodes,
+	processReutersDestinationCodes,
 	processUnknownFingerpostCategoryCodes,
 } from './categoryCodes';
 import {processCategoryCodes} from "./handler";
 
 
-describe('processReutersCategoryCodes', () => {
+describe('processReutersDestinationCodes', () => {
 	it('should return formatted custom cat codes for known destinations and ignores the rest', () => {
-		expect(processReutersCategoryCodes(['RWSA','RNP'])).toEqual(['REUTERS:RWSA']);
+		expect(processReutersDestinationCodes(['RWSA','RNP'])).toEqual(['REUTERS:RWSA']);
 	});
 });
 
@@ -296,6 +296,6 @@ describe('inferRegionCategoryFromText', () => {
 describe('processCategoryCodes', () => {
 	it('should filter out empty category codes', async () => {
 		const content = 'US and EU leaders meet in Paris to discuss international trade agreements.';
-		expect(await processCategoryCodes('MINOR_AGENCIES', [""], content)).toEqual([]);
+		expect(await processCategoryCodes('MINOR_AGENCIES', [""], [], content)).toEqual([]);
 	});
 })

--- a/ingestion-lambda/src/categoryCodes.ts
+++ b/ingestion-lambda/src/categoryCodes.ts
@@ -40,7 +40,7 @@ function replacePrefixesFromLookup(
 	return { prefix: newPrefix, code };
 }
 
-export function processReutersCategoryCodes(original: string[]): string[] {
+export function processReutersDestinationCodes(original: string[]): string[] {
 	const supportedDestinations: string[] = ['RWS', 'RNA', 'RWSA', 'REULB', 'RBN'];
 
 	return original


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Fix issue with Reuters cat codes.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
