### PR TITLE
Fix copy & paste of body text

### DIFF
--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -10,7 +10,6 @@ import {
 	EuiDescriptionListTitle,
 	EuiFlexGroup,
 	EuiFlexItem,
-	EuiScreenReaderOnly,
 	EuiSpacer,
 	EuiText,
 	EuiTitle,
@@ -261,14 +260,21 @@ export const WireDetail = ({
 				</EuiFlexItem>
 			</EuiFlexGroup>
 			<EuiSpacer size="s" />
-
-			<EuiSpacer size="s" />
 			{isShowingJson ? (
 				<EuiCodeBlock language="json">
 					{JSON.stringify(wire, null, 2)}
 				</EuiCodeBlock>
 			) : (
-				<>
+				<div
+					css={css`
+						& mark {
+							background-color: ${theme.euiTheme.colors.highlight};
+							font-weight: bold;
+							position: relative;
+							border: 3px solid ${theme.euiTheme.colors.highlight};
+						}
+					`}
+				>
 					<EuiSpacer size="xs" />
 					<h3
 						css={css`
@@ -279,65 +285,47 @@ export const WireDetail = ({
 					</h3>
 					<EuiSpacer size="s" />
 					{ednote && <EuiCallOut size="s" title={ednote} color="success" />}
-					<EuiSpacer size="s" />
+					<EuiSpacer size="m" />
+
+					{byline && (
+						<>
+							<p
+								css={css`
+									font-style: italic;
+								`}
+							>
+								Byline: {byline}
+							</p>
+							<EuiSpacer size="m" />
+						</>
+					)}
+					{safeAbstract && wire.supplier === AP && (
+						<>
+							<p>(abstract) {safeAbstract}</p>
+							<EuiSpacer size="m" />
+						</>
+					)}
+					{bodyTextContent && (
+						<>
+							<article
+								dangerouslySetInnerHTML={{ __html: bodyTextContent }}
+								css={css`
+									& p {
+										margin-bottom: ${theme.euiTheme.size.s};
+									}
+								`}
+								data-pinboard-selection-target
+							/>
+							<EuiSpacer size="m" />
+						</>
+					)}
 					<EuiDescriptionList
 						css={css`
-							& mark {
-								background-color: ${theme.euiTheme.colors.highlight};
-								font-weight: bold;
-								position: relative;
-								border: 3px solid ${theme.euiTheme.colors.highlight};
-							}
-
 							display: flex;
 							flex-direction: column;
 							gap: ${theme.euiTheme.size.s};
 						`}
 					>
-						{byline && (
-							<>
-								<EuiScreenReaderOnly>
-									<EuiDescriptionListTitle>Byline</EuiDescriptionListTitle>
-								</EuiScreenReaderOnly>
-								<EuiDescriptionListDescription>
-									<p
-										css={css`
-											font-style: italic;
-										`}
-									>
-										{byline}
-									</p>
-								</EuiDescriptionListDescription>
-							</>
-						)}
-						{safeAbstract && wire.supplier === AP && (
-							<>
-								<EuiScreenReaderOnly>
-									<EuiDescriptionListTitle>Abstract</EuiDescriptionListTitle>
-								</EuiScreenReaderOnly>
-								<EuiDescriptionListDescription>
-									<p>(abstract) {safeAbstract}</p>
-								</EuiDescriptionListDescription>
-							</>
-						)}
-						{bodyTextContent && (
-							<>
-								<EuiScreenReaderOnly>
-									<EuiDescriptionListTitle>Body text</EuiDescriptionListTitle>
-								</EuiScreenReaderOnly>
-								<EuiDescriptionListDescription>
-									<article
-										dangerouslySetInnerHTML={{ __html: bodyTextContent }}
-										css={css`
-											& p {
-												margin-bottom: ${theme.euiTheme.size.s};
-											}
-										`}
-										data-pinboard-selection-target
-									/>
-								</EuiDescriptionListDescription>
-							</>
-						)}
 						{nonEmptyKeywords.length > 0 && (
 							<>
 								<EuiDescriptionListTitle>Keywords</EuiDescriptionListTitle>
@@ -374,7 +362,7 @@ export const WireDetail = ({
 							<EuiSpacer />
 						</EuiDescriptionListDescription>
 					</EuiDescriptionList>
-				</>
+				</div>
 			)}
 		</>
 	);

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -283,10 +283,13 @@ export const WireDetail = ({
 					>
 						{wire.content.subhead}
 					</h3>
-					<EuiSpacer size="s" />
-					{ednote && <EuiCallOut size="s" title={ednote} color="success" />}
 					<EuiSpacer size="m" />
-
+					{ednote && (
+						<>
+							<EuiCallOut size="s" title={ednote} color="success" />
+							<EuiSpacer size="m" />
+						</>
+					)}
 					{byline && (
 						<>
 							<p


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Copy & paste was often bringing in visually hidden fields, and list styling, which is not ideal.

On reflection, there's no great need for the byline, body text and abstract to be rendered as part of the description list, because they're the main content of the item. So a simple solution is to pull them out of it.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

|Before|After|
|-|-|
|<img width="798" alt="image" src="https://github.com/user-attachments/assets/6779d7a8-2634-4412-9ea4-fd910cc3d970" />|<img width="796" alt="image" src="https://github.com/user-attachments/assets/5d90ed21-e90c-40ac-9b71-1921bfb1852b" />|

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
