### PR TITLE
improve esm interop in ts config for bundled code

### DIFF
--- a/ingestion-lambda/package.json
+++ b/ingestion-lambda/package.json
@@ -6,7 +6,7 @@
 		"dev": "ts-node-dev --respawn localRun.ts",
 		"typecheck": "tsc -noEmit",
 		"build": "esbuild src/handler.ts --bundle --minify --outfile=dist/handler.js --external:@aws-sdk --external:aws-sdk --platform=node",
-		"test": "cross-env NODE_OPTIONS=--experimental-vm-modules jest --detectOpenHandles --config ../jest.config.js --selectProjects ingestion-lambda",
+		"test": "jest --detectOpenHandles --config ../jest.config.js --selectProjects ingestion-lambda",
 		"lint": "eslint src/** --ext .ts --no-error-on-unmatched-pattern --fix",
 		"lint:ci": "eslint src/** --ext .ts --no-error-on-unmatched-pattern"
 	},
@@ -18,7 +18,6 @@
 	},
 	"devDependencies": {
 		"@types/aws-lambda": "8.10.145",
-		"cross-env": "^7.0.3",
 		"lorem-ipsum": "2.0.8"
 	}
 }

--- a/ingestion-lambda/src/categoryCodes.test.ts
+++ b/ingestion-lambda/src/categoryCodes.test.ts
@@ -253,49 +253,49 @@ describe('processUnknownFingerpostCategoryCodes', () => {
 });
 
 describe('inferRegionCategoryFromText', () => {
-	it('should return undefined if provided with an string', async () => {
-		expect(await inferRegionCategoryFromText('')).toEqual(undefined);
+	it('should return undefined if provided with an string', () => {
+		expect(inferRegionCategoryFromText('')).toEqual(undefined);
 	});
 
-	it('should return N2:GB when a UK country is mentioned', async () => {
+	it('should return N2:GB when a UK country is mentioned', () => {
 		const content = 'Prime Minister visits Scotland to address economic concerns in rural areas.';
-		expect(await inferRegionCategoryFromText(content)).toEqual('N2:GB');
+		expect(inferRegionCategoryFromText(content)).toEqual('N2:GB');
 	});
 
-	it('should return N2:GB for a UK city is mentioned', async () => {
+	it('should return N2:GB for a UK city is mentioned', () => {
 		const content = 'Manchester sees surge in tech sector jobs as new startups attract global investment.';
-		expect(await inferRegionCategoryFromText(content)).toEqual('N2:GB');
+		expect(inferRegionCategoryFromText(content)).toEqual('N2:GB');
 	});
 
-	it('should return N2:GB for a UK region is mentioned', async () => {
+	it('should return N2:GB for a UK region is mentioned', () => {
 		const content = 'Heavy rainfall causes flooding in the Lake District, prompting emergency response.';
-		expect(await inferRegionCategoryFromText(content)).toEqual('N2:GB');
+		expect(inferRegionCategoryFromText(content)).toEqual('N2:GB');
 	});
 
-	it('should return N2:GB even with varied casing and punctuation in text', async () => {
+	it('should return N2:GB even with varied casing and punctuation in text', () => {
 		const content = 'BREAKING: london officials respond to transportation delays across the city.';
-		expect(await inferRegionCategoryFromText(content)).toEqual('N2:GB');
+		expect(inferRegionCategoryFromText(content)).toEqual('N2:GB');
 	});
 
-	it('should return N2:GB when a London borough is mentioned', async () => {
+	it('should return N2:GB when a London borough is mentioned', () => {
 		const content = 'Hackney council launches initiative to support local small businesses amid rising rents.';
-		expect(await inferRegionCategoryFromText(content)).toEqual('N2:GB');
+		expect(inferRegionCategoryFromText(content)).toEqual('N2:GB');
 	});
 
-	it('should return N2:GB when a UK landmark is mentioned', async () => {
+	it('should return N2:GB when a UK landmark is mentioned', () => {
 		const content = 'Thousands of tourists expected at Stonehenge for the summer solstice celebrations.';
-		expect(await inferRegionCategoryFromText(content)).toEqual('N2:GB');
+		expect(inferRegionCategoryFromText(content)).toEqual('N2:GB');
 	});
 
-	it('should return undefined when only non-UK places are mentioned', async () => {
+	it('should return undefined when only non-UK places are mentioned', () => {
 		const content = 'US and EU leaders meet in Paris to discuss international trade agreements.';
-		expect(await inferRegionCategoryFromText(content)).toEqual(undefined);
+		expect(inferRegionCategoryFromText(content)).toEqual(undefined);
 	});
 });
 
 describe('processCategoryCodes', () => {
-	it('should filter out empty category codes', async () => {
+	it('should filter out empty category codes', () => {
 		const content = 'US and EU leaders meet in Paris to discuss international trade agreements.';
-		expect(await processCategoryCodes('MINOR_AGENCIES', [""], [], content)).toEqual([]);
+		expect(processCategoryCodes('MINOR_AGENCIES', [""], [], content)).toEqual([]);
 	});
 })

--- a/ingestion-lambda/src/categoryCodes.ts
+++ b/ingestion-lambda/src/categoryCodes.ts
@@ -1,3 +1,4 @@
+import nlp from 'compromise';
 import {lexicon, ukPlaces} from "./ukPlaces";
 
 interface CategoryCode {
@@ -122,12 +123,10 @@ export function processUnknownFingerpostCategoryCodes(
 	return deduped;
 }
 
-export async function inferRegionCategoryFromText(content: string | undefined): Promise<string | undefined> {
+export function inferRegionCategoryFromText(content: string | undefined): string | undefined {
 	if (!content) {
 		return undefined;
 	}
-
-	const { default: nlp } = await import('compromise');
 
 	const doc = nlp(content, lexicon) as {
 		places: () => { out: (format: string) => unknown };

--- a/ingestion-lambda/src/handler.ts
+++ b/ingestion-lambda/src/handler.ts
@@ -72,7 +72,7 @@ export const processKeywords = (
 	return cleanAndDedupeKeywords(keywords.split('+'));
 };
 
-export const processCategoryCodes = async (supplier: string, subjectCodes: string[], destinationCodes: string[], bodyText: string | undefined) => {
+export const processCategoryCodes = (supplier: string, subjectCodes: string[], destinationCodes: string[], bodyText: string | undefined) => {
 	switch (supplier) {
 		case 'REUTERS':
 			return [...subjectCodes, ...processReutersDestinationCodes(destinationCodes)]
@@ -85,7 +85,7 @@ export const processCategoryCodes = async (supplier: string, subjectCodes: strin
 		case 'PA':
 			return processFingerpostPACategoryCodes(subjectCodes);
 		case 'MINOR_AGENCIES': {
-			const region = await inferRegionCategoryFromText(bodyText);
+			const region = inferRegionCategoryFromText(bodyText);
 			const updatedSubjectCodes = region ? [...subjectCodes, region] : subjectCodes
 			return updatedSubjectCodes.filter(_ => _.length > 0);
 		}
@@ -223,7 +223,7 @@ export const main = async (event: SQSEvent): Promise<SQSBatchResponse> => {
 						const supplier =
 							lookupSupplier(snsMessageContent['source-feed']) ?? 'Unknown';
 
-						const categoryCodes = await processCategoryCodes(
+						const categoryCodes = processCategoryCodes(
 							supplier,
 							snsMessageContent.subjects?.code ?? [],
 							snsMessageContent.destinations?.code ?? [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,6 @@
 			},
 			"devDependencies": {
 				"@types/aws-lambda": "8.10.145",
-				"cross-env": "^7.0.3",
 				"lorem-ipsum": "2.0.8"
 			}
 		},
@@ -9997,25 +9996,6 @@
 			"integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/cross-env": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
-			"integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cross-spawn": "^7.0.1"
-			},
-			"bin": {
-				"cross-env": "src/bin/cross-env.js",
-				"cross-env-shell": "src/bin/cross-env-shell.js"
-			},
-			"engines": {
-				"node": ">=10.14",
-				"npm": ">=6",
-				"yarn": ">=1"
-			}
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
 	"extends": "@guardian/tsconfig/tsconfig.json",
 	"compilerOptions": {
-		"module": "nodenext",
-		"moduleResolution": "nodenext",
+		"module": "esnext",
+		"moduleResolution": "bundler",
 		"esModuleInterop": true
 	}
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
