### PR TITLE
Ingestion: debug content received from fingerpost

### DIFF
--- a/ingestion-lambda/src/handler.ts
+++ b/ingestion-lambda/src/handler.ts
@@ -219,13 +219,14 @@ export const main = async (event: SQSEvent): Promise<SQSBatchResponse> => {
 
 						const snsMessageContent = safeBodyParse(body);
 
+
 						const supplier =
 							lookupSupplier(snsMessageContent['source-feed']) ?? 'Unknown';
 
 						const categoryCodes = await processCategoryCodes(
 							supplier,
 							snsMessageContent.subjects?.code ?? [],
-							snsMessageContent.destination ?? [],
+							snsMessageContent.destinations?.code ?? [],
 							`${snsMessageContent.headline ?? ''} ${snsMessageContent.abstract ?? ''} ${snsMessageContent.body_text}`
 						);
 

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -25,6 +25,9 @@ const FingerpostContentSchema = z
 		abstract: z.string(),
 		bodyText: z.string(),
 		ednote: z.string(),
+		destinations: z.object({
+			code: z.array(z.string()),
+		}),
 	})
 	.partial();
 
@@ -34,7 +37,6 @@ export const WireDataSchema = z.object({
 	externalId: z.string(),
 	ingestedAt: z.string(),
 	categoryCodes: z.array(z.string()),
-	destination: z.array(z.string()).optional(),
 	content: FingerpostContentSchema,
 	composerId: z.string().optional(),
 	composerSentBy: z.string().optional(),

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -35,7 +35,11 @@ const FingerpostFeedPayloadSchema = z.object({
 			code: OptionalStringOrArrayAsArrayOfStrings,
 		})
 		.optional(),
-	destination:  z.array(z.string()).optional().nullable(),
+	destinations: z
+		.object({
+			code: OptionalStringOrArrayAsArrayOfStrings,
+		})
+		.optional(),
 	mediaCatCodes: z.string().optional(),
 	keywords: OptionalStringOrArrayAsArrayOfStrings,
 	organisation: z


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Fix the ingestion of the destinations field for Reuters stories.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
