### PR TITLE
UI: open filter menu from ticker

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -90,10 +90,15 @@ const Alert = ({
 };
 
 export function App() {
-	const { config, state, handleEnterQuery, handleRetry, openTicker } =
-		useSearch();
+	const {
+		config,
+		state,
+		handleEnterQuery,
+		handleRetry,
+		openTicker,
+		sideNavIsOpen,
+	} = useSearch();
 
-	const [sideNavIsOpen, setSideNavIsOpen] = useState<boolean>(false);
 	const [sideNavIsDocked, setSideNavIsDocked] = useState<boolean>(true);
 	const [displayDisclaimer, setDisplayDisclaimer] = useState<boolean>(() =>
 		loadOrSetInLocalStorage<boolean>('displayDisclaimer', z.boolean(), true),
@@ -198,6 +203,7 @@ export function App() {
 							${status === 'loading' && 'background: white;'}
 						`}
 					>
+						{isPoppedOut && <SideNav navIsDocked={false} />}
 						{!isPoppedOut && (
 							<EuiHeader position="fixed">
 								<EuiHeaderSection side={'left'}>
@@ -216,11 +222,7 @@ export function App() {
 										>
 											<EuiIcon type={'menu'} size="m" aria-hidden="true" />
 										</EuiHeaderSectionItemButton>
-										<SideNav
-											navIsOpen={sideNavIsOpen}
-											navIsDocked={sideNavIsDocked}
-											setNavIsOpen={setSideNavIsOpen}
-										/>
+										<SideNav navIsDocked={sideNavIsDocked} />
 									</EuiHeaderSectionItem>
 									<EuiShowFor sizes={['xs']}>
 										{!sideNavIsOpen && (

--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -1,6 +1,7 @@
 import {
 	EuiBadge,
 	EuiBeacon,
+	EuiButtonEmpty,
 	EuiButtonIcon,
 	useIsWithinBreakpoints,
 } from '@elastic/eui';
@@ -163,6 +164,7 @@ export const SearchSummary = () => {
 		state: { queryData, status, lastUpdate },
 		config,
 		openTicker,
+		setSideNavIsOpen,
 	} = useSearch();
 	const isPoppedOut = config.ticker;
 
@@ -264,6 +266,21 @@ export const SearchSummary = () => {
 					</Tooltip>
 				)}
 			<Summary searchSummaryLabel={!isPoppedOut && searchSummary} />
+
+			{isPoppedOut && (
+				<EuiButtonEmpty
+					size="xs"
+					iconType={'menu'}
+					onClick={() => setSideNavIsOpen(true)}
+					css={css`
+						margin-left: 4px;
+						color: #07101f;
+						background-color: #e3e8f2;
+					`}
+				>
+					Open filters
+				</EuiButtonEmpty>
+			)}
 		</div>
 	);
 };

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -8,7 +8,6 @@ import {
 	EuiHeaderSectionItemButton,
 	EuiIcon,
 	EuiPinnableListGroup,
-	EuiShowFor,
 	EuiSwitch,
 	EuiText,
 	EuiTitle,
@@ -58,17 +57,10 @@ function presetName(presetId: string): string | undefined {
 	return presets.find((preset) => preset.id === presetId)?.name;
 }
 
-export const SideNav = ({
-	navIsOpen,
-	navIsDocked,
-	setNavIsOpen,
-}: {
-	navIsOpen: boolean;
-	navIsDocked: boolean;
-	setNavIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
-}) => {
+export const SideNav = ({ navIsDocked }: { navIsDocked: boolean }) => {
 	const largeMinBreakpoint = useEuiMinBreakpoint('l');
 	const isLargeScreen = useIsWithinBreakpoints(['l']);
+	const isExtraSmallScreen = useIsWithinBreakpoints(['xs']);
 
 	const {
 		state,
@@ -78,7 +70,11 @@ export const SideNav = ({
 		activeSuppliers,
 		toggleSupplier,
 		openTicker,
+		sideNavIsOpen: navIsOpen,
+		setSideNavIsOpen: setNavIsOpen,
 	} = useSearch();
+
+	const isPoppedOut = config.ticker;
 
 	const searchHistory = state.successfulQueryHistory;
 
@@ -212,17 +208,19 @@ export const SideNav = ({
 				isDocked={navIsDocked}
 				size={300}
 				button={
-					<EuiHeaderSectionItemButton
-						aria-label="Toggle main navigation"
-						onClick={() => setNavIsOpen((isOpen) => !isOpen)}
-						css={css`
-							${largeMinBreakpoint} {
-								display: none;
-							}
-						`}
-					>
-						<EuiIcon type={'menu'} size="m" aria-hidden="true" />
-					</EuiHeaderSectionItemButton>
+					!isPoppedOut ? (
+						<EuiHeaderSectionItemButton
+							aria-label="Toggle main navigation"
+							onClick={() => setNavIsOpen((isOpen) => !isOpen)}
+							css={css`
+								${largeMinBreakpoint} {
+									display: none;
+								}
+							`}
+						>
+							<EuiIcon type={'menu'} size="m" aria-hidden="true" />
+						</EuiHeaderSectionItemButton>
+					) : undefined
 				}
 				onClose={() => setNavIsOpen(false)}
 				css={css`
@@ -245,21 +243,20 @@ export const SideNav = ({
 				`}
 			>
 				<div style={{ height: '90%', overflowY: 'auto' }}>
-					<EuiShowFor sizes={['xs']}>
-						<>
-							<EuiTitle
-								size={'s'}
-								css={css`
-									padding: 7px;
-								`}
-							>
-								<h1>
-									<AppTitle />
-									<BetaBadge size={'medium'} />
-								</h1>
-							</EuiTitle>
-						</>
-					</EuiShowFor>
+					{(isPoppedOut || isExtraSmallScreen) && (
+						<EuiTitle
+							size={'s'}
+							css={css`
+								padding: 7px;
+							`}
+						>
+							<h1>
+								<AppTitle />
+								<BetaBadge size={'medium'} />
+							</h1>
+						</EuiTitle>
+					)}
+
 					<EuiCollapsibleNavGroup title="Presets">
 						<EuiPinnableListGroup
 							onPinClick={() => {}}

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -124,6 +124,8 @@ export type SearchContextShape = {
 	loadMoreResults: (beforeId: string) => Promise<void>;
 	activeSuppliers: string[];
 	toggleSupplier: (supplier: string) => void;
+	sideNavIsOpen: boolean;
+	setSideNavIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };
 export const SearchContext: Context<SearchContextShape | null> =
 	createContext<SearchContextShape | null>(null);
@@ -134,6 +136,8 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 	const [previousItemId, setPreviousItemId] = useState<string | undefined>(
 		undefined,
 	);
+
+	const [sideNavIsOpen, setSideNavIsOpen] = useState<boolean>(false);
 
 	const [currentConfig, setConfig] = useState<Config>(() =>
 		urlToConfig(window.location),
@@ -458,6 +462,8 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 				activeSuppliers,
 				toggleSupplier,
 				openTicker,
+				sideNavIsOpen,
+				setSideNavIsOpen,
 			}}
 		>
 			{children}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Open the filter menu from a ticker window.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

Ticker window:
<img width="696" alt="Ticker window" src="https://github.com/user-attachments/assets/2a40435d-948f-4c18-8262-1fa7524c74e1" />

Filter menu:
<img width="695" alt="Filter menu" src="https://github.com/user-attachments/assets/2e035329-e427-4d13-aa49-235757d0279d" />

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [x] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [x] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [x] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
