### PR TITLE
Re-add prettier (as part of eslint config)

### DIFF
--- a/newswires/client/eslint.config.mjs
+++ b/newswires/client/eslint.config.mjs
@@ -1,11 +1,14 @@
 import guardian from '@guardian/eslint-config';
+import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
 import storybook from 'eslint-plugin-storybook';
 import newswiresConfig from '../../eslint.config.mjs';
+
 
 export default [
 	...newswiresConfig,
 	...guardian.configs.react,
 	...storybook.configs['flat/recommended'],
+	eslintPluginPrettierRecommended,
 	{
 		rules: {
       "@typescript-eslint/switch-exhaustiveness-check": [


### PR DESCRIPTION
I think that this maintains parity with the eslint 8 config