### PR TITLE
Show badges for categoryCodeExcl in search summary

### DIFF
--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -38,9 +38,12 @@ const Summary = ({
 		supplier: suppliers,
 		dateRange,
 		categoryCode,
+		categoryCodeExcl,
 	} = config.query;
 
 	const displayCategoryCodes = (categoryCode ?? []).length > 0;
+	const displayExcludedCategoryCodes =
+		categoryCodeExcl && categoryCodeExcl.length > 0;
 	const displaySuppliers = (suppliers ?? []).length > 0;
 
 	const displayFilters: boolean =
@@ -112,7 +115,9 @@ const Summary = ({
 			{displaySuppliers &&
 				suppliers!.map((supplier) => renderBadge('Supplier', supplier))}
 			{displayCategoryCodes &&
-				categoryCode!.map((code) => renderBadge('Category code', code))}
+				categoryCode!.map((code) => renderBadge('Category', code))}
+			{displayExcludedCategoryCodes &&
+				categoryCodeExcl.map((code) => renderBadge('(NOT) Category', code))}
 		</>
 	);
 };


### PR DESCRIPTION
We haven't got great support for managing category code searches yet, but this would be helpful for development, and if any other users _do_ manage to add an exclusion here then it's good to have it represented in the search summary.

When we do something more 'proper' for category codes we can also come up with better UX than just putting '(NOT)' in front of exclusions, but should be sufficient for the time being?

<img width="374" alt="image" src="https://github.com/user-attachments/assets/baa954f3-7961-46c3-b0e1-0930307cb51d" />
