### PR TITLE
Show 'open new ticker' secondary actions when focus is within parent button

### DIFF
--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -222,14 +222,9 @@ export const SideNav = ({
 					}
 
 					.euiListGroupItem:hover .hover-only-icon,
-					.euiListGroupItem:hover:focus-within .hover-only-icon {
+					.euiListGroupItem:focus-within .hover-only-icon {
 						opacity: 1;
 						pointer-events: auto;
-					}
-
-					.euiListGroupItem:focus-within .hover-only-icon {
-						opacity: 0;
-						pointer-events: none;
 					}
 				`}
 			>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Currently the 'open new ticker window' secondary action button is in the tab order of the page, but isn't visible when the button is focused. Rather, it's only visible on hover.

This branch makes it visible whenever the parent button is focused, which matches the current hover behaviour.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Run locally and tab through the page

## Images

### Focus on the main action button

<img width="285" alt="image" src="https://github.com/user-attachments/assets/1a1469ff-4956-4cab-9495-9b6b2db7e731" />


### Focus on the secondary action button

<img width="272" alt="image" src="https://github.com/user-attachments/assets/cf1b5117-747f-4a81-bc86-d5169f2174a3" />

### Hover & focus on secondary action button

<img width="277" alt="image" src="https://github.com/user-attachments/assets/e8fa37f3-b5e9-4d87-9d23-3ef35409fa3b" />


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
