### PR TITLE
Pf/edit/UI move search box

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -15,6 +15,7 @@ import {
 	EuiModalHeaderTitle,
 	EuiPageTemplate,
 	EuiProvider,
+	EuiScreenReaderOnly,
 	EuiShowFor,
 	EuiText,
 	EuiTitle,
@@ -193,12 +194,20 @@ export function App() {
 								<EuiHeaderSectionItem>
 									<SideNav />
 								</EuiHeaderSectionItem>
+								<EuiShowFor sizes={['xs']}>
+									<EuiScreenReaderOnly>
+										<h1>
+											<AppTitle />
+										</h1>
+									</EuiScreenReaderOnly>
+								</EuiShowFor>
 								<EuiShowFor sizes={['s', 'm', 'l', 'xl']}>
 									<EuiHeaderSectionItem>
 										<EuiTitle
 											size={'s'}
 											css={css`
 												padding-bottom: 3px;
+
 												${largeMaxBreakpoint} {
 													margin-right: 8px;
 												}

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -88,6 +88,7 @@ const Alert = ({
 
 export function App() {
 	const { config, state, handleEnterQuery, handleRetry } = useSearch();
+	const [navIsOpen, setNavIsOpen] = useState<boolean>(false);
 
 	const [displayDisclaimer, setDisplayDisclaimer] = useState<boolean>(() =>
 		loadOrSetInLocalStorage<boolean>('displayDisclaimer', z.boolean(), true),
@@ -192,14 +193,16 @@ export function App() {
 						<EuiHeader position="fixed">
 							<EuiHeaderSection side={'left'}>
 								<EuiHeaderSectionItem>
-									<SideNav />
+									<SideNav navIsOpen={navIsOpen} setNavIsOpen={setNavIsOpen} />
 								</EuiHeaderSectionItem>
 								<EuiShowFor sizes={['xs']}>
-									<EuiScreenReaderOnly>
-										<h1>
-											<AppTitle />
-										</h1>
-									</EuiScreenReaderOnly>
+									{!navIsOpen && (
+										<EuiScreenReaderOnly>
+											<h1>
+												<AppTitle />
+											</h1>
+										</EuiScreenReaderOnly>
+									)}
 								</EuiShowFor>
 								<EuiShowFor sizes={['s', 'm', 'l', 'xl']}>
 									<EuiHeaderSectionItem>

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -15,7 +15,7 @@ import {
 	useIsWithinMinBreakpoint,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 import { AppTitle } from './AppTitle.tsx';
 import { BetaBadge } from './BetaBadge.tsx';
 import { useSearch } from './context/SearchContext.tsx';
@@ -57,8 +57,15 @@ function presetName(presetId: string): string | undefined {
 	return presets.find((preset) => preset.id === presetId)?.name;
 }
 
-export const SideNav = () => {
-	const [navIsOpen, setNavIsOpen] = useState<boolean>(false);
+type A = (isOpen: boolean) => boolean;
+
+export const SideNav = ({
+	navIsOpen,
+	setNavIsOpen,
+}: {
+	navIsOpen: boolean;
+	setNavIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}) => {
 	const isOnLargerScreen = useIsWithinMinBreakpoint('m');
 
 	const {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
