### PR TITLE
Backend: add CloudFront

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -4,7 +4,7 @@ import { App } from 'aws-cdk-lib';
 import { STACK } from '../../shared/constants';
 import type { PollerId } from '../../shared/pollers';
 import { pollerIdToLambdaAppName, POLLERS_CONFIG } from '../../shared/pollers';
-import { Newswires } from '../lib/newswires';
+import { Newswires, NewswiresCloudFrontCertificate } from '../lib/newswires';
 import { WiresFeeds } from '../lib/wires-feeds';
 
 const app = new App();
@@ -25,7 +25,17 @@ const prodWiresFeeds = new WiresFeeds(app, 'WiresFeeds-PROD', {
 	stage: 'PROD',
 });
 
-new Newswires(app, 'Newswires-CODE', {
+const codeCloudFrontCertificate = new NewswiresCloudFrontCertificate(
+	app,
+	'Newswires-CloudFront-CODE',
+	{
+		domainName: 'newswires.code.dev-gutools.co.uk',
+		stack: STACK,
+		stage: 'CODE',
+	},
+);
+
+const codeNewwiresApp = new Newswires(app, 'Newswires-CODE', {
 	env,
 	stack: STACK,
 	stage: 'CODE',
@@ -33,9 +43,23 @@ new Newswires(app, 'Newswires-CODE', {
 	enableMonitoring: false,
 	sourceQueue: codeWiresFeeds.sourceQueue,
 	fingerpostQueue: codeWiresFeeds.fingerpostQueue,
-}).addDependency(codeWiresFeeds);
+	certificateArn: codeCloudFrontCertificate.certificateArn,
+});
 
-new Newswires(app, 'Newswires-PROD', {
+codeNewwiresApp.addDependency(codeWiresFeeds);
+codeNewwiresApp.addDependency(codeCloudFrontCertificate);
+
+const prodCloudFrontCertificate = new NewswiresCloudFrontCertificate(
+	app,
+	'Newswires-CloudFront-PROD',
+	{
+		domainName: 'newswires.gutools.co.uk',
+		stack: STACK,
+		stage: 'PROD',
+	},
+);
+
+const prodNewwiresApp = new Newswires(app, 'Newswires-PROD', {
 	env,
 	stack: STACK,
 	stage: 'PROD',
@@ -43,7 +67,11 @@ new Newswires(app, 'Newswires-PROD', {
 	enableMonitoring: true,
 	sourceQueue: prodWiresFeeds.sourceQueue,
 	fingerpostQueue: prodWiresFeeds.fingerpostQueue,
-}).addDependency(prodWiresFeeds);
+	certificateArn: prodCloudFrontCertificate.certificateArn,
+});
+
+prodNewwiresApp.addDependency(prodWiresFeeds);
+prodNewwiresApp.addDependency(prodCloudFrontCertificate);
 
 export const riffraff = new RiffRaffYamlFile(app);
 

--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`The Newswires stack matches the snapshot 1`] = `
 {
@@ -64,6 +64,18 @@ exports[`The Newswires stack matches the snapshot 1`] = `
     "AMINewswires": {
       "Description": "Amazon Machine Image ID for the app newswires. Use this in conjunction with AMIgo to keep AMIs up to date.",
       "Type": "AWS::EC2::Image::Id",
+    },
+    "AssetParametersd41c8e6342cd078b5ea5aec11522bdb605eae00f4bb98a3fb0b44c827e9b5ca9ArtifactHashBC7A89B8": {
+      "Description": "Artifact hash for asset "d41c8e6342cd078b5ea5aec11522bdb605eae00f4bb98a3fb0b44c827e9b5ca9"",
+      "Type": "String",
+    },
+    "AssetParametersd41c8e6342cd078b5ea5aec11522bdb605eae00f4bb98a3fb0b44c827e9b5ca9S3BucketC1107A9A": {
+      "Description": "S3 bucket for asset "d41c8e6342cd078b5ea5aec11522bdb605eae00f4bb98a3fb0b44c827e9b5ca9"",
+      "Type": "String",
+    },
+    "AssetParametersd41c8e6342cd078b5ea5aec11522bdb605eae00f4bb98a3fb0b44c827e9b5ca9S3VersionKey428D45FC": {
+      "Description": "S3 key for asset version "d41c8e6342cd078b5ea5aec11522bdb605eae00f4bb98a3fb0b44c827e9b5ca9"",
+      "Type": "String",
     },
     "DistributionBucketName": {
       "Default": "/account/services/artifact.bucket",
@@ -208,6 +220,118 @@ exports[`The Newswires stack matches the snapshot 1`] = `
       },
       "Type": "AWS::CertificateManager::Certificate",
       "UpdateReplacePolicy": "Retain",
+    },
+    "CustomCrossRegionExportReaderCustomResourceProviderHandler46647B68": {
+      "DependsOn": [
+        "CustomCrossRegionExportReaderCustomResourceProviderRole10531BBD",
+      ],
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "AssetParametersd41c8e6342cd078b5ea5aec11522bdb605eae00f4bb98a3fb0b44c827e9b5ca9S3BucketC1107A9A",
+          },
+          "S3Key": {
+            "Fn::Join": [
+              "",
+              [
+                {
+                  "Fn::Select": [
+                    0,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParametersd41c8e6342cd078b5ea5aec11522bdb605eae00f4bb98a3fb0b44c827e9b5ca9S3VersionKey428D45FC",
+                        },
+                      ],
+                    },
+                  ],
+                },
+                {
+                  "Fn::Select": [
+                    1,
+                    {
+                      "Fn::Split": [
+                        "||",
+                        {
+                          "Ref": "AssetParametersd41c8e6342cd078b5ea5aec11522bdb605eae00f4bb98a3fb0b44c827e9b5ca9S3VersionKey428D45FC",
+                        },
+                      ],
+                    },
+                  ],
+                },
+              ],
+            ],
+          },
+        },
+        "Handler": "__entrypoint__.handler",
+        "MemorySize": 128,
+        "Role": {
+          "Fn::GetAtt": [
+            "CustomCrossRegionExportReaderCustomResourceProviderRole10531BBD",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs20.x",
+        "Timeout": 900,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "CustomCrossRegionExportReaderCustomResourceProviderRole10531BBD": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Sub": "arn:\${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          },
+        ],
+        "Policies": [
+          {
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "ssm:AddTagsToResource",
+                    "ssm:RemoveTagsFromResource",
+                    "ssm:GetParameters",
+                  ],
+                  "Effect": "Allow",
+                  "Resource": {
+                    "Fn::Join": [
+                      "",
+                      [
+                        "arn:",
+                        {
+                          "Ref": "AWS::Partition",
+                        },
+                        ":ssm:eu-west-1:",
+                        {
+                          "Ref": "AWS::AccountId",
+                        },
+                        ":parameter/cdk/exports/Newswires/*",
+                      ],
+                    ],
+                  },
+                },
+              ],
+              "Version": "2012-10-17",
+            },
+            "PolicyName": "Inline",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
     },
     "DefaultSecurityGroupNewswires91CCC0BF": {
       "Properties": {
@@ -374,6 +498,26 @@ exports[`The Newswires stack matches the snapshot 1`] = `
       },
       "Type": "Guardian::DNS::RecordSet",
     },
+    "ExportsReader8B249524": {
+      "DeletionPolicy": "Delete",
+      "Properties": {
+        "ReaderProps": {
+          "imports": {
+            "/cdk/exports/Newswires/NewswiresCloudFrontCertificateuseast1RefcloudfrontcertificateTEST727745A81E6F953A": "{{resolve:ssm:/cdk/exports/Newswires/NewswiresCloudFrontCertificateuseast1RefcloudfrontcertificateTEST727745A81E6F953A}}",
+          },
+          "prefix": "Newswires",
+          "region": "eu-west-1",
+        },
+        "ServiceToken": {
+          "Fn::GetAtt": [
+            "CustomCrossRegionExportReaderCustomResourceProviderHandler46647B68",
+            "Arn",
+          ],
+        },
+      },
+      "Type": "Custom::CrossRegionExportReader",
+      "UpdateReplacePolicy": "Delete",
+    },
     "GetDistributablePolicyNewswires3D555C70": {
       "Properties": {
         "PolicyDocument": {
@@ -481,11 +625,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:kinesis:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:kinesis:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -517,11 +657,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -888,11 +1024,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -911,11 +1043,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -995,11 +1123,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::Partition",
                     },
-                    ":rds-db:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    ":rds-db:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -1188,11 +1312,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::Partition",
                     },
-                    ":rds-db:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    ":rds-db:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -1703,11 +1823,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -1726,11 +1842,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -1996,11 +2108,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -2019,11 +2127,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -2043,11 +2147,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
                     {
                       "Ref": "AWS::Partition",
                     },
-                    ":rds-db:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    ":rds-db:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -2237,11 +2337,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -2488,11 +2584,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -2573,11 +2665,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -2627,11 +2715,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -2663,11 +2747,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -2848,11 +2928,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -2871,11 +2947,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -3002,11 +3074,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -3038,11 +3106,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -3094,11 +3158,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -3132,11 +3192,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -3502,7 +3558,12 @@ dpkg -i /newswires/newswires.deb",
             },
           ],
           "ViewerCertificate": {
-            "AcmCertificateArn": "arn:aws:acm:us-east-1:000000000000:certificate/TEST-CERT-ID",
+            "AcmCertificateArn": {
+              "Fn::GetAtt": [
+                "ExportsReader8B249524",
+                "/cdk/exports/Newswires/NewswiresCloudFrontCertificateuseast1RefcloudfrontcertificateTEST727745A81E6F953A",
+              ],
+            },
             "MinimumProtocolVersion": "TLSv1.2_2021",
             "SslSupportMethod": "sni-only",
           },
@@ -3689,11 +3750,7 @@ dpkg -i /newswires/newswires.deb",
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -3774,11 +3831,7 @@ dpkg -i /newswires/newswires.deb",
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -3828,11 +3881,7 @@ dpkg -i /newswires/newswires.deb",
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -3864,11 +3913,7 @@ dpkg -i /newswires/newswires.deb",
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -4049,11 +4094,7 @@ dpkg -i /newswires/newswires.deb",
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -4072,11 +4113,7 @@ dpkg -i /newswires/newswires.deb",
                 "Fn::Join": [
                   "",
                   [
-                    "arn:aws:ssm:",
-                    {
-                      "Ref": "AWS::Region",
-                    },
-                    ":",
+                    "arn:aws:ssm:eu-west-1:",
                     {
                       "Ref": "AWS::AccountId",
                     },
@@ -4203,11 +4240,7 @@ dpkg -i /newswires/newswires.deb",
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -4239,11 +4272,7 @@ dpkg -i /newswires/newswires.deb",
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -4295,11 +4324,7 @@ dpkg -i /newswires/newswires.deb",
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },
@@ -4333,11 +4358,7 @@ dpkg -i /newswires/newswires.deb",
             "Fn::Join": [
               "",
               [
-                "arn:aws:sns:",
-                {
-                  "Ref": "AWS::Region",
-                },
-                ":",
+                "arn:aws:sns:eu-west-1:",
                 {
                   "Ref": "AWS::AccountId",
                 },

--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -44,6 +44,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
       "GuHttpsApplicationListener",
       "GuAlb5xxPercentageAlarm",
       "GuUnhealthyInstancesAlarm",
+      "GuS3Bucket",
       "GuCname",
     ],
     "gu:cdk:version": "TEST",
@@ -363,8 +364,8 @@ exports[`The Newswires stack matches the snapshot 1`] = `
         "ResourceRecords": [
           {
             "Fn::GetAtt": [
-              "LoadBalancerNewswires3B8BBCB3",
-              "DNSName",
+              "newswirescloudfrontdistroTESTEF1A4E5C",
+              "DomainName",
             ],
           },
         ],
@@ -3410,6 +3411,126 @@ dpkg -i /newswires/newswires.deb",
       },
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
+    },
+    "newswirescloudfrontbucketTESTNewswiresB8AD8EC9": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "LifecycleConfiguration": {
+          "Rules": [
+            {
+              "ExpirationInDays": 90,
+              "Status": "Enabled",
+            },
+          ],
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true,
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newswires",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::S3::Bucket",
+      "UpdateReplacePolicy": "Retain",
+    },
+    "newswirescloudfrontdistroTESTEF1A4E5C": {
+      "Properties": {
+        "DistributionConfig": {
+          "DefaultCacheBehavior": {
+            "AllowedMethods": [
+              "GET",
+              "HEAD",
+              "OPTIONS",
+              "PUT",
+              "PATCH",
+              "POST",
+              "DELETE",
+            ],
+            "CachePolicyId": "658327ea-f89d-4fab-a63d-7e88639e58f6",
+            "Compress": true,
+            "TargetOriginId": "NewswiresnewswirescloudfrontdistroTESTOrigin1591B99FE",
+            "ViewerProtocolPolicy": "allow-all",
+          },
+          "Enabled": true,
+          "HttpVersion": "http2",
+          "IPV6Enabled": true,
+          "Logging": {
+            "Bucket": {
+              "Fn::GetAtt": [
+                "newswirescloudfrontbucketTESTNewswiresB8AD8EC9",
+                "RegionalDomainName",
+              ],
+            },
+          },
+          "Origins": [
+            {
+              "CustomOriginConfig": {
+                "OriginProtocolPolicy": "https-only",
+                "OriginSSLProtocols": [
+                  "TLSv1.2",
+                ],
+              },
+              "DomainName": {
+                "Fn::GetAtt": [
+                  "LoadBalancerNewswires3B8BBCB3",
+                  "DNSName",
+                ],
+              },
+              "Id": "NewswiresnewswirescloudfrontdistroTESTOrigin1591B99FE",
+            },
+          ],
+          "ViewerCertificate": {
+            "AcmCertificateArn": "arn:aws:acm:us-east-1:000000000000:certificate/TEST-CERT-ID",
+            "MinimumProtocolVersion": "TLSv1.2_2021",
+            "SslSupportMethod": "sni-only",
+          },
+        },
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newswires",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::CloudFront::Distribution",
     },
     "newswiresemailalarmtopicB2906D97": {
       "Properties": {

--- a/cdk/lib/__snapshots__/riffraff.test.ts.snap
+++ b/cdk/lib/__snapshots__/riffraff.test.ts.snap
@@ -17,6 +17,18 @@ deployments:
       templateStagePaths:
         CODE: WiresFeeds-CODE.template.json
         PROD: WiresFeeds-PROD.template.json
+  cfn-us-east-1-editorial-feeds-newswires-cloud-front-certificate:
+    type: cloud-formation
+    regions:
+      - us-east-1
+    stacks:
+      - editorial-feeds
+    app: newswires-cloud-front-certificate
+    contentDirectory: cdk.out
+    parameters:
+      templateStagePaths:
+        CODE: Newswires-CloudFront-CODE.template.json
+        PROD: Newswires-CloudFront-PROD.template.json
   lambda-upload-eu-west-1-editorial-feeds-ingestion-lambda:
     type: aws-lambda
     stacks:
@@ -111,6 +123,7 @@ deployments:
       - lambda-upload-eu-west-1-editorial-feeds-apPoller_poller_lambda
       - asg-upload-eu-west-1-editorial-feeds-newswires
       - cfn-eu-west-1-editorial-feeds-wires-feeds
+      - cfn-us-east-1-editorial-feeds-newswires-cloud-front-certificate
   lambda-update-eu-west-1-editorial-feeds-ingestion-lambda:
     type: aws-lambda
     stacks:

--- a/cdk/lib/newswires.test.ts
+++ b/cdk/lib/newswires.test.ts
@@ -32,6 +32,8 @@ describe('The Newswires stack', () => {
 			enableMonitoring: true,
 			fingerpostQueue: mockFingerpostQueue,
 			sourceQueue: mockSourceQueue,
+			certificateArn:
+				'arn:aws:acm:us-east-1:000000000000:certificate/TEST-CERT-ID',
 		});
 		const template = Template.fromStack(stack);
 		expect(template.toJSON()).toMatchSnapshot();

--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -2,16 +2,15 @@ import type { Alarms } from '@guardian/cdk';
 import { GuPlayApp, GuScheduledLambda } from '@guardian/cdk';
 import { AccessScope } from '@guardian/cdk/lib/constants';
 import type { NoMonitoring } from '@guardian/cdk/lib/constructs/cloudwatch';
-import { GuParameter, GuStack } from '@guardian/cdk/lib/constructs/core';
 import type { GuStackProps } from '@guardian/cdk/lib/constructs/core';
+import { GuParameter, GuStack } from '@guardian/cdk/lib/constructs/core';
 import { GuCname } from '@guardian/cdk/lib/constructs/dns';
 import { GuVpc, SubnetType } from '@guardian/cdk/lib/constructs/ec2';
 import { GuGetS3ObjectsPolicy } from '@guardian/cdk/lib/constructs/iam';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 import type { App } from 'aws-cdk-lib';
-import { aws_logs, Duration } from 'aws-cdk-lib';
-import { aws_certificatemanager as acm } from 'aws-cdk-lib';
+import { aws_certificatemanager as acm, aws_logs, Duration } from 'aws-cdk-lib';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import {
 	AllowedMethods,

--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -336,6 +336,7 @@ export class NewswiresCloudFrontCertificate extends GuStack {
 			env: {
 				region: 'us-east-1',
 			},
+			crossRegionReferences: true,
 			...props,
 		});
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
