### PR TITLE
remove client dependabot group and exclude react upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,11 @@ updates:
         update-types:
           - "version-update:semver-major"
           - "version-update:semver-minor"
+      # We can't upgrade to react 19 until eui does
+      - dependency-name: "react"
+      - dependency-name: "react-dom"
+      - dependency-name: "@types/react"
+      - dependency-name: "@types/react-dom"
     groups:
       cdk-dependencies:
         patterns:
@@ -28,22 +33,6 @@ updates:
           - "*"
         exclude-patterns:
           - "@guardian/cdk"
-          - "typescript"
-
-  - package-ecosystem: "npm"
-    directory: "/newswires/client"
-    schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "@types/node"
-        update-types:
-          - "version-update:semver-major"
-          - "version-update:semver-minor"
-    groups:
-      client:
-        patterns:
-          - "*"
-        exclude-patterns:
           - "typescript"
 
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Now we've included the client project into the npm workspace, it's included in the non-cdk-dependencies group, so dependabot is producing duplicate PRs (eg. https://github.com/guardian/newswires/pull/354 and https://github.com/guardian/newswires/pull/352 which both update the client dependencies). In fact the "client" group one is broken, as there is no package-lock in `newswires/client` so dependabot updates only the main `package.json`. Let's remove that group.

Ideally I'd keep the client group and separate it out from the rest, but I can't see a dependabot option to split groups by workspace (since the directory needs to remain the root since that's where the package-lock is)