### PR TITLE
UI: improve ticker spacing

### DIFF
--- a/newswires/client/src/Feed.tsx
+++ b/newswires/client/src/Feed.tsx
@@ -15,8 +15,11 @@ export const Feed = () => {
 	const { state } = useSearch();
 	const { status, queryData } = state;
 
+	const isPoppedOut = !!window.opener;
+
 	return (
 		<EuiPageTemplate.Section
+			paddingSize={isPoppedOut ? 's' : 'm'}
 			css={css`
 				padding: 0 0.5rem;
 			`}
@@ -62,9 +65,11 @@ export const Feed = () => {
 								<EuiFlexItem style={{ flex: 1 }}>
 									<SearchSummary />
 								</EuiFlexItem>
-								<EuiFlexItem grow={false}>
-									<DatePicker />
-								</EuiFlexItem>
+								{!isPoppedOut && (
+									<EuiFlexItem grow={false}>
+										<DatePicker />
+									</EuiFlexItem>
+								)}
 							</EuiFlexGroup>
 						</div>
 

--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -14,10 +14,12 @@ import { configToUrl } from './urlState.ts';
 
 const presetLabel = (preset: string) => {
 	switch (preset) {
+		case 'all-uk':
+			return 'UK';
 		case 'all-world':
 			return 'World';
 		default:
-			return '';
+			return preset;
 	}
 };
 

--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -12,7 +12,11 @@ import { deriveDateMathRangeLabel, isRestricted } from './dateHelpers.ts';
 import { Tooltip } from './Tooltip.tsx';
 import { configToUrl } from './urlState.ts';
 
-const Summary = ({ searchSummary }: { searchSummary: string }) => {
+const Summary = ({
+	searchSummaryLabel,
+}: {
+	searchSummaryLabel: string | boolean;
+}) => {
 	const { config, handleEnterQuery } = useSearch();
 	const {
 		q,
@@ -66,10 +70,12 @@ const Summary = ({ searchSummary }: { searchSummary: string }) => {
 
 	return (
 		<>
-			<span>
-				{searchSummary}
-				{displayFilters && ' for: '}
-			</span>
+			{searchSummaryLabel && (
+				<span>
+					{searchSummaryLabel}
+					{displayFilters && ' for: '}
+				</span>
+			)}
 			{dateRange &&
 				renderBadge(
 					'Time range',
@@ -183,7 +189,7 @@ export const SearchSummary = () => {
 							/>
 						</Tooltip>
 					)}
-				<Summary searchSummary={searchSummary} />
+				<Summary searchSummaryLabel={!isPoppedOut && searchSummary} />
 			</p>
 		</EuiText>
 	);


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Reduce spacing at the top of ticker windows to allow more space for the news feed.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before:
<img width="402" alt="Before" src="https://github.com/user-attachments/assets/e01d3c2a-7bfd-4db3-8559-6ae9898013a9" />

After:
<img width="408" alt="After" src="https://github.com/user-attachments/assets/06613f7a-2490-40c8-989f-a745c843be8a" />



## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
