### PR TITLE
UI: add jump to top button

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -285,7 +285,7 @@ export function App() {
 							<EuiShowFor sizes={['xs', 's']}>
 								{isPoppedOut && (
 									<ResizableContainer
-										Feed={<Feed />}
+										Feed={Feed}
 										Item={
 											selectedItemId ? (
 												<ItemData id={selectedItemId} />
@@ -303,7 +303,7 @@ export function App() {
 							</EuiShowFor>
 							<EuiShowFor sizes={['m', 'l', 'xl']}>
 								<ResizableContainer
-									Feed={<Feed />}
+									Feed={Feed}
 									Item={
 										selectedItemId ? (
 											<ItemData id={selectedItemId} />

--- a/newswires/client/src/Feed.tsx
+++ b/newswires/client/src/Feed.tsx
@@ -9,10 +9,15 @@ import { css } from '@emotion/react';
 import { useSearch } from './context/SearchContext.tsx';
 import { DatePicker } from './DatePicker.tsx';
 import { isOpenAsTicker } from './openTicker.ts';
+import { ScrollToTopButton } from './ScrollToTopButton.tsx';
 import { SearchSummary } from './SearchSummary.tsx';
 import { WireItemList } from './WireItemList.tsx';
 
-export const Feed = () => {
+export interface FeedProps {
+	containerRef?: React.RefObject<HTMLDivElement>;
+}
+
+export const Feed = ({ containerRef }: FeedProps) => {
 	const { state } = useSearch();
 	const { status, queryData } = state;
 
@@ -78,6 +83,8 @@ export const Feed = () => {
 							wires={queryData.results}
 							totalCount={queryData.totalCount}
 						/>
+
+						<ScrollToTopButton threshold={300} containerRef={containerRef} />
 					</>
 				)}
 		</EuiPageTemplate.Section>

--- a/newswires/client/src/ResizableContainer.tsx
+++ b/newswires/client/src/ResizableContainer.tsx
@@ -1,12 +1,13 @@
 import { EuiEmptyPrompt, EuiResizableContainer } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { z } from 'zod';
 import {
 	loadOrSetInLocalStorage,
 	saveToLocalStorage,
 } from './context/localStorage.tsx';
 import { useUserSettings } from './context/UserSettingsContext.tsx';
+import type { FeedProps } from './Feed.tsx';
 
 export type PanelDirections = 'vertical' | 'horizontal';
 
@@ -41,10 +42,12 @@ export const ResizableContainer = ({
 	Item,
 	directionOverride,
 }: {
-	Feed: React.ReactNode;
+	Feed: React.ComponentType<FeedProps>;
 	Item?: React.ReactNode;
 	directionOverride?: PanelDirections;
 }) => {
+	const leftPanelRef = useRef<HTMLDivElement>(null);
+
 	const { resizablePanelsDirection: directionFromSettings } = useUserSettings();
 
 	const direction = directionOverride ?? directionFromSettings;
@@ -77,8 +80,9 @@ export const ResizableContainer = ({
 						initialSize={Item ? sizes[direction][firstPanelId] : 100}
 						className="eui-yScroll"
 						style={{ padding: 0 }}
+						panelRef={leftPanelRef}
 					>
-						{Feed}
+						<Feed containerRef={leftPanelRef} />
 					</EuiResizablePanel>
 					<EuiResizableButton
 						accountForScrollbars={'both'}

--- a/newswires/client/src/ScrollToTopButton.tsx
+++ b/newswires/client/src/ScrollToTopButton.tsx
@@ -1,0 +1,130 @@
+import { EuiButton, EuiPortal, useEuiTheme } from '@elastic/eui';
+import type { RefObject } from 'react';
+import type React from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useSearch } from './context/SearchContext';
+
+/**
+ * Floating Scroll-to-Top Button bounded to a scroll container
+ */
+export const ScrollToTopButton = ({
+	threshold = 200,
+	label,
+	containerRef,
+}: {
+	threshold?: number;
+	label?: string;
+	containerRef?: RefObject<HTMLElement>;
+}) => {
+	const buttonRef = useRef<HTMLDivElement>(null);
+	const { euiTheme } = useEuiTheme();
+	const { state } = useSearch();
+	const { queryData } = state;
+
+	const [incomingStories, setIncomingStories] = useState(0);
+	const [visible, setVisible] = useState(false);
+	const [btnStyle, setBtnStyle] = useState<React.CSSProperties>({});
+
+	// Accumulate counts of newly loaded stories
+	useEffect(() => {
+		if (!queryData) return;
+		const newCount = queryData.results.filter((r) => r.isFromRefresh).length;
+		setIncomingStories((currentCount) => currentCount + newCount);
+	}, [queryData, queryData?.results]);
+
+	// Show/hide based on scroll offset
+	useEffect(() => {
+		const scrollEl = containerRef?.current ?? window;
+		const onScroll = () => {
+			const scrollTop =
+				scrollEl === window
+					? window.scrollY
+					: (scrollEl as HTMLElement).scrollTop;
+			if (scrollTop > threshold) {
+				setVisible(true);
+			} else {
+				setVisible(false);
+				setIncomingStories(0);
+			}
+		};
+
+		scrollEl.addEventListener('scroll', onScroll, { passive: true });
+		return () => scrollEl.removeEventListener('scroll', onScroll);
+	}, [threshold, containerRef]);
+
+	// Recalculate position on show, scroll, or resize
+	useEffect(() => {
+		if (!visible) return;
+
+		const updatePosition = () => {
+			const cont = containerRef?.current;
+			const btn = buttonRef.current;
+
+			const offset = 16;
+			if (cont && btn) {
+				const contRect = cont.getBoundingClientRect();
+				const btnRect = btn.getBoundingClientRect();
+				setBtnStyle({
+					position: 'fixed',
+					top: contRect.top + contRect.height - btnRect.height - offset,
+					left: contRect.left + contRect.width - btnRect.width - offset,
+					zIndex: 1000,
+				});
+			} else {
+				setBtnStyle({
+					position: 'fixed',
+					bottom: offset,
+					right: euiTheme.size.s,
+					zIndex: 1000,
+				});
+			}
+		};
+
+		window.addEventListener('resize', updatePosition);
+
+		const scrollEl = containerRef?.current ?? window;
+		scrollEl.addEventListener('scroll', updatePosition, { passive: true });
+
+		// Observe container size changes
+		let resizeObs: ResizeObserver | null = null;
+		if (containerRef?.current) {
+			resizeObs = new ResizeObserver(updatePosition);
+			resizeObs.observe(containerRef.current);
+		}
+
+		updatePosition();
+
+		return () => {
+			window.removeEventListener('resize', updatePosition);
+			scrollEl.removeEventListener('scroll', updatePosition);
+			if (resizeObs) resizeObs.disconnect();
+		};
+	}, [visible, containerRef, euiTheme.size.s]);
+
+	const handleClick = () => {
+		if (containerRef?.current) {
+			containerRef.current.scrollTo({ top: 0, behavior: 'smooth' });
+		} else {
+			window.scrollTo({ top: 0, behavior: 'smooth' });
+		}
+	};
+
+	if (!visible) return null;
+
+	return (
+		<EuiPortal>
+			<div ref={buttonRef} style={btnStyle}>
+				<EuiButton
+					iconType="arrowUp"
+					onClick={handleClick}
+					size="m"
+					color="primary"
+				>
+					{incomingStories > 0
+						? `${incomingStories} new stories`
+						: (label ?? 'Back to Top')}
+				</EuiButton>
+			</div>
+		</EuiPortal>
+	);
+};

--- a/newswires/client/src/context/SearchReducer.ts
+++ b/newswires/client/src/context/SearchReducer.ts
@@ -57,7 +57,10 @@ function mergeQueryData(
 				...newData.results
 					.filter((newItem) => !existingIds.has(newItem.id))
 					.map((newItem) => ({ ...newItem, isFromRefresh: true })),
-				...filteredExistingResults,
+				...filteredExistingResults.map((item) => ({
+					...item,
+					isFromRefresh: false,
+				})),
 			],
 		};
 	} else {

--- a/newswires/client/src/icons.ts
+++ b/newswires/client/src/icons.ts
@@ -4,6 +4,7 @@
 import { icon as arrowDown } from '@elastic/eui/es/components/icon/assets/arrow_down';
 import { icon as arrowLeft } from '@elastic/eui/es/components/icon/assets/arrow_left';
 import { icon as arrowRight } from '@elastic/eui/es/components/icon/assets/arrow_right';
+import { icon as arrowUp } from '@elastic/eui/es/components/icon/assets/arrow_up';
 import { icon as arrowEnd } from '@elastic/eui/es/components/icon/assets/arrowEnd';
 import { icon as arrowStart } from '@elastic/eui/es/components/icon/assets/arrowStart';
 import { icon as beaker } from '@elastic/eui/es/components/icon/assets/beaker'; // nb. might be renamed 'flask' in newer versions?
@@ -44,6 +45,7 @@ const icons = {
 	calendar,
 	clock,
 	arrowDown,
+	arrowUp,
 	arrowLeft,
 	arrowRight,
 	arrowEnd,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add jump to top button:

- Accumulate counts of newly loaded stories and reset when scrolling up
- Show/hide the button based on scroll offset
- Recalculate position on show, scroll, or resize

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Large screen feed only:
<img width="1694" alt="Large screen feed only" src="https://github.com/user-attachments/assets/347de18f-43a7-4bc9-a3cb-7234dccd3a20" />

Large screen with opened story:
<img width="1707" alt="Large screen with opened story" src="https://github.com/user-attachments/assets/850aa347-7441-4568-ac3f-22a5b305227d" />

Large screen with story opened below feed:
<img width="1702" alt="Large screen with story opened below feed" src="https://github.com/user-attachments/assets/02624650-e8c5-4c9a-b6df-7f420baf6106" />

Small screen feed only:
<img width="621" alt="Small screen feed only" src="https://github.com/user-attachments/assets/919e8ff7-e3b2-4989-b057-6793392d6a7b" />

Ticker screen feed only:
<img width="638" alt="Ticker screen feed only" src="https://github.com/user-attachments/assets/d479389b-1e25-4f02-8eb8-8df66fa59465" />

Ticker screen feed wit story opened below feed:
<img width="629" alt="Ticker screen feed wit story opened below feed" src="https://github.com/user-attachments/assets/3204a50b-f307-4975-8a36-00fc282c9d72" />


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
