### PR TITLE
Don't show date info in search summary if it's the same as the default

### DIFF
--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -8,7 +8,11 @@ import {
 import { css } from '@emotion/react';
 import { useEffect, useState } from 'react';
 import { useSearch } from './context/SearchContext.tsx';
-import { deriveDateMathRangeLabel, isRestricted } from './dateHelpers.ts';
+import {
+	deriveDateMathRangeLabel,
+	isDefaultDateRange,
+	isRestricted,
+} from './dateHelpers.ts';
 import { Tooltip } from './Tooltip.tsx';
 import { configToUrl } from './urlState.ts';
 
@@ -88,6 +92,7 @@ const Summary = ({
 				</span>
 			)}
 			{dateRange &&
+				!isDefaultDateRange(dateRange) &&
 				renderBadge(
 					'Time range',
 					deriveDateMathRangeLabel(dateRange.start, dateRange.end),
@@ -176,11 +181,7 @@ export const SearchSummary = () => {
 							color={'primary'}
 							onClick={() =>
 								window.open(
-									configToUrl({
-										...config,
-										view: 'feed',
-										itemId: undefined,
-									}),
+									configToUrl({ ...config, view: 'feed', itemId: undefined }),
 									'_blank',
 									'popout=true,width=400,height=800,top=200,location=no,menubar=no,toolbar=no',
 								)

--- a/newswires/client/src/dateHelpers.ts
+++ b/newswires/client/src/dateHelpers.ts
@@ -1,5 +1,6 @@
 import dateMath from '@elastic/datemath';
 import moment from 'moment-timezone';
+import { DEFAULT_DATE_RANGE } from './dateConstants';
 
 export interface TimeRange {
 	start: string;
@@ -112,17 +113,9 @@ export const timeRangeOption = (start: string) => {
 		case '24h':
 			return { start: `now-24h`, end: 'now', label: 'Last 24 hours' };
 		case 'today':
-			return {
-				start: 'now/d',
-				end: 'now/d',
-				label: 'Today',
-			};
+			return { start: 'now/d', end: 'now/d', label: 'Today' };
 		case '1d':
-			return {
-				start: `now-1d/d`,
-				end: `now-1d/d`,
-				label: 'Yesterday',
-			};
+			return { start: `now-1d/d`, end: `now-1d/d`, label: 'Yesterday' };
 		case '2d':
 			return {
 				start: `now-2d/d`,
@@ -133,3 +126,13 @@ export const timeRangeOption = (start: string) => {
 			return { start: `now-2w`, end: 'now', label: 'Last 14 days' };
 	}
 };
+
+export function isDefaultDateRange(dateRange: {
+	start: string;
+	end: string;
+}): boolean {
+	return (
+		dateRange.start === DEFAULT_DATE_RANGE.start &&
+		dateRange.end === DEFAULT_DATE_RANGE.end
+	);
+}


### PR DESCRIPTION
- We don't generally show other filters when they're set to the default value, and users seem to value there being less metadata in the view where possible, especially in ticker view. 
- Also, you can't actually remove this filter (except by setting a different value) so having the dismissible badge at the top is a bit misleading.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

|Before|After|
|-|-|
|<img width="393" alt="image" src="https://github.com/user-attachments/assets/86c60a11-8a05-470e-9b18-06489521d355" />|<img width="395" alt="image" src="https://github.com/user-attachments/assets/efeeec27-ecb1-4524-8d16-0be000abbc61" />|

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
