### PR TITLE
Add window config and telemetry provider to stories

### DIFF
--- a/newswires/client/.storybook/preview-head.html
+++ b/newswires/client/.storybook/preview-head.html
@@ -1,0 +1,6 @@
+<script>
+	var data = {};
+	window.configuration = {
+		switches: { abc: 1 },
+	};
+</script>

--- a/newswires/client/src/Item.stories.tsx
+++ b/newswires/client/src/Item.stories.tsx
@@ -1,6 +1,7 @@
 import { EuiProvider } from '@elastic/eui';
 import type { Meta, StoryObj } from '@storybook/react';
 import { SearchContextProvider } from './context/SearchContext';
+import { TelemetryContextProvider } from './context/TelemetryContext';
 import { setUpIcons } from './icons';
 import { Item } from './Item';
 
@@ -42,11 +43,13 @@ const meta = {
 	decorators: [
 		(Story) => (
 			<EuiProvider colorMode="light">
-				<SearchContextProvider>
-					<div style={{ maxWidth: '800px', margin: '0 auto' }}>
-						<Story />
-					</div>
-				</SearchContextProvider>
+				<TelemetryContextProvider sendTelemetryEvent={console.log}>
+					<SearchContextProvider>
+						<div style={{ maxWidth: '800px', margin: '0 auto' }}>
+							<Story />
+						</div>
+					</SearchContextProvider>
+				</TelemetryContextProvider>
 			</EuiProvider>
 		),
 	],

--- a/newswires/client/src/SearchBox.stories.tsx
+++ b/newswires/client/src/SearchBox.stories.tsx
@@ -1,6 +1,7 @@
 import { EuiProvider } from '@elastic/eui';
 import type { Meta, StoryObj } from '@storybook/react';
 import { SearchContextProvider } from './context/SearchContext';
+import { TelemetryContextProvider } from './context/TelemetryContext';
 import { setUpIcons } from './icons';
 import { SearchBox } from './SearchBox';
 
@@ -14,9 +15,11 @@ const meta = {
 	decorators: [
 		(Story) => (
 			<EuiProvider colorMode="light">
-				<SearchContextProvider>
-					<Story />
-				</SearchContextProvider>
+				<TelemetryContextProvider sendTelemetryEvent={console.log}>
+					<SearchContextProvider>
+						<Story />
+					</SearchContextProvider>
+				</TelemetryContextProvider>
 			</EuiProvider>
 		),
 	],


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?


A couple of recent PRs introduced dependencies which hadn't been added to the storybook config.


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
