### PR TITLE
Fix: header for smaller screens

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -2,6 +2,7 @@ import {
 	EuiBetaBadge,
 	EuiButton,
 	EuiButtonEmpty,
+	EuiButtonIcon,
 	EuiEmptyPrompt,
 	EuiFlexGroup,
 	EuiHeader,
@@ -37,6 +38,7 @@ import { FeedbackContent } from './FeedbackContent.tsx';
 import { ItemData } from './ItemData.tsx';
 import { SettingsMenu } from './SettingsMenu.tsx';
 import { SideNav } from './SideNav';
+import { Tooltip } from './Tooltip.tsx';
 import { configToUrl, defaultQuery } from './urlState';
 
 const Alert = ({
@@ -217,15 +219,30 @@ export function App() {
 											>
 												Newswires
 											</EuiLink>
-											<EuiBetaBadge
-												label="Under construction"
-												title="Currently under construction"
-												color={'accent'}
-												size="s"
-												css={css`
-													margin-left: 8px;
-												`}
-											/>
+											<EuiShowFor sizes={['xs', 's']}>
+												<EuiBetaBadge
+													iconType={'beaker'}
+													label="Currently under construction"
+													aria-label="(Under construction)"
+													color={'accent'}
+													size="m"
+													css={css`
+														margin-left: 8px;
+													`}
+												/>
+											</EuiShowFor>
+											<EuiShowFor sizes={['m', 'l', 'xl']}>
+												<EuiBetaBadge
+													label="Under construction"
+													aria-label="(Under construction)"
+													title="Currently under construction"
+													color={'accent'}
+													size="s"
+													css={css`
+														margin-left: 8px;
+													`}
+												/>
+											</EuiShowFor>
 										</h1>
 									</EuiTitle>
 								</EuiHeaderSectionItem>
@@ -238,23 +255,49 @@ export function App() {
 										margin-left: 8px;
 									`}
 								>
-									<EuiButton
-										size="s"
-										iconType={'popout'}
-										onClick={() =>
-											window.open(
-												configToUrl({
-													...config,
-													view: 'feed',
-													itemId: undefined,
-												}),
-												'_blank',
-												'popout=true,width=400,height=800,top=200,location=no,menubar=no,toolbar=no',
-											)
-										}
-									>
-										New ticker
-									</EuiButton>
+									<EuiShowFor sizes={['xs', 's']}>
+										<Tooltip
+											tooltipContent={'Open ticker in a new window'}
+											position="left"
+										>
+											<EuiButtonIcon
+												aria-label="New ticker"
+												display="base"
+												size="s"
+												iconType={'popout'}
+												onClick={() =>
+													window.open(
+														configToUrl({
+															...config,
+															view: 'feed',
+															itemId: undefined,
+														}),
+														'_blank',
+														'popout=true,width=400,height=800,top=200,location=no,menubar=no,toolbar=no',
+													)
+												}
+											/>
+										</Tooltip>
+									</EuiShowFor>
+									<EuiShowFor sizes={['m', 'l', 'xl']}>
+										<EuiButton
+											size="s"
+											iconType={'popout'}
+											onClick={() =>
+												window.open(
+													configToUrl({
+														...config,
+														view: 'feed',
+														itemId: undefined,
+													}),
+													'_blank',
+													'popout=true,width=400,height=800,top=200,location=no,menubar=no,toolbar=no',
+												)
+											}
+										>
+											New ticker
+										</EuiButton>
+									</EuiShowFor>
 									<SettingsMenu />
 								</EuiFlexGroup>
 							</EuiHeaderSectionItem>

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -256,10 +256,7 @@ export function App() {
 									`}
 								>
 									<EuiShowFor sizes={['xs', 's']}>
-										<Tooltip
-											tooltipContent={'Open ticker in a new window'}
-											position="left"
-										>
+										<Tooltip tooltipContent={'Open new ticker'} position="left">
 											<EuiButtonIcon
 												aria-label="New ticker"
 												display="base"

--- a/newswires/client/src/DatePicker.tsx
+++ b/newswires/client/src/DatePicker.tsx
@@ -48,6 +48,7 @@ export const DatePicker = () => {
 		<div>
 			<EuiSuperDatePicker
 				width={'auto'}
+				compressed={true}
 				start={
 					config.query.dateRange
 						? config.query.dateRange.start

--- a/newswires/client/src/icons.ts
+++ b/newswires/client/src/icons.ts
@@ -6,6 +6,7 @@ import { icon as arrowLeft } from '@elastic/eui/es/components/icon/assets/arrow_
 import { icon as arrowRight } from '@elastic/eui/es/components/icon/assets/arrow_right';
 import { icon as arrowEnd } from '@elastic/eui/es/components/icon/assets/arrowEnd';
 import { icon as arrowStart } from '@elastic/eui/es/components/icon/assets/arrowStart';
+import { icon as beaker } from '@elastic/eui/es/components/icon/assets/beaker'; // nb. might be renamed 'flask' in newer versions?
 import { icon as boxesHorizontal } from '@elastic/eui/es/components/icon/assets/boxes_horizontal';
 import { icon as boxesVertical } from '@elastic/eui/es/components/icon/assets/boxes_vertical';
 import { icon as calendar } from '@elastic/eui/es/components/icon/assets/calendar';
@@ -76,6 +77,7 @@ const icons = {
 	plusInCircle,
 	error,
 	gear,
+	beaker,
 };
 
 // One or more icons are passed in as an object of iconKey (string): IconComponent


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

1. Reduce the horizontal space needed for the header elements when rendering in smaller breakpoints:
    - Icon-only button for the new ticker button
    - Icon-only visual rendering of the beta badge
2. Use 'compact' mode for the date picker (not related to the header changes, but felt like a small enough change that it was reasonable to bundle in here)

---

New layout on smaller screens:

<img width="357" alt="image" src="https://github.com/user-attachments/assets/29343fc7-e573-4e8c-99b8-6eca4cfff364" />

---

Comparison of non-compact (left) vs. proposed compact (right) versions of the date picker:

![image](https://github.com/user-attachments/assets/ab1ae377-2438-4af8-a2f9-9e5147a4d3f2)


