### PR TITLE
UI: fix back to top button position bug

### DIFF
--- a/newswires/client/src/Feed.tsx
+++ b/newswires/client/src/Feed.tsx
@@ -15,9 +15,10 @@ import { WireItemList } from './WireItemList.tsx';
 
 export interface FeedProps {
 	containerRef?: React.RefObject<HTMLDivElement>;
+	direction?: string;
 }
 
-export const Feed = ({ containerRef }: FeedProps) => {
+export const Feed = ({ containerRef, direction }: FeedProps) => {
 	const { state } = useSearch();
 	const { status, queryData } = state;
 
@@ -84,7 +85,11 @@ export const Feed = ({ containerRef }: FeedProps) => {
 							totalCount={queryData.totalCount}
 						/>
 
-						<ScrollToTopButton threshold={300} containerRef={containerRef} />
+						<ScrollToTopButton
+							threshold={300}
+							containerRef={containerRef}
+							direction={direction}
+						/>
 					</>
 				)}
 		</EuiPageTemplate.Section>

--- a/newswires/client/src/ResizableContainer.tsx
+++ b/newswires/client/src/ResizableContainer.tsx
@@ -82,7 +82,7 @@ export const ResizableContainer = ({
 						style={{ padding: 0 }}
 						panelRef={leftPanelRef}
 					>
-						<Feed containerRef={leftPanelRef} />
+						<Feed containerRef={leftPanelRef} direction={direction} />
 					</EuiResizablePanel>
 					<EuiResizableButton
 						accountForScrollbars={'both'}

--- a/newswires/client/src/ScrollToTopButton.tsx
+++ b/newswires/client/src/ScrollToTopButton.tsx
@@ -1,7 +1,13 @@
 import { EuiButton, EuiPortal, useEuiTheme } from '@elastic/eui';
 import type { RefObject } from 'react';
 import type React from 'react';
-import { useEffect, useRef, useState } from 'react';
+import {
+	useCallback,
+	useEffect,
+	useLayoutEffect,
+	useRef,
+	useState,
+} from 'react';
 import { useSearch } from './context/SearchContext';
 
 /**
@@ -11,10 +17,12 @@ export const ScrollToTopButton = ({
 	threshold = 200,
 	label,
 	containerRef,
+	direction,
 }: {
 	threshold?: number;
 	label?: string;
 	containerRef?: RefObject<HTMLElement>;
+	direction?: string;
 }) => {
 	const buttonRef = useRef<HTMLDivElement>(null);
 	const { euiTheme } = useEuiTheme();
@@ -24,6 +32,30 @@ export const ScrollToTopButton = ({
 	const [incomingStories, setIncomingStories] = useState(0);
 	const [visible, setVisible] = useState(false);
 	const [btnStyle, setBtnStyle] = useState<React.CSSProperties>({});
+
+	const updatePosition = useCallback(() => {
+		const cont = containerRef?.current;
+		const btn = buttonRef.current;
+
+		const offset = 16;
+		if (cont && btn) {
+			const contRect = cont.getBoundingClientRect();
+			const btnRect = btn.getBoundingClientRect();
+			setBtnStyle({
+				position: 'fixed',
+				top: contRect.top + contRect.height - btnRect.height - offset,
+				left: contRect.left + contRect.width - btnRect.width - offset,
+				zIndex: 1000,
+			});
+		} else {
+			setBtnStyle({
+				position: 'fixed',
+				bottom: offset,
+				right: euiTheme.size.s,
+				zIndex: 1000,
+			});
+		}
+	}, [containerRef, euiTheme.size.s]);
 
 	// Accumulate counts of newly loaded stories
 	useEffect(() => {
@@ -56,30 +88,6 @@ export const ScrollToTopButton = ({
 	useEffect(() => {
 		if (!visible) return;
 
-		const updatePosition = () => {
-			const cont = containerRef?.current;
-			const btn = buttonRef.current;
-
-			const offset = 16;
-			if (cont && btn) {
-				const contRect = cont.getBoundingClientRect();
-				const btnRect = btn.getBoundingClientRect();
-				setBtnStyle({
-					position: 'fixed',
-					top: contRect.top + contRect.height - btnRect.height - offset,
-					left: contRect.left + contRect.width - btnRect.width - offset,
-					zIndex: 1000,
-				});
-			} else {
-				setBtnStyle({
-					position: 'fixed',
-					bottom: offset,
-					right: euiTheme.size.s,
-					zIndex: 1000,
-				});
-			}
-		};
-
 		window.addEventListener('resize', updatePosition);
 
 		const scrollEl = containerRef?.current ?? window;
@@ -99,7 +107,11 @@ export const ScrollToTopButton = ({
 			scrollEl.removeEventListener('scroll', updatePosition);
 			if (resizeObs) resizeObs.disconnect();
 		};
-	}, [visible, containerRef, euiTheme.size.s]);
+	}, [visible, containerRef, euiTheme.size.s, updatePosition]);
+
+	useLayoutEffect(() => {
+		updatePosition();
+	}, [direction, updatePosition]);
 
 	const handleClick = () => {
 		if (containerRef?.current) {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Fix the Scroll-to-top button position when toggling from 'show item below' to 'show item next to feed'.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Rogue button example:
<img width="1716" alt="button mispositioned" src="https://github.com/user-attachments/assets/e7d2091d-f530-4fea-a64a-0ad0074e617e" />


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
