### PR TITLE
Don't allow timestamps to line break anywhere

### DIFF
--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -49,12 +49,7 @@ export const WireItemList = ({
 			<ul>
 				{wires.map(
 					({ id, content, supplier, highlight, isFromRefresh, ingestedAt }) => (
-						<li
-							key={id}
-							css={css`
-								line-break: anywhere;
-							`}
-						>
+						<li key={id}>
 							<WirePreviewCard
 								id={id}
 								ingestedAt={ingestedAt}
@@ -235,6 +230,7 @@ const WirePreviewCard = ({
 						box-sizing: content-box;
 						color: ${theme.euiTheme.colors.text};
 						background-color: ${hasBeenViewed ? accentBgColor : 'inherit'};
+						line-break: anywhere;
 
 						& h3 {
 							grid-area: title;
@@ -266,6 +262,7 @@ const WirePreviewCard = ({
 						justify-self: end;
 						text-align: right;
 						font-variant-numeric: tabular-nums;
+						line-break: strict;
 					`}
 				>
 					{formatTimestamp(ingestedAt)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Override the `line-break: anywhere` on wire item list for the date component, because it was being split in an unreadable way on the 'compact' view. (See screenshots below)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before:
<img width="416" alt="image" src="https://github.com/user-attachments/assets/3d7322ac-f076-4fdc-8352-1fe08e004f61" />

After:
<img width="406" alt="image" src="https://github.com/user-attachments/assets/40aca22e-c3e2-4fd3-a70f-a6120787243c" />



<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
