### PR TITLE
UI: add date search presets

### DIFF
--- a/newswires/client/src/DatePicker.tsx
+++ b/newswires/client/src/DatePicker.tsx
@@ -70,6 +70,8 @@ export const DatePicker = () => {
 					timeRangeOption('30m'),
 					timeRangeOption('1h'),
 					timeRangeOption('24h'),
+					timeRangeOption('3d'),
+					timeRangeOption('1w'),
 					timeRangeOption('today'),
 					timeRangeOption('1d'),
 					timeRangeOption('2d'),

--- a/newswires/client/src/dateHelpers.ts
+++ b/newswires/client/src/dateHelpers.ts
@@ -122,6 +122,10 @@ export const timeRangeOption = (start: string) => {
 				end: `now-2d/d`,
 				label: moment().subtract(2, 'days').format('dddd'),
 			};
+		case '3d':
+			return { start: `now-3d`, end: `now`, label: 'Last 3 days' };
+		case '1w':
+			return { start: `now-1w`, end: 'now', label: 'Last 1 week' };
 		default:
 			return { start: `now-2w`, end: 'now', label: 'Last 14 days' };
 	}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add date search presets:
- Last 3 days
- Last 1 week

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Date picker:
<img width="439" alt="Date picker" src="https://github.com/user-attachments/assets/4a36f2f7-020e-4297-9c2d-9d5a6602e8ce" />

Search summary:
<img width="569" alt="Last 3 days" src="https://github.com/user-attachments/assets/cc83b756-e965-4326-aa52-11ab816973c7" />

<img width="578" alt="Last 1 week" src="https://github.com/user-attachments/assets/7561affa-d3b7-4dce-8ec4-fb6a5816a708" />

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
