### PR TITLE
Refactor TS error handling

### DIFF
--- a/cleanup-lambda/src/handler.ts
+++ b/cleanup-lambda/src/handler.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from '../../shared/getErrorMessage';
 import { createDbConnection } from '../../shared/rds';
 import { TABLE_NAME } from './database';
 
@@ -13,7 +14,7 @@ export const main = async (): Promise<void> => {
 
 		console.log(`Deleted ${result.count} records`);
 	} catch (error) {
-		console.error('Error deleting old records:', error);
+		console.error('Error deleting old records:', getErrorMessage(error));
 	} finally {
 		await sql.end();
 	}

--- a/ingestion-lambda/src/handler.ts
+++ b/ingestion-lambda/src/handler.ts
@@ -4,6 +4,7 @@ import {
 	INGESTION_PROCESSING_SQS_MESSAGE_EVENT_TYPE,
 	SUCCESSFUL_INGESTION_EVENT_TYPE,
 } from '../../shared/constants';
+import { getErrorMessage } from '../../shared/getErrorMessage';
 import { createLogger } from '../../shared/lambda-logging';
 import { createDbConnection } from '../../shared/rds';
 import type { IngestorInputBody } from '../../shared/types';
@@ -316,7 +317,7 @@ export const main = async (event: SQSEvent): Promise<SQSBatchResponse> => {
 							});
 						}
 					} catch (e) {
-						const reason = e instanceof Error ? e.message : 'Unknown error';
+						const reason = getErrorMessage(e);
 						return {
 							status: 'failure',
 							reason,

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,5 +17,7 @@ const generateProject = (name) => {
 module.exports = {
 	verbose: true,
 	testEnvironment: 'node',
-	projects: ['cdk', 'ingestion-lambda', 'poller-lambdas'].map(generateProject),
+	projects: ['cdk', 'ingestion-lambda', 'poller-lambdas', 'shared'].map(
+		generateProject,
+	),
 };

--- a/newswires/client/src/ComposerConnection.tsx
+++ b/newswires/client/src/ComposerConnection.tsx
@@ -5,6 +5,7 @@ import {
 	EuiLoadingSpinner,
 } from '@elastic/eui';
 import { useCallback, useState } from 'react';
+import { getErrorMessage } from '../../../shared/getErrorMessage.ts';
 import { useTelemetry } from './context/TelemetryContext.tsx';
 import { composerPageForId, sendToComposer } from './send-to-composer.ts';
 import type { WireData } from './sharedTypes.ts';
@@ -98,11 +99,8 @@ export const ComposerConnection = ({ itemData }: { itemData: WireData }) => {
 				});
 			})
 			.catch((cause) => {
-				if (cause instanceof Error) {
-					setFailureReason(cause.message);
-				} else if (typeof cause === 'string') {
-					setFailureReason(cause);
-				}
+				setFailureReason(getErrorMessage(cause));
+
 				sendTelemetryEvent('NEWSWIRES_SEND_TO_COMPOSER', {
 					itemId: itemData.id,
 					status: 'failed',

--- a/newswires/client/src/ItemData.tsx
+++ b/newswires/client/src/ItemData.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { getErrorMessage } from '../../../shared/getErrorMessage.ts';
 import { useSearch } from './context/SearchContext.tsx';
 import { transformWireItemQueryResult } from './context/transformQueryResponse.ts';
 import { Item } from './Item';
@@ -38,14 +39,9 @@ export const ItemData = ({ id }: { id: string }) => {
 				}
 			})
 			.catch((e) => {
-				console.error(e);
-				setError(
-					e instanceof Error
-						? e.message
-						: typeof e === 'string'
-							? e
-							: 'unknown error',
-				);
+				const errorMessage = getErrorMessage(e);
+				console.error(errorMessage);
+				setError(errorMessage);
 			});
 	}, [id, config.query.q]);
 

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -9,6 +9,7 @@ import {
 	useState,
 } from 'react';
 import { z } from 'zod';
+import { getErrorMessage } from '../../../../shared/getErrorMessage.ts';
 import type { Config, Query } from '../sharedTypes.ts';
 import {
 	ConfigSchema,
@@ -150,14 +151,11 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 	});
 
 	function handleFetchError(error: ErrorEvent) {
-		if (error instanceof Error) {
+		if (error instanceof Error && error.name === 'AbortError') {
 			// we don't want to treat aborts as errors
-			if (error.name !== 'AbortError') {
-				dispatch({ type: 'FETCH_ERROR', error: error.message });
-			}
-		} else {
-			dispatch({ type: 'FETCH_ERROR', error: 'unknown error' });
+			return;
 		}
+		dispatch({ type: 'FETCH_ERROR', error: getErrorMessage(error) });
 	}
 
 	const pushConfigState = useCallback(

--- a/newswires/client/src/context/SearchReducer.ts
+++ b/newswires/client/src/context/SearchReducer.ts
@@ -1,6 +1,7 @@
 import dateMath from '@elastic/datemath';
 import { isEqual as deepIsEqual } from 'lodash';
 import moment from 'moment-timezone';
+import { getErrorMessage } from '../../../../shared/getErrorMessage.ts';
 import type { Query, WiresQueryData } from '../sharedTypes.ts';
 import { defaultQuery } from '../urlState.ts';
 import type { Action, SearchHistory, State } from './SearchContext.tsx';
@@ -15,7 +16,7 @@ export const safeReducer = (
 			return {
 				...state,
 				status: 'error',
-				error: `Error processing action (${action.type}) ${error instanceof Error ? error.message : 'Unknown error'}`,
+				error: `Error processing action (${action.type}) ${getErrorMessage(error)}`,
 			};
 		}
 	};

--- a/newswires/client/src/context/fetchResults.ts
+++ b/newswires/client/src/context/fetchResults.ts
@@ -19,27 +19,24 @@ export const fetchResults = async (
 		},
 		signal: abortController?.signal ?? undefined,
 	});
-	try {
-		const data = (await response.json()) as unknown;
-		if (!response.ok) {
-			throw new Error(
-				// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- this is the expected shape from Play but you never know
-				(data as { error: { exception: { description: string } } }).error
-					.exception.description ?? 'Unknown error',
-			);
-		}
 
-		const parseResult = WiresQueryResponseSchema.safeParse(data);
-		if (!parseResult.success) {
-			throw new Error(
-				`Received invalid data from server: ${JSON.stringify(parseResult.error)}`,
-			);
-		}
-		return {
-			...parseResult.data,
-			results: parseResult.data.results.map(transformWireItemQueryResult),
-		};
-	} catch (e) {
-		throw new Error(e instanceof Error ? e.message : 'Unknown error');
+	const data = (await response.json()) as unknown;
+	if (!response.ok) {
+		throw new Error(
+			// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- this is the expected shape from Play but you never know
+			(data as { error: { exception: { description: string } } }).error
+				.exception.description ?? 'Unknown error',
+		);
 	}
+
+	const parseResult = WiresQueryResponseSchema.safeParse(data);
+	if (!parseResult.success) {
+		throw new Error(
+			`Received invalid data from server: ${JSON.stringify(parseResult.error)}`,
+		);
+	}
+	return {
+		...parseResult.data,
+		results: parseResult.data.results.map(transformWireItemQueryResult),
+	};
 };

--- a/newswires/client/src/context/localStorage.tsx
+++ b/newswires/client/src/context/localStorage.tsx
@@ -1,4 +1,5 @@
 import type { z } from 'zod';
+import { getErrorMessage } from '../../../../shared/getErrorMessage';
 
 function loadFromLocalStorage<T>(
 	key: string,
@@ -16,7 +17,7 @@ function loadFromLocalStorage<T>(
 		}
 		return parsed.data;
 	} catch (e) {
-		console.error(e);
+		console.error(getErrorMessage(e));
 		return null;
 	}
 }
@@ -25,7 +26,7 @@ export function saveToLocalStorage<T>(key: string, data: T) {
 	try {
 		localStorage.setItem(key, JSON.stringify(data));
 	} catch (e) {
-		console.error(e);
+		console.error(getErrorMessage(e));
 	}
 }
 

--- a/poller-lambdas/src/index.ts
+++ b/poller-lambdas/src/index.ts
@@ -8,6 +8,7 @@ import {
 	POLLER_FAILURE_EVENT_TYPE,
 	POLLER_INVOCATION_EVENT_TYPE,
 } from '../../shared/constants';
+import { getErrorMessage } from '../../shared/getErrorMessage';
 import { createLogger } from '../../shared/lambda-logging';
 import type { PollerId } from '../../shared/pollers';
 import { POLLER_LAMBDA_ENV_VAR_KEYS } from '../../shared/pollers';
@@ -78,7 +79,7 @@ const pollerWrapper =
 						await sqs.send(new SendMessageCommand(message)).catch((error) => {
 							logger.error({
 								message: `Sending to queue failed for ${externalId}`,
-								error: error instanceof Error ? error.message : error,
+								error: getErrorMessage(error),
 								queueMessage: JSON.stringify(message),
 							});
 							throw error; // we still expect this to be terminal for the poller lambda
@@ -120,7 +121,7 @@ const pollerWrapper =
 				})
 				.catch((error) => {
 					logger.error({
-						message: `Poller lambda failed with message: ${error instanceof Error ? error.message : error}`,
+						message: `Poller lambda failed with message: ${getErrorMessage(error)}`,
 						sqsMessageId: Records.map((record) => record.messageId).join(', '),
 						eventType: POLLER_FAILURE_EVENT_TYPE,
 						pollerName: pollerFunction.name,

--- a/poller-lambdas/src/pollers/reuters/auth.ts
+++ b/poller-lambdas/src/pollers/reuters/auth.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { getErrorMessage } from '../../../../shared/getErrorMessage';
 
 const AuthSchema = z.object({
 	access_token: z.string(),
@@ -33,7 +34,7 @@ export async function auth(
 		);
 		return access_token;
 	} catch (error) {
-		console.error(error);
+		console.error(getErrorMessage(error));
 		throw new Error('Failed to get auth token from Reuters');
 	}
 }

--- a/shared/getErrorMessage.test.ts
+++ b/shared/getErrorMessage.test.ts
@@ -1,0 +1,51 @@
+import { getErrorMessage } from './getErrorMessage';
+
+function throwCatchAndReturnErrorMessage(error: unknown): string {
+	try {
+		throw error;
+	} catch (e) {
+		return getErrorMessage(e);
+	}
+}
+
+describe('getErrorMessage', () => {
+	it('should return the error message from an Error object', () => {
+		const error = new Error('This is an error');
+		expect(getErrorMessage(error)).toBe('This is an error');
+
+		expect(throwCatchAndReturnErrorMessage(error)).toBe('This is an error');
+	});
+
+	it('should return the message from an object with a message property', () => {
+		const error = { message: 'This is a custom error message' };
+		expect(getErrorMessage(error)).toBe('This is a custom error message');
+	});
+
+	it('should handle non-error objects by stringifying them', () => {
+		const error = { foo: 'bar' };
+		expect(getErrorMessage(error)).toBe('{"foo":"bar"}');
+	});
+
+	it('should handle circular references somewhat gracefully', () => {
+		const circularObj = {};
+		// @ts-expect-error -- we haven't specified a type for circularObj but we want to test circular references
+		circularObj.self = circularObj;
+		expect(getErrorMessage(circularObj)).toBe('[object Object]');
+	});
+
+	it("should handle the various things you can (but almost certainly shouldn't) throw in JavaScript", () => {
+		expect(throwCatchAndReturnErrorMessage('string error')).toBe(
+			'"string error"',
+		);
+		expect(throwCatchAndReturnErrorMessage(42)).toBe('42');
+		expect(throwCatchAndReturnErrorMessage(true)).toBe('true');
+		expect(throwCatchAndReturnErrorMessage(null)).toBe('null');
+		expect(throwCatchAndReturnErrorMessage(undefined)).toBe('');
+		expect(throwCatchAndReturnErrorMessage(Symbol('A'))).toBe('');
+		expect(throwCatchAndReturnErrorMessage({})).toBe('{}');
+		expect(throwCatchAndReturnErrorMessage([])).toBe('[]');
+
+		const date = new Date();
+		expect(throwCatchAndReturnErrorMessage(date)).toBe(JSON.stringify(date));
+	});
+});

--- a/shared/getErrorMessage.test.ts
+++ b/shared/getErrorMessage.test.ts
@@ -35,7 +35,7 @@ describe('getErrorMessage', () => {
 
 	it("should handle the various things you can (but almost certainly shouldn't) throw in JavaScript", () => {
 		expect(throwCatchAndReturnErrorMessage('string error')).toBe(
-			'"string error"',
+			'string error',
 		);
 		expect(throwCatchAndReturnErrorMessage(42)).toBe('42');
 		expect(throwCatchAndReturnErrorMessage(true)).toBe('true');

--- a/shared/getErrorMessage.ts
+++ b/shared/getErrorMessage.ts
@@ -19,6 +19,9 @@ function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
 	if (isErrorWithMessage(maybeError)) return maybeError;
 
 	try {
+		if (typeof maybeError === 'string') {
+			return new Error(maybeError);
+		}
 		return new Error(JSON.stringify(maybeError));
 	} catch {
 		// fallback in case there's an error stringifying the maybeError

--- a/shared/getErrorMessage.ts
+++ b/shared/getErrorMessage.ts
@@ -1,0 +1,32 @@
+/**
+ * @see https://kentcdodds.com/blog/get-a-catch-block-error-message-with-typescript
+ */
+
+type ErrorWithMessage = {
+	message: string;
+};
+
+function isErrorWithMessage(error: unknown): error is ErrorWithMessage {
+	return (
+		typeof error === 'object' &&
+		error !== null &&
+		'message' in error &&
+		typeof (error as Record<string, unknown>).message === 'string'
+	);
+}
+
+function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
+	if (isErrorWithMessage(maybeError)) return maybeError;
+
+	try {
+		return new Error(JSON.stringify(maybeError));
+	} catch {
+		// fallback in case there's an error stringifying the maybeError
+		// like with circular references for example.
+		return new Error(String(maybeError));
+	}
+}
+
+export function getErrorMessage(error: unknown) {
+	return toErrorWithMessage(error).message;
+}


### PR DESCRIPTION
There are a number of places where we try to pull a useful message out of an `Error` (or, more accurately, something that's been thrown). We're doing it in slightly different ways in different places.

There's a [blog post about extracting error messages in TypeScript](https://kentcdodds.com/blog/get-a-catch-block-error-message-with-typescript) which seems to cover most of the possible cases pretty well, so it feels worth adding as a helper function and just using that when needed.