### PR TITLE
Add toggle for 'compact view' (hide subheadings from feed)

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -3,6 +3,7 @@ import {
 	EuiButton,
 	EuiButtonEmpty,
 	EuiEmptyPrompt,
+	EuiFlexGroup,
 	EuiHeader,
 	EuiHeaderSection,
 	EuiHeaderSectionItem,
@@ -33,6 +34,7 @@ import { isRestricted } from './dateHelpers.ts';
 import { Feed } from './Feed';
 import { FeedbackContent } from './FeedbackContent.tsx';
 import { ItemData } from './ItemData.tsx';
+import { SettingsMenu } from './SettingsMenu.tsx';
 import { SideNav } from './SideNav';
 import { configToUrl, defaultQuery } from './urlState';
 
@@ -200,26 +202,31 @@ export function App() {
 							</EuiHeaderSection>
 
 							<EuiHeaderSectionItem>
-								<EuiButton
+								<EuiFlexGroup
+									gutterSize="xs"
 									css={css`
 										margin-left: 8px;
 									`}
-									size="s"
-									iconType={'popout'}
-									onClick={() =>
-										window.open(
-											configToUrl({
-												...config,
-												view: 'feed',
-												itemId: undefined,
-											}),
-											'_blank',
-											'popout=true,width=400,height=800,top=200,location=no,menubar=no,toolbar=no',
-										)
-									}
 								>
-									New ticker
-								</EuiButton>
+									<EuiButton
+										size="s"
+										iconType={'popout'}
+										onClick={() =>
+											window.open(
+												configToUrl({
+													...config,
+													view: 'feed',
+													itemId: undefined,
+												}),
+												'_blank',
+												'popout=true,width=400,height=800,top=200,location=no,menubar=no,toolbar=no',
+											)
+										}
+									>
+										New ticker
+									</EuiButton>
+									<SettingsMenu />
+								</EuiFlexGroup>
 							</EuiHeaderSectionItem>
 						</EuiHeader>
 					)}

--- a/newswires/client/src/SettingsMenu.tsx
+++ b/newswires/client/src/SettingsMenu.tsx
@@ -1,0 +1,81 @@
+import {
+	EuiButtonIcon,
+	EuiContextMenu,
+	EuiFormRow,
+	EuiPopover,
+	EuiSwitch,
+	useGeneratedHtmlId,
+} from '@elastic/eui';
+import { useState } from 'react';
+import { useUserSettings } from './context/UserSettingsContext';
+
+export const SettingsMenu = () => {
+	const { showSecondaryFeedContent, toggleShowSecondaryFeedContent } =
+		useUserSettings();
+
+	const [isPopoverOpen, setPopover] = useState(false);
+
+	const contextMenuPopoverId = useGeneratedHtmlId({
+		prefix: 'contextMenuPopover',
+	});
+	const embeddedCodeSwitchId__1 = useGeneratedHtmlId({
+		prefix: 'embeddedCodeSwitchId',
+	});
+
+	const onButtonClick = () => {
+		setPopover(!isPopoverOpen);
+	};
+
+	const closePopover = () => {
+		setPopover(false);
+	};
+
+	const panels = [
+		{
+			id: 0,
+			title: 'Site settings',
+			items: [
+				{
+					renderItem: () => (
+						<div style={{ padding: 16 }}>
+							<EuiFormRow hasChildLabel={true}>
+								<EuiSwitch
+									name="switch"
+									id={embeddedCodeSwitchId__1}
+									label="Show subheadings in feed"
+									checked={showSecondaryFeedContent}
+									onChange={() => {
+										toggleShowSecondaryFeedContent();
+									}}
+								/>
+							</EuiFormRow>
+						</div>
+					),
+				},
+			],
+		},
+	];
+
+	const button = (
+		<EuiButtonIcon
+			aria-label="Settings"
+			display="base"
+			size="s"
+			iconType={'gear'}
+			onClick={onButtonClick}
+		/>
+	);
+
+	return (
+		<EuiPopover
+			id={contextMenuPopoverId}
+			button={button}
+			isOpen={isPopoverOpen}
+			closePopover={closePopover}
+			panelPaddingSize="none"
+			anchorPosition="downLeft"
+		>
+			<EuiContextMenu initialPanelId={0} panels={panels} />
+		</EuiPopover>
+	);
+};

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -251,26 +251,26 @@ const WirePreviewCard = ({
 						<h4>viewed</h4>
 					</EuiScreenReaderOnly>
 				)}
-				{formatTimestamp(ingestedAt)
-					.split(', ')
-					.map((part) => (
-						<EuiText
-							size="xs"
-							key={part}
-							css={css`
-								grid-area: time;
-								padding-left: 5px;
-								font-weight: ${hasBeenViewed
-									? theme.euiTheme.font.weight.regular
-									: theme.euiTheme.font.weight.medium};
-								justify-self: end;
-								text-align: right;
-								font-variant-numeric: tabular-nums;
-							`}
-						>
-							{part}
-						</EuiText>
-					))}
+				<div
+					css={css`
+						grid-area: time;
+						padding-left: 5px;
+						font-weight: ${hasBeenViewed
+							? theme.euiTheme.font.weight.regular
+							: theme.euiTheme.font.weight.medium};
+						justify-self: end;
+						text-align: right;
+						font-variant-numeric: tabular-nums;
+					`}
+				>
+					{formatTimestamp(ingestedAt)
+						.split(', ')
+						.map((part) => (
+							<EuiText size="xs" key={part}>
+								{part}
+							</EuiText>
+						))}
+				</div>
 				<EuiBadge
 					css={css`
 						grid-area: supplier;

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -2,7 +2,6 @@ import {
 	EuiBadge,
 	EuiButton,
 	EuiScreenReaderOnly,
-	EuiSpacer,
 	EuiText,
 	EuiTextBlockTruncate,
 	useEuiBackgroundColor,
@@ -14,6 +13,7 @@ import { useEffect, useRef, useState } from 'react';
 import sanitizeHtml from 'sanitize-html';
 import { lightShadeOf } from './colour-utils.ts';
 import { useSearch } from './context/SearchContext.tsx';
+import { useUserSettings } from './context/UserSettingsContext.tsx';
 import { formatTimestamp } from './formatTimestamp.ts';
 import { Link } from './Link.tsx';
 import type { WireData } from './sharedTypes.ts';
@@ -164,6 +164,8 @@ const WirePreviewCard = ({
 	isFromRefresh: boolean;
 }) => {
 	const { viewedItemIds } = useSearch();
+	const { showSecondaryFeedContent } = useUserSettings();
+
 	const ref = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
@@ -182,7 +184,10 @@ const WirePreviewCard = ({
 
 	const supplierInfo = getSupplierInfo(supplier);
 
-	const supplierLabel = supplierInfo?.label ?? supplier;
+	const supplierLabel =
+		(showSecondaryFeedContent
+			? supplierInfo?.label
+			: supplierInfo?.shortLabel) ?? supplier;
 	const supplierColour = supplierInfo?.colour ?? theme.euiTheme.colors.text;
 
 	const mainHeadingContent = decideMainHeadingContent(supplier, content);
@@ -191,11 +196,19 @@ const WirePreviewCard = ({
 
 	const cardGrid = css`
 		display: grid;
-		gap: 0.5rem;
+
 		align-items: baseline;
-		grid-template-areas: 'title title meta' 'content content meta';
-		grid-template-columns: 1fr 1fr min-content;
-		grid-template-rows: auto auto;
+		grid-template-areas: 'title time' 'title supplier' 'content supplier' 'content supplier';
+		grid-template-columns: 1fr min-content;
+		grid-template-rows: auto auto auto auto;
+	`;
+
+	const compactCardGrid = css`
+		display: grid;
+		gap: 0.3rem;
+		grid-template-areas: 'title supplier time';
+		grid-template-columns: 1fr min-content min-content;
+		align-items: baseline;
 	`;
 
 	return (
@@ -203,7 +216,7 @@ const WirePreviewCard = ({
 			<div
 				ref={ref}
 				css={[
-					cardGrid,
+					showSecondaryFeedContent ? cardGrid : compactCardGrid,
 					css`
 						&:hover {
 							background-color: ${theme.euiTheme.colors.lightestShade};
@@ -238,47 +251,49 @@ const WirePreviewCard = ({
 						<h4>viewed</h4>
 					</EuiScreenReaderOnly>
 				)}
-				<div
+				{formatTimestamp(ingestedAt)
+					.split(', ')
+					.map((part) => (
+						<EuiText
+							size="xs"
+							key={part}
+							css={css`
+								grid-area: time;
+								padding-left: 5px;
+								font-weight: ${hasBeenViewed
+									? theme.euiTheme.font.weight.regular
+									: theme.euiTheme.font.weight.medium};
+								justify-self: end;
+								text-align: right;
+								font-variant-numeric: tabular-nums;
+							`}
+						>
+							{part}
+						</EuiText>
+					))}
+				<EuiBadge
 					css={css`
-						grid-area: meta;
-						text-align: right;
+						grid-area: supplier;
+						justify-self: end;
+						margin-top: ${showSecondaryFeedContent ? '0.5rem' : '0'};
 					`}
+					color={hasBeenViewed ? lightShadeOf(supplierColour) : supplierColour}
 				>
-					{formatTimestamp(ingestedAt)
-						.split(', ')
-						.map((part) => (
-							<EuiText
-								size="xs"
-								key={part}
-								css={css`
-									padding-left: 5px;
-									font-weight: ${hasBeenViewed
-										? theme.euiTheme.font.weight.regular
-										: theme.euiTheme.font.weight.medium};
-								`}
-							>
-								{part}
-							</EuiText>
-						))}
-					<EuiSpacer size="xs" />
-					<EuiBadge
-						color={
-							hasBeenViewed ? lightShadeOf(supplierColour) : supplierColour
-						}
+					{supplierLabel}
+				</EuiBadge>
+				{showSecondaryFeedContent && (
+					<div
+						css={css`
+							margin-top: 0.5rem;
+							grid-area: content;
+							font-weight: ${hasBeenViewed
+								? theme.euiTheme.font.weight.light
+								: theme.euiTheme.font.weight.regular};
+						`}
 					>
-						{supplierLabel}
-					</EuiBadge>
-				</div>
-				<div
-					css={css`
-						grid-area: content;
-						font-weight: ${hasBeenViewed
-							? theme.euiTheme.font.weight.light
-							: theme.euiTheme.font.weight.regular};
-					`}
-				>
-					<MaybeSecondaryCardContent {...content} highlight={highlight} />
-				</div>
+						<MaybeSecondaryCardContent {...content} highlight={highlight} />
+					</div>
+				)}
 			</div>
 		</Link>
 	);

--- a/newswires/client/src/context/UserSettingsContext.tsx
+++ b/newswires/client/src/context/UserSettingsContext.tsx
@@ -1,0 +1,58 @@
+import { createContext, useContext, useState } from 'react';
+import { z } from 'zod';
+import { loadOrSetInLocalStorage, saveToLocalStorage } from './localStorage';
+import { useTelemetry } from './TelemetryContext';
+
+interface UserSettingsContextShape {
+	showSecondaryFeedContent: boolean;
+	toggleShowSecondaryFeedContent: () => void;
+}
+
+const UserSettingsContext = createContext<UserSettingsContextShape | null>(
+	null,
+);
+
+export const UserSettingsContextProvider = ({
+	children,
+}: {
+	children: React.ReactNode;
+}) => {
+	const { sendTelemetryEvent } = useTelemetry();
+	const [showSecondaryFeedContent, setShowSecondaryFeedContent] =
+		useState<boolean>(
+			loadOrSetInLocalStorage<boolean>(
+				'showSecondaryFeedContent',
+				z.boolean(),
+				true,
+			),
+		);
+
+	const toggleShowSecondaryFeedContent = () => {
+		setShowSecondaryFeedContent(!showSecondaryFeedContent);
+		saveToLocalStorage<boolean>(
+			'showSecondaryFeedContent',
+			!showSecondaryFeedContent,
+		);
+		sendTelemetryEvent('toggleShowSecondaryFeedContent', {
+			compactView: !showSecondaryFeedContent ? 'on' : 'off',
+		});
+	};
+
+	return (
+		<UserSettingsContext.Provider
+			value={{ showSecondaryFeedContent, toggleShowSecondaryFeedContent }}
+		>
+			{children}
+		</UserSettingsContext.Provider>
+	);
+};
+
+export const useUserSettings = () => {
+	const context = useContext(UserSettingsContext);
+	if (!context) {
+		throw new Error(
+			'useUserSettings must be used within a UserSettingsProvider',
+		);
+	}
+	return context;
+};

--- a/newswires/client/src/icons.ts
+++ b/newswires/client/src/icons.ts
@@ -19,6 +19,7 @@ import { icon as empty } from '@elastic/eui/es/components/icon/assets/empty';
 import { icon as error } from '@elastic/eui/es/components/icon/assets/error';
 import { icon as faceSad } from '@elastic/eui/es/components/icon/assets/face_sad';
 import { icon as filter } from '@elastic/eui/es/components/icon/assets/filter';
+import { icon as gear } from '@elastic/eui/es/components/icon/assets/gear';
 import { icon as heart } from '@elastic/eui/es/components/icon/assets/heart';
 import { icon as iInCircle } from '@elastic/eui/es/components/icon/assets/iInCircle';
 import { icon as kqlFunction } from '@elastic/eui/es/components/icon/assets/kql_function';
@@ -74,6 +75,7 @@ const icons = {
 	filter,
 	plusInCircle,
 	error,
+	gear,
 };
 
 // One or more icons are passed in as an object of iconKey (string): IconComponent

--- a/newswires/client/src/main.tsx
+++ b/newswires/client/src/main.tsx
@@ -5,6 +5,7 @@ import { App } from './App.tsx';
 import './icons';
 import { SearchContextProvider } from './context/SearchContext.tsx';
 import { TelemetryContextProvider } from './context/TelemetryContext.tsx';
+import { UserSettingsContextProvider } from './context/UserSettingsContext.tsx';
 import { createTelemetryEventSender } from './telemetry.ts';
 
 const { sendTelemetryEvent } = createTelemetryEventSender(stage);
@@ -19,9 +20,11 @@ document.head.appendChild(script);
 createRoot(document.getElementById('root')!).render(
 	<StrictMode>
 		<TelemetryContextProvider sendTelemetryEvent={sendTelemetryEvent}>
-			<SearchContextProvider>
-				<App />
-			</SearchContextProvider>
+			<UserSettingsContextProvider>
+				<SearchContextProvider>
+					<App />
+				</SearchContextProvider>
+			</UserSettingsContextProvider>
 		</TelemetryContextProvider>
 	</StrictMode>,
 );

--- a/newswires/client/src/suppliers.ts
+++ b/newswires/client/src/suppliers.ts
@@ -12,36 +12,44 @@ const allSupplierData: Record<
 	string,
 	{
 		label: string;
+		shortLabel: string;
 		colour: string;
 	}
 > = {
-	REUTERS: { label: 'Reuters', colour: reutersBrand },
+	REUTERS: { label: 'Reuters', shortLabel: 'Reu', colour: reutersBrand },
 	AP: {
 		label: 'AP',
+		shortLabel: 'AP',
 		colour: APBrand,
 	},
 	AAP: {
 		label: 'AAP',
+		shortLabel: 'AAP',
 		colour: AAPBrand,
 	},
 	AFP: {
 		label: 'AFP',
+		shortLabel: 'AFP',
 		colour: AFPBrand,
 	},
 	PA: {
 		label: 'PA',
+		shortLabel: 'PA',
 		colour: PABrand,
 	},
 	GUAP: {
 		label: 'AP (Gu)',
+		shortLabel: 'AP (Gu)',
 		colour: APBrand,
 	},
 	GUREUTERS: {
 		label: 'Reuters (Gu)',
+		shortLabel: 'Reuters (Gu)',
 		colour: reutersBrand,
 	},
 	MINOR_AGENCIES: {
 		label: 'Minor agencies',
+		shortLabel: 'Min.',
 		colour: '#39756a',
 	},
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Add a `UserSettingsContextProvider` with a `showSecondaryFeedContent` setting.
- Change the layout of the feed cards depending on that setting.
- A couple of other tweaks to the card layouts to standardise the grid sizes and reduce vertical spacing when either title or content wraps.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

A few people have asked for a more compact view, we should check to see if this works better for them.

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Default view, before and after:

<img width="1307" alt="image" src="https://github.com/user-attachments/assets/ee878b37-714e-4090-9ab2-6b735c60bf3d" />

---

Default and compact views in this branch:

<img width="1301" alt="image" src="https://github.com/user-attachments/assets/0406eb69-9dff-45e4-a72c-8ecca91b7b2e" />


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
