### PR TITLE
UI: handle home URL when converting URL to config

### DIFF
--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -73,7 +73,7 @@ export function urlToConfig(location: {
 
 	const pageSegments = page.split('/');
 
-	if (page.includes('feed')) {
+	if (page === '' || page.includes('feed')) {
 		return { view: 'feed', query, ticker: page.includes('ticker') };
 	} else if (
 		page.includes('item/') &&


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Issue:
The home URL does not update when the search query changes.

Update:
Update the home URL in the same way as the feed URL when converting the URL to a config.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<img width="1713" alt="Home page" src="https://github.com/user-attachments/assets/1950c8fd-30c3-4bff-b490-f6e6b4ada4f7" />


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
