### PR TITLE
UI: update story list top section layout

### DIFF
--- a/newswires/client/src/DatePicker.tsx
+++ b/newswires/client/src/DatePicker.tsx
@@ -15,7 +15,7 @@ import {
 import type { TimeRange } from './dateHelpers.ts';
 import { timeRangeOption } from './dateHelpers.ts';
 
-export const DatePicker = () => {
+export const DatePicker = ({ width = 'auto' }: { width?: 'full' | 'auto' }) => {
 	const { config, handleEnterQuery } = useSearch();
 
 	/*
@@ -50,7 +50,7 @@ export const DatePicker = () => {
 			{/* Wrap date picker so StopShortcutPropagationWrapper can catch and stop its keyboard events */}
 			<div>
 				<EuiSuperDatePicker
-					width={'auto'}
+					width={width}
 					compressed={true}
 					start={
 						config.query.dateRange

--- a/newswires/client/src/Feed.tsx
+++ b/newswires/client/src/Feed.tsx
@@ -6,6 +6,7 @@ import {
 	EuiPageTemplate,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
+import { useEffect, useState } from 'react';
 import { useSearch } from './context/SearchContext.tsx';
 import { DatePicker } from './DatePicker.tsx';
 import { ScrollToTopButton } from './ScrollToTopButton.tsx';
@@ -17,11 +18,35 @@ export interface FeedProps {
 	direction?: string;
 }
 
+const baseStyles = css`
+	padding-bottom: 12px;
+`;
+
+const columnStyles = css`
+	flex-direction: column;
+`;
+
 export const Feed = ({ containerRef, direction }: FeedProps) => {
 	const { state, config } = useSearch();
 	const { status, queryData } = state;
 
 	const isPoppedOut = config.ticker;
+
+	const [isColumn, setIsColumn] = useState(false);
+
+	useEffect(() => {
+		const el = containerRef?.current;
+		if (!el) return;
+
+		const observer = new ResizeObserver((entries) => {
+			for (const entry of entries) {
+				setIsColumn(entry.contentRect.width < 450);
+			}
+		});
+
+		observer.observe(el);
+		return () => observer.disconnect();
+	}, [containerRef]);
 
 	return (
 		<EuiPageTemplate.Section
@@ -63,17 +88,13 @@ export const Feed = ({ containerRef, direction }: FeedProps) => {
 				queryData.results.length > 0 && (
 					<>
 						<div>
-							<EuiFlexGroup
-								css={css`
-									padding-bottom: 12px;
-								`}
-							>
+							<EuiFlexGroup css={[baseStyles, isColumn && columnStyles]}>
 								<EuiFlexItem style={{ flex: 1 }}>
 									<SearchSummary />
 								</EuiFlexItem>
 								{!isPoppedOut && (
 									<EuiFlexItem grow={false}>
-										<DatePicker />
+										<DatePicker width={isColumn ? 'full' : 'auto'} />
 									</EuiFlexItem>
 								)}
 							</EuiFlexGroup>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Make the story list top section layout responsive on large screens.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Before:
<img width="1567" alt="Before" src="https://github.com/user-attachments/assets/8bc44291-2771-435c-9e9d-f4b4a960662e" />


After:
<img width="1622" alt="After" src="https://github.com/user-attachments/assets/5a60a626-5a0b-42f7-90fe-05a47ed80b4f" />


## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
