### PR TITLE
Fix search badge toggle behaviour

### DIFF
--- a/newswires/client/.eslintrc.cjs
+++ b/newswires/client/.eslintrc.cjs
@@ -39,6 +39,7 @@ module.exports = {
 				caughtErrorsIgnorePattern: '^_',
 			},
 		],
+		"@typescript-eslint/switch-exhaustiveness-check": "error",
 		'prettier/prettier': 'warn',
 		'react/no-unknown-property': ['error', { ignore: ['css'] }],
 		'no-restricted-syntax': [

--- a/newswires/client/.storybook/preview-head.html
+++ b/newswires/client/.storybook/preview-head.html
@@ -1,6 +1,7 @@
 <script>
 	var data = {};
 	window.configuration = {
-		switches: { abc: 1 },
+		switches: { ShowGuSuppliers: false, },
+		stage: "test"
 	};
 </script>

--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -30,12 +30,20 @@ const presetLabel = (preset: string) => {
 	}
 };
 
+type SearchTermBadgeLabel =
+	| 'Search term'
+	| 'Time range'
+	| 'Preset'
+	| 'Supplier'
+	| 'Category'
+	| '(NOT) Category';
+
 const Summary = ({
 	searchSummaryLabel,
 }: {
 	searchSummaryLabel: string | boolean;
 }) => {
-	const { config, handleEnterQuery } = useSearch();
+	const { config, handleEnterQuery, toggleSupplier } = useSearch();
 	const {
 		q,
 		preset,
@@ -53,24 +61,47 @@ const Summary = ({
 	const displayFilters: boolean =
 		!!q || !!preset || displayCategoryCodes || displaySuppliers;
 
-	const handleBadgeClick = (label: string, value: string) => {
-		const supplier = config.query.supplier ?? [];
+	const handleBadgeClick = (label: SearchTermBadgeLabel, value: string) => {
 		const categoryCodes = config.query.categoryCode ?? [];
+		const categoryCodesExcl = config.query.categoryCodeExcl ?? [];
 
-		handleEnterQuery({
-			...config.query,
-			q: label === 'Search term' ? '' : config.query.q,
-			dateRange: label === 'Time range' ? undefined : config.query.dateRange,
-			preset: label === 'Preset' ? undefined : config.query.preset,
-			supplier:
-				label === 'Supplier'
-					? supplier.filter((s: string) => s !== value)
-					: supplier,
-			categoryCode:
-				label === 'Category code'
-					? categoryCodes.filter((s: string) => s !== value)
-					: categoryCodes,
-		});
+		switch (label) {
+			case 'Search term':
+				handleEnterQuery({
+					...config.query,
+					q: '',
+				});
+				break;
+			case 'Time range':
+				handleEnterQuery({
+					...config.query,
+					dateRange: undefined,
+				});
+				break;
+			case 'Supplier':
+				toggleSupplier(value);
+				break;
+			case 'Preset':
+				handleEnterQuery({
+					...config.query,
+					preset: undefined,
+				});
+				break;
+			case 'Category':
+				handleEnterQuery({
+					...config.query,
+					categoryCode: categoryCodes.filter((s: string) => s !== value),
+				});
+				break;
+			case '(NOT) Category':
+				handleEnterQuery({
+					...config.query,
+					categoryCodeExcl: categoryCodesExcl.filter(
+						(s: string) => s !== value,
+					),
+				});
+				break;
+		}
 	};
 
 	const renderBadge = (label: SearchTermBadgeLabel, value: string) =>

--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -53,7 +53,7 @@ const Summary = ({
 	const displayFilters: boolean =
 		!!q || !!preset || displayCategoryCodes || displaySuppliers;
 
-	const handleBadgeClick = (label: string, value?: string) => {
+	const handleBadgeClick = (label: string, value: string) => {
 		const supplier = config.query.supplier ?? [];
 		const categoryCodes = config.query.categoryCode ?? [];
 
@@ -73,7 +73,7 @@ const Summary = ({
 		});
 	};
 
-	const renderBadge = (label: string, value?: string) =>
+	const renderBadge = (label: SearchTermBadgeLabel, value: string) =>
 		value ? (
 			<EuiBadge
 				key={value}

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -13,7 +13,7 @@ import {
 	useIsWithinMinBreakpoint,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { useCallback, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useSearch } from './context/SearchContext.tsx';
 import { deriveDateMathRangeLabel } from './dateHelpers.ts';
 import { FeedbackContent } from './FeedbackContent.tsx';
@@ -58,13 +58,10 @@ export const SideNav = () => {
 	const [navIsOpen, setNavIsOpen] = useState<boolean>(false);
 	const isOnLargerScreen = useIsWithinMinBreakpoint('m');
 
-	const { state, config, handleEnterQuery, toggleAutoUpdate } = useSearch();
+	const { state, config, handleEnterQuery, toggleAutoUpdate, toggleSupplier } =
+		useSearch();
 
 	const searchHistory = state.successfulQueryHistory;
-	const activeSuppliers = useMemo(
-		() => config.query.supplier ?? [],
-		[config.query.supplier],
-	);
 
 	const activePreset = config.query.preset;
 
@@ -78,28 +75,9 @@ export const SideNav = () => {
 		[searchHistory],
 	);
 
-	const toggleSupplier = useCallback(
-		(supplier: string) => {
-			// If 'activeSuppliers' is empty, that means that *all* suppliers are active.
-			if (activeSuppliers.length === 0) {
-				handleEnterQuery({
-					...config.query,
-					supplier: [supplier],
-				});
-				return;
-			}
-			const newSuppliers = activeSuppliers.includes(supplier)
-				? activeSuppliers.filter((s) => s !== supplier)
-				: [...activeSuppliers, supplier];
-			handleEnterQuery({
-				...config.query,
-				// if all the suppliers are active, we don't need to specify them in the query
-				supplier: recognisedSuppliers.every((s) => newSuppliers.includes(s))
-					? []
-					: newSuppliers,
-			});
-		},
-		[config.query, handleEnterQuery, activeSuppliers],
+	const activeSuppliers = useMemo(
+		() => config.query.supplier ?? [],
+		[config.query.supplier],
 	);
 
 	const suppliers = useMemo(

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -58,8 +58,14 @@ export const SideNav = () => {
 	const [navIsOpen, setNavIsOpen] = useState<boolean>(false);
 	const isOnLargerScreen = useIsWithinMinBreakpoint('m');
 
-	const { state, config, handleEnterQuery, toggleAutoUpdate, toggleSupplier } =
-		useSearch();
+	const {
+		state,
+		config,
+		handleEnterQuery,
+		toggleAutoUpdate,
+		activeSuppliers,
+		toggleSupplier,
+	} = useSearch();
 
 	const searchHistory = state.successfulQueryHistory;
 
@@ -73,11 +79,6 @@ export const SideNav = () => {
 				resultsCount,
 			})),
 		[searchHistory],
-	);
-
-	const activeSuppliers = useMemo(
-		() => config.query.supplier ?? [],
-		[config.query.supplier],
 	);
 
 	const suppliers = useMemo(

--- a/newswires/client/src/app-configuration.ts
+++ b/newswires/client/src/app-configuration.ts
@@ -1,6 +1,24 @@
-export const SUPPLIERS_TO_EXCLUDE = window.configuration.switches
-	.ShowGuSuppliers
+const isNode = typeof process !== 'undefined';
+const isJest = isNode && process.env.JEST_WORKER_ID !== undefined;
+
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- if the code isn't
+if (isJest === undefined && !window.configuration) {
+	throw new Error('window object is defined, but window.configuration is not');
+}
+
+const configLookup = isJest
+	? {
+			switches: {
+				ShowGuSuppliers: false,
+			},
+			stage: 'test',
+		}
+	: window.configuration;
+
+const showGuSuppliers = configLookup.switches.ShowGuSuppliers;
+
+export const SUPPLIERS_TO_EXCLUDE = showGuSuppliers
 	? []
 	: ['GUAP', 'GUREUTERS'];
 
-export const stage = window.configuration.stage;
+export const stage = configLookup.stage;

--- a/newswires/client/src/app-configuration.ts
+++ b/newswires/client/src/app-configuration.ts
@@ -1,12 +1,14 @@
+import type { AppConfiguration } from './windowConfigType';
+
 const isNode = typeof process !== 'undefined';
 const isJest = isNode && process.env.JEST_WORKER_ID !== undefined;
 
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- if the code isn't
-if (isJest === undefined && !window.configuration) {
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- if the code isn't running in jest, window should be defined
+if (!isJest && !window.configuration) {
 	throw new Error('window object is defined, but window.configuration is not');
 }
 
-const configLookup = isJest
+const configLookup: AppConfiguration = isJest
 	? {
 			switches: {
 				ShowGuSuppliers: false,

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -120,6 +120,7 @@ export type SearchContextShape = {
 	handlePreviousItem: () => void;
 	toggleAutoUpdate: () => void;
 	loadMoreResults: (beforeId: string) => Promise<void>;
+	activeSuppliers: string[];
 	toggleSupplier: (supplier: string) => void;
 };
 export const SearchContext: Context<SearchContextShape | null> =
@@ -415,6 +416,7 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 				loadMoreResults,
 				viewedItemIds,
 				previousItemId,
+				activeSuppliers,
 				toggleSupplier,
 			}}
 		>

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -250,32 +250,35 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 		state.queryData?.results,
 	]);
 
-	const handleEnterQuery = (query: Query) => {
-		sendTelemetryEvent(
-			'NEWSWIRES_ENTER_SEARCH',
-			Object.fromEntries(
-				Object.entries(query).map(([key, value]) => [
-					`search-query_${key}`,
-					JSON.stringify(value),
-				]),
-			),
-		);
-		dispatch({
-			type: 'ENTER_QUERY',
-		});
-		if (currentConfig.view === 'item') {
-			pushConfigState({
-				...currentConfig,
-				query,
+	const handleEnterQuery = useCallback(
+		(query: Query) => {
+			sendTelemetryEvent(
+				'NEWSWIRES_ENTER_SEARCH',
+				Object.fromEntries(
+					Object.entries(query).map(([key, value]) => [
+						`search-query_${key}`,
+						JSON.stringify(value),
+					]),
+				),
+			);
+			dispatch({
+				type: 'ENTER_QUERY',
 			});
-		} else {
-			pushConfigState({
-				...currentConfig,
-				view: 'feed',
-				query,
-			});
-		}
-	};
+			if (currentConfig.view === 'item') {
+				pushConfigState({
+					...currentConfig,
+					query,
+				});
+			} else {
+				pushConfigState({
+					...currentConfig,
+					view: 'feed',
+					query,
+				});
+			}
+		},
+		[currentConfig, pushConfigState, sendTelemetryEvent],
+	);
 
 	const handleRetry = () => {
 		dispatch({ type: 'RETRY' });

--- a/newswires/client/src/windowConfigType.ts
+++ b/newswires/client/src/windowConfigType.ts
@@ -2,15 +2,17 @@ interface FeatureSwitches {
 	ShowGuSuppliers: boolean;
 }
 
+export interface AppConfiguration {
+	switches: FeatureSwitches;
+	stage: string;
+}
+
 declare global {
 	/* ~ Here, declare things that go in the global namespace, or augment
 	 *~ existing declarations in the global namespace
 	 */
 	interface Window {
-		configuration: {
-			switches: FeatureSwitches;
-			stage: string;
-		};
+		configuration: AppConfiguration;
 	}
 }
 /* ~ this line is required as per TypeScript's global-modifying-module.d.ts instructions */


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Fix a bug whereby dismissing a category code search badge wasn't removing the code from the search config.
- As part of addressing this, refactor the SearchSummary component to add a bit more type safety, to hopefully reduce the chance of this happening again, if new badges are created, or old ones are renamed.


<img width="414" alt="image" src="https://github.com/user-attachments/assets/b890b936-16aa-4657-aee0-985530ef0dad" />


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
