### PR TITLE
UI: update story not found message

### DIFF
--- a/newswires/client/src/Item.tsx
+++ b/newswires/client/src/Item.tsx
@@ -3,11 +3,13 @@ import {
 	EuiButtonIcon,
 	EuiFlexGroup,
 	EuiHorizontalRule,
-	EuiPageTemplate,
 	EuiSplitPanel,
 	EuiSwitch,
+	EuiText,
+	EuiTitle,
 	useIsWithinBreakpoints,
 } from '@elastic/eui';
+import { css } from '@emotion/react';
 import { useEffect, useRef, useState } from 'react';
 import { type WireData } from './sharedTypes';
 import { Tooltip } from './Tooltip.tsx';
@@ -46,13 +48,46 @@ export const Item = ({
 	}, [headingRef, itemData?.id]);
 
 	return (
-		<EuiSplitPanel.Outer>
+		<EuiSplitPanel.Outer
+			direction="column"
+			css={css`
+				min-height: 100%;
+			`}
+		>
 			{error && (
-				<EuiPageTemplate.EmptyPrompt>
-					<p>{error}</p>
-				</EuiPageTemplate.EmptyPrompt>
+				<EuiSplitPanel.Inner
+					css={css`
+						flex: 1;
+						display: flex;
+						flex-direction: column;
+						padding: 16px;
+						position: relative;
+					`}
+				>
+					<div
+						css={css`
+							align-self: flex-end;
+						`}
+					>
+						<Tooltip tooltipContent="Close story" position="left">
+							<EuiButtonIcon
+								iconType="cross"
+								onClick={handleDeselectItem}
+								aria-label="Close story"
+							/>
+						</Tooltip>
+					</div>
+					<EuiHorizontalRule margin="s" />
+
+					<EuiText textAlign="left">
+						<EuiTitle size="xs">
+							<h2>Item Not Found</h2>
+						</EuiTitle>
+						<p>Stories are available for 14 days before being removed.</p>
+					</EuiText>
+				</EuiSplitPanel.Inner>
 			)}
-			{itemData && (
+			{!error && itemData && (
 				<>
 					<EuiSplitPanel.Inner>
 						<EuiFlexGroup


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Update story not found message:
- Add close button
- Update layout and message

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before:
<img width="1571" alt="Before" src="https://github.com/user-attachments/assets/9ad14021-5230-4a3b-a410-1df39a6b8259" />

After:
<img width="1615" alt="After" src="https://github.com/user-attachments/assets/5ac506a7-1b9b-4310-b2e3-a836941ef9b9" />


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
