### PR TITLE
Add UK sport preset

### DIFF
--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -14,6 +14,7 @@ object SearchPresets {
     case "all-uk"               => Some(AllUk)
     case "pa-home"              => Some(PaHome)
     case "all-business"         => Some(AllBusiness)
+    case "all-sport"            => Some(AllSport)
     case _                      => None
   }
 
@@ -198,6 +199,55 @@ object SearchPresets {
     )
   )
 
+  private val ReutersSport = List(
+    SearchParams(
+      text = None,
+      suppliersIncl = List("REUTERS"),
+      categoryCodesIncl = Categories.sportRelatedTopicCodes
+    )
+  )
+
+  private val PaSport = List(
+    SearchParams(
+      text = None,
+      suppliersIncl = List("PA"),
+      categoryCodesIncl = List(
+        "paCat:SRS", // General Sport News
+        "paCat:SSS", // General Sport News
+        "paCat:SSO", // Soccer News
+        "paCat:SCR", // Cricket News
+        "paCat:SRR", // Racing News
+        "paCat:SST" // Scottish sports
+
+      )
+    )
+  )
+
+  private val AfpSport = List(
+    SearchParams(
+      text = None,
+      suppliersIncl = List("AFP"),
+      categoryCodesIncl = List("afpCat:SPO")
+    )
+  )
+
+  private val AapSport = List(
+    SearchParams(
+      text = None,
+      suppliersIncl = List("AAP"),
+      keywordIncl = List("Sports"),
+      categoryCodesIncl = Categories.sportsRelatedNewsCodes
+    )
+  )
+
+  private val ApSport = List(
+    SearchParams(
+      text = None,
+      suppliersIncl = List("AP"),
+      categoryCodesIncl = List("apCat:s")
+    )
+  )
+
   private val AllWorld =
     ApWorld ::: ReutersWorld ::: ReutersSchedule ::: AapWorld ::: AfpWorld ::: MinorAgenciesWorld
 
@@ -206,6 +256,9 @@ object SearchPresets {
 
   private val AllBusiness =
     ReutersBusiness ::: ApBusiness ::: AapBusiness ::: PaBusiness
+
+  private val AllSport =
+    ReutersSport ::: PaSport ::: AfpSport ::: AapSport ::: ApSport
 }
 
 object Categories {
@@ -738,6 +791,101 @@ object Categories {
     "N2:SHOPAL",
     "N2:SPCRET",
     "N2:NO EQUIVALENT"
+  )
+  private[conf] val sportRelatedTopicCodes = List(
+    "N2:DOP",
+    "N2:FO1",
+    "N2:MMA",
+    "N2:NBA",
+    "N2:NFL",
+    "N2:NHL",
+    "N2:SNO",
+    "N2:SPO",
+    "N2:ALPS",
+    "N2:Sports",
+    "N2:ANGL",
+    "N2:ARCH",
+    "N2:ATHL",
+    "N2:AUSR",
+    "N2:BADM",
+    "N2:BASE",
+    "N2:BASK",
+    "N2:BIAT",
+    "N2:BILL",
+    "N2:BOAR",
+    "N2:BOBS",
+    "N2:BOWL",
+    "N2:BOXI",
+    "N2:CANO",
+    "N2:CLMB",
+    "N2:CRIC",
+    "N2:CURL",
+    "N2:CYCL",
+    "N2:DIVE",
+    "N2:DNCG",
+    "N2:DRTS",
+    "N2:EQUE",
+    "N2:FENC",
+    "N2:FIGS",
+    "N2:FSKI",
+    "N2:GOLF",
+    "N2:GYMN",
+    "N2:HAND",
+    "N2:HOCK",
+    "N2:HORS",
+    "N2:ICEH",
+    "N2:JAIA",
+    "N2:JUDO",
+    "N2:KARA",
+    "N2:LACR",
+    "N2:LUGE",
+    "N2:MOCR",
+    "N2:MOCY",
+    "N2:MODE",
+    "N2:MORA",
+    "N2:MTHN",
+    "N2:NETB",
+    "N2:NORS",
+    "N2:RALL",
+    "N2:ROWI",
+    "N2:RUGL",
+    "N2:RUGU",
+    "N2:SDOG",
+    "N2:SHOO",
+    "N2:SKAT",
+    "N2:SKEL",
+    "N2:SKIJ",
+    "N2:SNOO",
+    "N2:SOCC",
+    "N2:SOFT",
+    "N2:SPEE",
+    "N2:SQUA",
+    "N2:STSK",
+    "N2:SUMO",
+    "N2:SWIM",
+    "N2:TABT",
+    "N2:TAEK",
+    "N2:TENN",
+    "N2:TENP",
+    "N2:TRIA",
+    "N2:VOLL",
+    "N2:WATP",
+    "N2:WATS",
+    "N2:WEIG",
+    "N2:WRES",
+    "N2:XCTY",
+    "N2:YACH",
+    "N2:AQSPO",
+    "N2:BVOLL",
+    "N2:CHESS",
+    "N2:MARTS",
+    "N2:ORENT",
+    "N2:PBOAT",
+    "N2:SBOAT",
+    "N2:SPOLO",
+    "N2:SPOOL",
+    "N2:SRFNG",
+    "N2:SYNCS"
   )
 
   private[conf] val sportsRelatedTopicCodes = List(

--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -22,6 +22,8 @@ const presetLabel = (preset: string) => {
 			return 'World';
 		case 'all-uk':
 			return 'UK';
+		case 'all-sport':
+			return 'Sport';
 		case 'all-business':
 			return 'Business';
 		default:

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -50,6 +50,7 @@ const presets = [
 	{ id: 'all-world', name: 'World' },
 	{ id: 'all-uk', name: 'UK' },
 	{ id: 'all-business', name: 'Business' },
+	{ id: 'all-sport', name: 'Sport' },
 ];
 
 function presetName(presetId: string): string | undefined {

--- a/newswires/client/src/category-code-lookup-tables.ts
+++ b/newswires/client/src/category-code-lookup-tables.ts
@@ -6782,7 +6782,14 @@ export const lookupTables: Array<{
 			'paCat:PPS': 'Scottish Parliament news',
 			'paCat:SCN': 'Scottish news',
 			'paCat:IFN': 'Irish news',
-			// Football
+			// Sport news
+			'paCat:SRS': 'General Sports (General sports news)',
+			'paCat:SSS': 'General Sports (General sports news)',
+			'paCat:SSO': 'Soccer News',
+			'paCat:SCR': 'Cricket News',
+			'paCat:SRR': 'Racing News',
+			'paCat:SST': 'Scottish sports',
+			// Football results
 			'paCat:RFC': 'Collated Results (Full-time scores and match details)',
 			'paCat:RSA': 'Soccer Attendance (Match attendance figures)',
 			'paCat:RSF': 'Soccer Full Time (Final match results)',
@@ -6803,8 +6810,9 @@ export const lookupTables: Array<{
 			'paCat:STB': 'Soccer Tables (various formats)',
 			'paCat:STC': 'Soccer Tables (various formats)',
 			'paCat:STD': 'Soccer Tables (various formats)',
-			'paCat:SSO': 'Soccer News',
-			// Rugby
+			'paCat:SSP': 'Soccer Fixtures',
+			// Rugby results
+			'paCat:RRI': 'Rugby Results (Match results)',
 			'paCat:RRE': 'Rugby Results (Match results)',
 			'paCat:RRG': 'Rugby Results (Match results)',
 			'paCat:RRL': 'Rugby League (League-specific results)',
@@ -6813,32 +6821,32 @@ export const lookupTables: Array<{
 			'paCat:RDJ': 'Rugby Union Collated Summaries',
 			'paCat:SDF': 'Rugby League/Union Tables',
 			'paCat:SDT': 'Rugby League/Union Tables',
-			// Cricket
+			'paCat:STE': 'Rugby Tables',
+			'paCat:STF': 'Rugby Tables',
+			// Cricket results
 			'paCat:RCK': 'Cricket Results (Match scores and details)',
+			'paCat:RCB': 'Cricket Scores',
 			'paCat:RDG': 'Cricket Scores',
-			'paCat:RDC': 'Cricket News',
-			'paCat:SCR': 'Cricket News',
+			'paCat:RDC': 'Cricket Scores',
 			'paCat:SRX': 'Cricket Tables',
 			'paCat:SRY': 'Cricket Tables',
-			// Racing
+			// Racing results
 			'paCat:RRR': 'Racing Results',
 			'paCat:RDR': 'Racing Results',
 			'paCat:SRN': 'Racing Results',
-			'paCat:SRR': 'Racing Results',
-			'paCat:RRT': 'Racing News',
-			'paCat:SRZ': 'Racing News',
-			'paCat:STR': 'Racing News',
+			'paCat:RRT': 'Racing',
+			'paCat:SRZ': 'Racing Results',
+			'paCat:STR': 'Racing',
 			'paCat:SDQ': 'Race Cards',
 			'paCat:SDP': 'Race Cards',
 			'paCat:SDR': 'Race Cards',
 			'paCat:SDS': 'Race Cards',
-			'paCat:SGN': 'Greyhound News',
+			'paCat:SGN': 'Greyhound',
 			'paCat:SGR': 'Greyhound Results',
 			// General Sports
 			'paCat:RGA': 'General Sports (General sports news)',
-			'paCat:RSR': 'General Sports (General sports news)',
-			'paCat:SRS': 'General Sports (General sports news)',
-			'paCat:SSF': 'General Sports (General sports news)',
+			'paCat:RSR': 'General Sports (General sports results)',
+			'paCat:SSF': 'General Sports (General sports fixtures)',
 			'paCat:RGD': 'General Sports Data (General sports statistics)',
 			'paCat:RFD': 'Football Data (General football information)',
 			'paCat:RCD': 'Cricket Data (General cricket information)',
@@ -6851,9 +6859,7 @@ export const lookupTables: Array<{
 			// Other
 			'paCat:SSD': 'Rugby Scores (Rugby match scores)',
 			'paCat:SSG': 'Goal Flash (Soccer goal updates)',
-			'paCat:SSS': 'Soccer Scores (Soccer match scores)',
 			'paCat:SRD': 'Sports Data (General sports statistics)',
-			'paCat:SST': 'Scottish sports',
 		},
 	},
 ];


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add UK sport search preset, only include sport news stories (exclude fixtures and results).

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
