### PR TITLE
Add horizontal/vertical split toggle

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -123,12 +123,13 @@ const ResizableContainer = ({
 					>
 						{Feed}
 					</EuiResizablePanel>
-					<EuiResizableButton accountForScrollbars={'before'} />
+					<EuiResizableButton accountForScrollbars={'both'} />
 					<EuiResizablePanel
 						id={secondPanelId}
 						minSize="20%"
 						initialSize={sizes[secondPanelId]}
 						className="eui-yScroll"
+						paddingSize="none"
 					>
 						{Item}
 					</EuiResizablePanel>

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -16,7 +16,6 @@ import {
 	EuiModalHeaderTitle,
 	EuiPageTemplate,
 	EuiProvider,
-	EuiResizableContainer,
 	EuiShowFor,
 	EuiText,
 	EuiTitle,
@@ -31,11 +30,11 @@ import {
 	saveToLocalStorage,
 } from './context/localStorage.tsx';
 import { useSearch } from './context/SearchContext.tsx';
-import { useUserSettings } from './context/UserSettingsContext.tsx';
 import { isRestricted } from './dateHelpers.ts';
 import { Feed } from './Feed';
 import { FeedbackContent } from './FeedbackContent.tsx';
 import { ItemData } from './ItemData.tsx';
+import { ResizableContainer } from './ResizableContainer.tsx';
 import { SettingsMenu } from './SettingsMenu.tsx';
 import { SideNav } from './SideNav';
 import { configToUrl, defaultQuery } from './urlState';
@@ -76,66 +75,6 @@ const Alert = ({
 				`}
 			></EuiToast>
 		</div>
-	);
-};
-
-const ResizableContainer = ({
-	Feed,
-	Item,
-}: {
-	Feed: React.ReactNode;
-	Item: React.ReactNode;
-}) => {
-	const firstPanelId = 'firstResizablePanel';
-	const secondPanelId = 'secondResizablePanel';
-
-	const { resizablePanelsDirection } = useUserSettings();
-
-	const [sizes, setSizes] = useState<{
-		[firstPanelId]: number;
-		[secondPanelId]: number;
-	}>(() =>
-		loadOrSetInLocalStorage(
-			'resizablePanelSizes',
-			z.object({ [firstPanelId]: z.number(), [secondPanelId]: z.number() }),
-			{ [firstPanelId]: 50, [secondPanelId]: 50 },
-		),
-	);
-
-	return (
-		<EuiResizableContainer
-			className="eui-fullHeight"
-			direction={resizablePanelsDirection}
-			onPanelWidthChange={(newSizes) => {
-				console.log('newSizes', JSON.stringify(newSizes));
-				saveToLocalStorage('resizablePanelSizes', newSizes);
-				setSizes((prevSizes) => ({ ...prevSizes, ...newSizes }));
-			}}
-		>
-			{(EuiResizablePanel, EuiResizableButton) => (
-				<>
-					<EuiResizablePanel
-						id={firstPanelId}
-						minSize="20%"
-						initialSize={sizes[firstPanelId]}
-						className="eui-yScroll"
-						style={{ padding: 0 }}
-					>
-						{Feed}
-					</EuiResizablePanel>
-					<EuiResizableButton accountForScrollbars={'both'} />
-					<EuiResizablePanel
-						id={secondPanelId}
-						minSize="20%"
-						initialSize={sizes[secondPanelId]}
-						className="eui-yScroll"
-						paddingSize="none"
-					>
-						{Item}
-					</EuiResizablePanel>
-				</>
-			)}
-		</EuiResizableContainer>
 	);
 };
 

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -107,6 +107,7 @@ const ResizableContainer = ({
 			className="eui-fullHeight"
 			direction={resizablePanelsDirection}
 			onPanelWidthChange={(newSizes) => {
+				console.log('newSizes', JSON.stringify(newSizes));
 				saveToLocalStorage('resizablePanelSizes', newSizes);
 				setSizes((prevSizes) => ({ ...prevSizes, ...newSizes }));
 			}}
@@ -188,7 +189,7 @@ export function App() {
 					}
 				}}
 				css={css`
-					max-height: 100vh;
+					height: 100vh;
 				`}
 			>
 				{displayDisclaimer && (
@@ -247,6 +248,7 @@ export function App() {
 						  }
 						`}
 						height: 100%;
+						max-height: 100vh;
 						${(status === 'loading' || status === 'error') &&
 						'display: flex; align-items: center;'}
 						${status === 'loading' && 'background: white;'}

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -268,6 +268,7 @@ export function App() {
 										<ResizableContainer
 											Feed={<Feed />}
 											Item={<ItemData id={selectedItemId} />}
+											directionOverride={'vertical'}
 										/>
 									) : (
 										<ItemData id={selectedItemId} />

--- a/newswires/client/src/ResizableContainer.tsx
+++ b/newswires/client/src/ResizableContainer.tsx
@@ -1,0 +1,68 @@
+import { EuiResizableContainer } from '@elastic/eui';
+import { useState } from 'react';
+import { z } from 'zod';
+import {
+	loadOrSetInLocalStorage,
+	saveToLocalStorage,
+} from './context/localStorage.tsx';
+import { useUserSettings } from './context/UserSettingsContext.tsx';
+
+export const ResizableContainer = ({
+	Feed,
+	Item,
+}: {
+	Feed: React.ReactNode;
+	Item: React.ReactNode;
+}) => {
+	const firstPanelId = 'firstResizablePanel';
+	const secondPanelId = 'secondResizablePanel';
+
+	const { resizablePanelsDirection } = useUserSettings();
+
+	const [sizes, setSizes] = useState<{
+		[firstPanelId]: number;
+		[secondPanelId]: number;
+	}>(() =>
+		loadOrSetInLocalStorage(
+			'resizablePanelSizes',
+			z.object({ [firstPanelId]: z.number(), [secondPanelId]: z.number() }),
+			{ [firstPanelId]: 50, [secondPanelId]: 50 },
+		),
+	);
+
+	return (
+		<EuiResizableContainer
+			className="eui-fullHeight"
+			direction={resizablePanelsDirection}
+			onPanelWidthChange={(newSizes) => {
+				console.log('newSizes', JSON.stringify(newSizes));
+				saveToLocalStorage('resizablePanelSizes', newSizes);
+				setSizes((prevSizes) => ({ ...prevSizes, ...newSizes }));
+			}}
+		>
+			{(EuiResizablePanel, EuiResizableButton) => (
+				<>
+					<EuiResizablePanel
+						id={firstPanelId}
+						minSize="20%"
+						initialSize={sizes[firstPanelId]}
+						className="eui-yScroll"
+						style={{ padding: 0 }}
+					>
+						{Feed}
+					</EuiResizablePanel>
+					<EuiResizableButton accountForScrollbars={'both'} />
+					<EuiResizablePanel
+						id={secondPanelId}
+						minSize="20%"
+						initialSize={sizes[secondPanelId]}
+						className="eui-yScroll"
+						paddingSize="none"
+					>
+						{Item}
+					</EuiResizablePanel>
+				</>
+			)}
+		</EuiResizableContainer>
+	);
+};

--- a/newswires/client/src/ResizableContainer.tsx
+++ b/newswires/client/src/ResizableContainer.tsx
@@ -38,11 +38,15 @@ const defaultPanelSizes: ResizablePanelSizesData = {
 export const ResizableContainer = ({
 	Feed,
 	Item,
+	directionOverride,
 }: {
 	Feed: React.ReactNode;
 	Item: React.ReactNode;
+	directionOverride?: PanelDirections;
 }) => {
-	const { resizablePanelsDirection: direction } = useUserSettings();
+	const { resizablePanelsDirection: directionFromSettings } = useUserSettings();
+
+	const direction = directionOverride ?? directionFromSettings;
 
 	const [sizes, setSizes] = useState<ResizablePanelSizesData>(() =>
 		loadOrSetInLocalStorage(

--- a/newswires/client/src/SettingsMenu.tsx
+++ b/newswires/client/src/SettingsMenu.tsx
@@ -10,8 +10,12 @@ import { useState } from 'react';
 import { useUserSettings } from './context/UserSettingsContext';
 
 export const SettingsMenu = () => {
-	const { showSecondaryFeedContent, toggleShowSecondaryFeedContent } =
-		useUserSettings();
+	const {
+		resizablePanelsDirection,
+		toggleResizablePanelsDirection,
+		showSecondaryFeedContent,
+		toggleShowSecondaryFeedContent,
+	} = useUserSettings();
 
 	const [isPopoverOpen, setPopover] = useState(false);
 
@@ -19,6 +23,9 @@ export const SettingsMenu = () => {
 		prefix: 'contextMenuPopover',
 	});
 	const embeddedCodeSwitchId__1 = useGeneratedHtmlId({
+		prefix: 'embeddedCodeSwitchId',
+	});
+	const embeddedCodeSwitchId__2 = useGeneratedHtmlId({
 		prefix: 'embeddedCodeSwitchId',
 	});
 
@@ -52,6 +59,24 @@ export const SettingsMenu = () => {
 						</div>
 					),
 				},
+				{
+					renderItem: () => (
+						<div style={{ padding: 16 }}>
+							<EuiFormRow hasChildLabel={true}>
+								<EuiSwitch
+									name="switch"
+									id={embeddedCodeSwitchId__2}
+									label="Display wire details below feed"
+									checked={resizablePanelsDirection === 'vertical'}
+									onChange={() => {
+										toggleResizablePanelsDirection();
+									}}
+								/>
+							</EuiFormRow>
+						</div>
+					),
+				},
+				{ name: 'Close', icon: 'cross', onClick: closePopover },
 			],
 		},
 	];

--- a/newswires/client/src/context/UserSettingsContext.tsx
+++ b/newswires/client/src/context/UserSettingsContext.tsx
@@ -6,6 +6,8 @@ import { useTelemetry } from './TelemetryContext';
 interface UserSettingsContextShape {
 	showSecondaryFeedContent: boolean;
 	toggleShowSecondaryFeedContent: () => void;
+	resizablePanelsDirection: 'vertical' | 'horizontal';
+	toggleResizablePanelsDirection: () => void;
 }
 
 const UserSettingsContext = createContext<UserSettingsContextShape | null>(
@@ -26,6 +28,15 @@ export const UserSettingsContextProvider = ({
 				true,
 			),
 		);
+	const [resizablePanelsDirection, setResizablePanelsDirection] = useState<
+		'vertical' | 'horizontal'
+	>(
+		loadOrSetInLocalStorage(
+			'resizablePanelDirection',
+			z.enum(['vertical', 'horizontal']),
+			'horizontal',
+		),
+	);
 
 	const toggleShowSecondaryFeedContent = () => {
 		setShowSecondaryFeedContent(!showSecondaryFeedContent);
@@ -34,13 +45,28 @@ export const UserSettingsContextProvider = ({
 			!showSecondaryFeedContent,
 		);
 		sendTelemetryEvent('toggleShowSecondaryFeedContent', {
-			compactView: !showSecondaryFeedContent ? 'on' : 'off',
+			showSecondaryFeedContent: !showSecondaryFeedContent ? 'on' : 'off',
+		});
+	};
+
+	const toggleResizablePanelsDirection = () => {
+		const newDirection =
+			resizablePanelsDirection === 'horizontal' ? 'vertical' : 'horizontal';
+		setResizablePanelsDirection(newDirection);
+		saveToLocalStorage('resizablePanelDirection', newDirection);
+		sendTelemetryEvent('toggleResizablePanelsDirection', {
+			resizablePanelsDirection: newDirection,
 		});
 	};
 
 	return (
 		<UserSettingsContext.Provider
-			value={{ showSecondaryFeedContent, toggleShowSecondaryFeedContent }}
+			value={{
+				showSecondaryFeedContent,
+				toggleShowSecondaryFeedContent,
+				resizablePanelsDirection,
+				toggleResizablePanelsDirection,
+			}}
 		>
 			{children}
 		</UserSettingsContext.Provider>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Refactor the resizable panels to make it easier to pass a direction prop (horizontal/vertical)
- Add a new setting to allow users to toggle panel direction
- Also save the preferred proportions of the two panels in localstorage, for each orientation, so that it will re-open in the same layout
- On small screens:
    - For standard view, still open items separate from the feed (no split)
    - For ticker view, always open items in a split below the feed, regardless of user preference for direction

<img width="200" alt="image" src="https://github.com/user-attachments/assets/47e2b3df-7536-46cb-a570-506086f36d68" />


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

|Horizontal|Vertical|
|-|-|
|**Desktop breakpoints**||
|<img width="1916" alt="image" src="https://github.com/user-attachments/assets/6ceaff9b-bebc-49c7-8354-45b565371001" />|<img width="1916" alt="image" src="https://github.com/user-attachments/assets/42dd936f-f2a4-48b4-9e79-932912c13e70" />|
|**Tablet breakpoints**||
|<img width="874" alt="image" src="https://github.com/user-attachments/assets/8eff36ae-8273-4c5f-907b-dae0535b755f" />|<img width="873" alt="image" src="https://github.com/user-attachments/assets/7a616714-d236-4801-aefb-1717d88f2e6a" />|
|**Ticker mode**||
|<img width="200" alt="image" src="https://github.com/user-attachments/assets/8637ccbe-7d76-4050-be78-b9340dffcb1e" />|<img width="200" alt="image" src="https://github.com/user-attachments/assets/1d4aaeb1-7493-4433-9545-6c62fd07e1b5" />|


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
