### PR TITLE
Add telemetry tracking pixel

### DIFF
--- a/newswires/client/src/TelemetryPixel.tsx
+++ b/newswires/client/src/TelemetryPixel.tsx
@@ -1,0 +1,17 @@
+import { useSearch } from './context/SearchContext';
+import { getTelemetryUrl } from './telemetry';
+
+export const TelemetryPixel = ({ stage }: { stage: string }) => {
+	const telemetryUrl = getTelemetryUrl(stage);
+	const { config } = useSearch();
+
+	const path = config.view === 'home' ? '/' : config.view;
+
+	return (
+		<img
+			height="0"
+			width="0"
+			src={`${telemetryUrl}/guardian-tool-accessed?app=newswires&stage=${stage}&path=${path}`}
+		></img>
+	);
+};

--- a/newswires/client/src/main.tsx
+++ b/newswires/client/src/main.tsx
@@ -2,12 +2,13 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { stage } from './app-configuration.ts';
 import { App } from './App.tsx';
-import './icons';
 import { KeyboardShortcutsProvider } from './context/KeyboardShortcutsContext.tsx';
 import { SearchContextProvider } from './context/SearchContext.tsx';
 import { TelemetryContextProvider } from './context/TelemetryContext.tsx';
 import { UserSettingsContextProvider } from './context/UserSettingsContext.tsx';
+import './icons';
 import { createTelemetryEventSender } from './telemetry.ts';
+import { TelemetryPixel } from './TelemetryPixel.tsx';
 
 const { sendTelemetryEvent } = createTelemetryEventSender(stage);
 
@@ -24,6 +25,7 @@ createRoot(document.getElementById('root')!).render(
 			<UserSettingsContextProvider>
 				<SearchContextProvider>
 					<KeyboardShortcutsProvider>
+						<TelemetryPixel stage={stage} />
 						<App />
 					</KeyboardShortcutsProvider>
 				</SearchContextProvider>

--- a/newswires/client/src/telemetry.ts
+++ b/newswires/client/src/telemetry.ts
@@ -10,14 +10,15 @@ export type TelemetryEventSender = (
 	value?: boolean | number,
 ) => void;
 
-export const createTelemetryEventSender = (stage: string) => {
+export function getTelemetryUrl(stage: string): string {
 	const telemetryDomain =
 		stage === 'PROD' ? 'gutools.co.uk' : 'code.dev-gutools.co.uk';
+	return `https://user-telemetry.${telemetryDomain}`;
+}
 
-	const telemetryEventService = new UserTelemetryEventSender(
-		`https://user-telemetry.${telemetryDomain}`,
-		100,
-	);
+export const createTelemetryEventSender = (stage: string) => {
+	const telemetryUrl = getTelemetryUrl(stage);
+	const telemetryEventService = new UserTelemetryEventSender(telemetryUrl, 100);
 
 	const sendTelemetryEvent: TelemetryEventSender = (
 		type: string,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds the [tracking pixel](https://github.com/guardian/editorial-tools-user-telemetry-service?tab=readme-ov-file#tracking-pixel) that's being used as part of the tools audit. 

**nb.** This telemetry does include some user information, but this mechanism has been reviewed recently with Data Privacy as part of the tools audit. Our intention in adding it is only to understand how many distinct users are using the service, using a mechanism that provides parity between this service and the legacy `editorial-wires` service.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
