### PR TITLE
UI: add menu button to large screens

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -7,6 +7,7 @@ import {
 	EuiHeader,
 	EuiHeaderSection,
 	EuiHeaderSectionItem,
+	EuiHeaderSectionItemButton,
 	EuiIcon,
 	EuiModal,
 	EuiModalBody,
@@ -93,6 +94,7 @@ export function App() {
 		useSearch();
 
 	const [sideNavIsOpen, setSideNavIsOpen] = useState<boolean>(false);
+	const [sideNavIsDocked, setSideNavIsDocked] = useState<boolean>(true);
 	const [displayDisclaimer, setDisplayDisclaimer] = useState<boolean>(() =>
 		loadOrSetInLocalStorage<boolean>('displayDisclaimer', z.boolean(), true),
 	);
@@ -201,8 +203,22 @@ export function App() {
 								<EuiHeaderSection side={'left'}>
 									<TelemetryPixel stage={stage} />
 									<EuiHeaderSectionItem>
+										<EuiHeaderSectionItemButton
+											aria-label="Toggle main navigation"
+											onClick={() =>
+												setSideNavIsDocked((isDocked) => !isDocked)
+											}
+											css={css`
+												${largeMaxBreakpoint} {
+													display: none;
+												}
+											`}
+										>
+											<EuiIcon type={'menu'} size="m" aria-hidden="true" />
+										</EuiHeaderSectionItemButton>
 										<SideNav
 											navIsOpen={sideNavIsOpen}
+											navIsDocked={sideNavIsDocked}
 											setNavIsOpen={setSideNavIsOpen}
 										/>
 									</EuiHeaderSectionItem>
@@ -227,7 +243,7 @@ export function App() {
 													}
 
 													${largeMinBreakpoint} {
-														width: 298px;
+														width: 258px;
 													}
 												`}
 											>

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -12,10 +12,11 @@ import {
 	EuiSwitch,
 	EuiText,
 	EuiTitle,
-	useIsWithinMinBreakpoint,
+	useEuiMinBreakpoint,
+	useIsWithinBreakpoints,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { AppTitle } from './AppTitle.tsx';
 import { BetaBadge } from './BetaBadge.tsx';
 import { useSearch } from './context/SearchContext.tsx';
@@ -59,12 +60,15 @@ function presetName(presetId: string): string | undefined {
 
 export const SideNav = ({
 	navIsOpen,
+	navIsDocked,
 	setNavIsOpen,
 }: {
 	navIsOpen: boolean;
+	navIsDocked: boolean;
 	setNavIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 }) => {
-	const isOnLargerScreen = useIsWithinMinBreakpoint('m');
+	const largeMinBreakpoint = useEuiMinBreakpoint('l');
+	const isLargeScreen = useIsWithinBreakpoints(['l']);
 
 	const {
 		state,
@@ -195,16 +199,27 @@ export const SideNav = ({
 		}),
 	);
 
+	useEffect(() => {
+		if (isLargeScreen) {
+			setNavIsOpen(false);
+		}
+	}, [isLargeScreen, setNavIsOpen]);
+
 	return (
 		<>
 			<EuiCollapsibleNav
 				isOpen={navIsOpen}
-				isDocked={isOnLargerScreen}
+				isDocked={navIsDocked}
 				size={300}
 				button={
 					<EuiHeaderSectionItemButton
 						aria-label="Toggle main navigation"
 						onClick={() => setNavIsOpen((isOpen) => !isOpen)}
+						css={css`
+							${largeMinBreakpoint} {
+								display: none;
+							}
+						`}
 					>
 						<EuiIcon type={'menu'} size="m" aria-hidden="true" />
 					</EuiHeaderSectionItemButton>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add menu button to large screens to allow users to toggle the side nav.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

With side nav:
<img width="1184" alt="With side nav" src="https://github.com/user-attachments/assets/71ee8a29-c219-47ed-ae69-0da57570b165" />

Without side nav:
<img width="1185" alt="Without side nav" src="https://github.com/user-attachments/assets/54f2c818-829e-4586-a0f6-cde6dd36ce37" />

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
