### PR TITLE
Improve UK preset

### DIFF
--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -147,15 +147,6 @@ object SearchPresets {
     )
   )
 
-  private val ReutersUk = List(
-    SearchParams(
-      text = None,
-      suppliersIncl = List("REUTERS"),
-      categoryCodesIncl = List("N2:GB"),
-      categoryCodesExcl = List("REUTERS:RBN", "REUTERS:RWS")
-    )
-  )
-
   private val ReutersBusiness = List(
     SearchParams(
       text = None,
@@ -188,7 +179,7 @@ object SearchPresets {
     ApWorld ::: ReutersWorld ::: AapWorld ::: AfpWorld ::: MinorAgenciesWorld
 
   private val AllUk =
-    PaHome ::: ReutersUk ::: MinorAgenciesUk
+    PaHome ::: MinorAgenciesUk
 
   private val AllBusiness = ReutersBusiness ::: ApBusiness ::: AapBusiness
 }

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -87,7 +87,9 @@ function decideMainHeadingContent(
 	{ headline, slug }: WireData['content'],
 ): string {
 	const prefix =
-		supplier === 'AAP' && slug && slug.length > 0 ? `${slug} - ` : '';
+		(supplier === 'AAP' || supplier === 'PA') && slug && slug.length > 0
+			? `${slug} - `
+			: '';
 
 	if (headline && headline.length > 0) {
 		return `${prefix}${headline}`;
@@ -136,10 +138,10 @@ function MaybeSecondaryCardContent({
 		return <p>{subhead}</p>;
 	}
 	const maybeBodyTextPreview = bodyText
-		? sanitizeHtml(bodyText, { allowedTags: [], allowedAttributes: {} }).slice(
-				0,
-				300,
-			)
+		? sanitizeHtml(bodyText.replace(/<br \/>/g, '&nbsp;'), {
+				allowedTags: [],
+				allowedAttributes: {},
+			}).slice(0, 300)
 		: undefined;
 	if (maybeBodyTextPreview && maybeBodyTextPreview !== headline) {
 		return (


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Remove Reuters from UK preset
- Add slug to PA story list items
- Replace `<br />` with a space in body text preview for story list items

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
