### PR TITLE
UI: fix spacing below app header

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -27,6 +27,7 @@ import {
 import { css, Global } from '@emotion/react';
 import { useEffect, useState } from 'react';
 import { z } from 'zod';
+import { stage } from './app-configuration.ts';
 import { AppTitle } from './AppTitle.tsx';
 import { BetaBadge } from './BetaBadge.tsx';
 import { useKeyboardShortcuts } from './context/KeyboardShortcutsContext.tsx';
@@ -44,6 +45,7 @@ import { ResizableContainer } from './ResizableContainer.tsx';
 import { SearchBox } from './SearchBox.tsx';
 import { SettingsMenu } from './SettingsMenu.tsx';
 import { SideNav } from './SideNav';
+import { TelemetryPixel } from './TelemetryPixel.tsx';
 import { Tooltip } from './Tooltip.tsx';
 import { defaultQuery } from './urlState';
 
@@ -197,6 +199,7 @@ export function App() {
 						{!isPoppedOut && (
 							<EuiHeader position="fixed">
 								<EuiHeaderSection side={'left'}>
+									<TelemetryPixel stage={stage} />
 									<EuiHeaderSectionItem>
 										<SideNav
 											navIsOpen={sideNavIsOpen}

--- a/newswires/client/src/main.tsx
+++ b/newswires/client/src/main.tsx
@@ -8,7 +8,6 @@ import { TelemetryContextProvider } from './context/TelemetryContext.tsx';
 import { UserSettingsContextProvider } from './context/UserSettingsContext.tsx';
 import './icons';
 import { createTelemetryEventSender } from './telemetry.ts';
-import { TelemetryPixel } from './TelemetryPixel.tsx';
 
 const { sendTelemetryEvent } = createTelemetryEventSender(stage);
 
@@ -25,7 +24,6 @@ createRoot(document.getElementById('root')!).render(
 			<UserSettingsContextProvider>
 				<SearchContextProvider>
 					<KeyboardShortcutsProvider>
-						<TelemetryPixel stage={stage} />
 						<App />
 					</KeyboardShortcutsProvider>
 				</SearchContextProvider>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Remove space below app header

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before:
<img width="1714" alt="Before" src="https://github.com/user-attachments/assets/f814034d-898e-4c86-a56f-ba41d4698f1d" />

After:
<img width="1566" alt="After" src="https://github.com/user-attachments/assets/dd0acc74-5563-49ab-b237-3f455042a593" />



## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
