### PR TITLE
Re-raise hotkey fixes

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -24,7 +24,7 @@ import {
 	useIsWithinMinBreakpoint,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { z } from 'zod';
 import { useKeyboardShortcuts } from './context/KeyboardShortcutsContext.tsx';
 import {

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -24,8 +24,9 @@ import {
 	useIsWithinMinBreakpoint,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { z } from 'zod';
+import { useKeyboardShortcuts } from './context/KeyboardShortcutsContext.tsx';
 import {
 	loadOrSetInLocalStorage,
 	saveToLocalStorage,
@@ -82,19 +83,13 @@ const Alert = ({
 };
 
 export function App() {
-	const {
-		config,
-		state,
-		handleEnterQuery,
-		handleRetry,
-		handleDeselectItem,
-		handleNextItem,
-		handlePreviousItem,
-	} = useSearch();
+	const { config, state, handleEnterQuery, handleRetry } = useSearch();
 
 	const [displayDisclaimer, setDisplayDisclaimer] = useState<boolean>(() =>
 		loadOrSetInLocalStorage<boolean>('displayDisclaimer', z.boolean(), true),
 	);
+
+	const { handleShortcutKeyUp } = useKeyboardShortcuts();
 
 	const { view, itemId: selectedItemId, query } = config;
 	const { status } = state;
@@ -108,6 +103,14 @@ export function App() {
 		}
 	};
 
+	useEffect(() => {
+		window.addEventListener('keyup', handleShortcutKeyUp);
+
+		return () => {
+			window.removeEventListener('keyup', handleShortcutKeyUp);
+		};
+	}, [handleShortcutKeyUp]);
+
 	const breakpoints = {
 		sm: '@media (max-width: 600px)',
 		md: '@media (min-width: 900px)',
@@ -116,21 +119,6 @@ export function App() {
 	return (
 		<EuiProvider colorMode="light">
 			<EuiPageTemplate
-				onKeyUp={(e) => {
-					if (view == 'item') {
-						switch (e.key) {
-							case 'Escape':
-								handleDeselectItem();
-								break;
-							case 'ArrowLeft':
-								handlePreviousItem();
-								break;
-							case 'ArrowRight':
-								handleNextItem();
-								break;
-						}
-					}
-				}}
 				css={css`
 					height: 100vh;
 				`}

--- a/newswires/client/src/DatePicker.tsx
+++ b/newswires/client/src/DatePicker.tsx
@@ -5,6 +5,7 @@ import { EuiSuperDatePicker } from '@elastic/eui';
 import type { EuiCommonlyUsedTimeRanges } from '@elastic/eui/src/components/date_picker/super_date_picker/quick_select_popover/commonly_used_time_ranges';
 import moment from 'moment';
 import type { ReactElement } from 'react';
+import { StopShortcutPropagationWrapper } from './context/KeyboardShortcutsContext.tsx';
 import { useSearch } from './context/SearchContext.tsx';
 import {
 	DEFAULT_DATE_RANGE,
@@ -45,7 +46,7 @@ export const DatePicker = () => {
 	);
 
 	return (
-		<div>
+		<StopShortcutPropagationWrapper>
 			<EuiSuperDatePicker
 				width={'auto'}
 				compressed={true}
@@ -77,6 +78,6 @@ export const DatePicker = () => {
 					timeRangeOption('2d'),
 				]}
 			/>
-		</div>
+		</StopShortcutPropagationWrapper>
 	);
 };

--- a/newswires/client/src/Disclosure.stories.tsx
+++ b/newswires/client/src/Disclosure.stories.tsx
@@ -4,7 +4,7 @@ import { Disclosure } from './Disclosure';
 import { setUpIcons } from './icons';
 
 export default { component: Disclosure };
-const meta = {
+const _meta = {
 	title: 'Components/Disclosure',
 	component: Disclosure,
 	parameters: {
@@ -22,7 +22,7 @@ const meta = {
 	],
 } satisfies Meta<typeof Disclosure>;
 
-type Story = StoryObj<typeof meta>;
+type Story = StoryObj<typeof _meta>;
 
 setUpIcons();
 

--- a/newswires/client/src/SearchBox.tsx
+++ b/newswires/client/src/SearchBox.tsx
@@ -1,5 +1,6 @@
 import { EuiFieldSearch } from '@elastic/eui';
 import { useEffect, useMemo, useState } from 'react';
+import { StopShortcutPropagationWrapper } from './context/KeyboardShortcutsContext.tsx';
 import { useSearch } from './context/SearchContext.tsx';
 import { debounce } from './debounce';
 
@@ -17,15 +18,17 @@ export function SearchBox() {
 	);
 
 	return (
-		<EuiFieldSearch
-			value={freeTextQuery}
-			onChange={(e) => {
-				const newQuery = e.target.value;
-				setFreeTextQuery(newQuery);
-				debouncedUpdate({ ...config.query, q: newQuery });
-			}}
-			aria-label="search wires"
-			style={{ borderRadius: '0', border: 'none' }}
-		/>
+		<StopShortcutPropagationWrapper>
+			<EuiFieldSearch
+				value={freeTextQuery}
+				onChange={(e) => {
+					const newQuery = e.target.value;
+					setFreeTextQuery(newQuery);
+					debouncedUpdate({ ...config.query, q: newQuery });
+				}}
+				aria-label="search wires"
+				style={{ borderRadius: '0', border: 'none' }}
+			/>
+		</StopShortcutPropagationWrapper>
 	);
 }

--- a/newswires/client/src/SettingsMenu.tsx
+++ b/newswires/client/src/SettingsMenu.tsx
@@ -7,6 +7,7 @@ import {
 	useGeneratedHtmlId,
 } from '@elastic/eui';
 import { useState } from 'react';
+import { StopShortcutPropagationWrapper } from './context/KeyboardShortcutsContext';
 import { useUserSettings } from './context/UserSettingsContext';
 
 export const SettingsMenu = () => {
@@ -92,15 +93,17 @@ export const SettingsMenu = () => {
 	);
 
 	return (
-		<EuiPopover
-			id={contextMenuPopoverId}
-			button={button}
-			isOpen={isPopoverOpen}
-			closePopover={closePopover}
-			panelPaddingSize="none"
-			anchorPosition="downLeft"
-		>
-			<EuiContextMenu initialPanelId={0} panels={panels} />
-		</EuiPopover>
+		<StopShortcutPropagationWrapper>
+			<EuiPopover
+				id={contextMenuPopoverId}
+				button={button}
+				isOpen={isPopoverOpen}
+				closePopover={closePopover}
+				panelPaddingSize="none"
+				anchorPosition="downLeft"
+			>
+				<EuiContextMenu initialPanelId={0} panels={panels} />
+			</EuiPopover>
+		</StopShortcutPropagationWrapper>
 	);
 };

--- a/newswires/client/src/context/KeyboardShortcutsContext.tsx
+++ b/newswires/client/src/context/KeyboardShortcutsContext.tsx
@@ -1,0 +1,103 @@
+import type { KeyboardEventHandler } from 'react';
+import { createContext, useCallback, useContext } from 'react';
+import { useSearch } from './SearchContext';
+
+const keysWithShortcuts = ['ArrowLeft', 'ArrowRight', 'Escape'] as const;
+
+type KeyWithShortcut = (typeof keysWithShortcuts)[number];
+
+function isKeyWithShortcut(key: string): key is KeyWithShortcut {
+	return keysWithShortcuts.includes(key as KeyWithShortcut);
+}
+
+const stopShortcutPropagation: KeyboardEventHandler<HTMLElement> = (event) => {
+	if (isKeyWithShortcut(event.key)) {
+		if (event.target instanceof HTMLElement) {
+			console.log(
+				`Stopping propagation for key: ${event.key} above ${event.target.tagName} (${event.target.className})`,
+			);
+		} else {
+			console.log(
+				`Stopping propagation for key: ${event.key} above ${JSON.stringify(event.target)}`,
+			);
+		}
+		event.stopPropagation();
+	}
+};
+
+type KeyboardShortcutsContextShape = {
+	handleShortcutKeyUp: (event: KeyboardEvent) => void;
+	stopShortcutPropagation: KeyboardEventHandler<HTMLElement>;
+};
+
+export const KeyboardShortcutsContext =
+	createContext<KeyboardShortcutsContextShape | null>(null);
+
+export function KeyboardShortcutsProvider({
+	children,
+}: {
+	children: React.ReactNode;
+}) {
+	const { config, handleDeselectItem, handleNextItem, handlePreviousItem } =
+		useSearch();
+
+	const { view } = config;
+
+	const handleShortcutKeyUp = useCallback(
+		(event: KeyboardEvent): void => {
+			const key = event.key;
+
+			if (!isKeyWithShortcut(key)) return;
+
+			if (!(event.target instanceof HTMLElement)) return;
+			const target = event.target;
+			const isTextInput =
+				target instanceof HTMLTextAreaElement ||
+				target instanceof HTMLInputElement ||
+				target.isContentEditable;
+
+			if (isTextInput) return;
+
+			if (view == 'item') {
+				switch (key) {
+					case 'Escape':
+						handleDeselectItem();
+						break;
+					case 'ArrowLeft':
+						handlePreviousItem();
+						break;
+					case 'ArrowRight':
+						handleNextItem();
+						break;
+				}
+			}
+		},
+		[handleDeselectItem, handleNextItem, handlePreviousItem, view],
+	);
+
+	return (
+		<KeyboardShortcutsContext.Provider
+			value={{ handleShortcutKeyUp, stopShortcutPropagation }}
+		>
+			{children}
+		</KeyboardShortcutsContext.Provider>
+	);
+}
+
+export function useKeyboardShortcuts() {
+	const context = useContext(KeyboardShortcutsContext);
+	if (context === null) {
+		throw new Error(
+			'useKeyboardShortcuts must be used within a KeyboardShortcutsProvider',
+		);
+	}
+	return context;
+}
+
+export const StopShortcutPropagationWrapper = ({
+	children,
+}: {
+	children: React.ReactNode;
+}) => {
+	return <div onKeyUp={stopShortcutPropagation}>{children}</div>;
+};

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -33,7 +33,7 @@ const SearchHistorySchema = z.array(
 export type SearchHistory = z.infer<typeof SearchHistorySchema>;
 
 // State Schema
-const StateSchema = z.discriminatedUnion('status', [
+const _StateSchema = z.discriminatedUnion('status', [
 	z.object({
 		status: z.literal('initialised'),
 		error: z.string().optional(),
@@ -77,10 +77,10 @@ const StateSchema = z.discriminatedUnion('status', [
 ]);
 
 // Infer State Type
-export type State = z.infer<typeof StateSchema>;
+export type State = z.infer<typeof _StateSchema>;
 
 // Action Schema
-const ActionSchema = z.discriminatedUnion('type', [
+const _ActionSchema = z.discriminatedUnion('type', [
 	z.object({ type: z.literal('ENTER_QUERY') }),
 	z.object({
 		type: z.literal('FETCH_SUCCESS'),
@@ -103,7 +103,7 @@ const ActionSchema = z.discriminatedUnion('type', [
 ]);
 
 // Infer Action Type
-export type Action = z.infer<typeof ActionSchema>;
+export type Action = z.infer<typeof _ActionSchema>;
 
 export type SearchContextShape = {
 	config: Config;

--- a/newswires/client/src/main.tsx
+++ b/newswires/client/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { stage } from './app-configuration.ts';
 import { App } from './App.tsx';
 import './icons';
+import { KeyboardShortcutsProvider } from './context/KeyboardShortcutsContext.tsx';
 import { SearchContextProvider } from './context/SearchContext.tsx';
 import { TelemetryContextProvider } from './context/TelemetryContext.tsx';
 import { UserSettingsContextProvider } from './context/UserSettingsContext.tsx';
@@ -22,7 +23,9 @@ createRoot(document.getElementById('root')!).render(
 		<TelemetryContextProvider sendTelemetryEvent={sendTelemetryEvent}>
 			<UserSettingsContextProvider>
 				<SearchContextProvider>
-					<App />
+					<KeyboardShortcutsProvider>
+						<App />
+					</KeyboardShortcutsProvider>
 				</SearchContextProvider>
 			</UserSettingsContextProvider>
 		</TelemetryContextProvider>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Un-revert #287 

The original PR was reverted because the logic I'd added to prevent keypresses from propagating to the global shortcut handler when keyboard-operable components were active, was not working properly.

This PR re-instates the global shortcut handler, whilst adding a more robust process to stop propagation of shortcut keypresses on certain components. I've also identified a couple of other components where we don't want to propagate shortcut keys (i.e. the date picker and the settings menu, where arrow keys and/or the escape key are used within the components themselves).

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
