### PR TITLE
'Minor agencies' becomes 'minor'

### DIFF
--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -95,7 +95,7 @@ export const SideNav = () => {
 				colour: 'black',
 			},
 			...Object.entries(supplierData).map(([supplier, { label, colour }]) => ({
-				label,
+				label: label === 'Minor' ? 'Minor agencies' : label,
 				isActive:
 					activeSuppliers.includes(supplier) || activeSuppliers.length === 0,
 				colour: colour,

--- a/newswires/client/src/suppliers.ts
+++ b/newswires/client/src/suppliers.ts
@@ -48,7 +48,7 @@ const allSupplierData: Record<
 		colour: reutersBrand,
 	},
 	MINOR_AGENCIES: {
-		label: 'Minor agencies',
+		label: 'Minor',
 		shortLabel: 'Min.',
 		colour: '#39756a',
 	},


### PR DESCRIPTION
Shorter label is more consistent with other labels, and we agreed as a team that 'minor' should be sufficiently clear to users.