### PR TITLE
UI: fix feed item line break

### DIFF
--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -49,7 +49,12 @@ export const WireItemList = ({
 			<ul>
 				{wires.map(
 					({ id, content, supplier, highlight, isFromRefresh, ingestedAt }) => (
-						<li key={id}>
+						<li
+							key={id}
+							css={css`
+								line-break: anywhere;
+							`}
+						>
 							<WirePreviewCard
 								id={id}
 								ingestedAt={ingestedAt}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Fix feed item line break.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before:
<img width="405" alt="Line break issue" src="https://github.com/user-attachments/assets/0f2ef7d5-d1d8-4888-8d3d-5a490d77a4be" />

After:
<img width="407" alt="Fixed" src="https://github.com/user-attachments/assets/7488d4e3-302d-42d0-90d6-816f48a5be74" />



## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
