### PR TITLE
Prepare for email integration

### DIFF
--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -60,6 +60,18 @@ exports[`The Newswires stack matches the snapshot 1`] = `
         ],
       },
     },
+    "NewswiresIngestionLambdaArnOutput": {
+      "Description": "ARN of the ingestion lambda function",
+      "Export": {
+        "Name": "NewswiresIngestionLambdaFunctionArn-TEST",
+      },
+      "Value": {
+        "Fn::GetAtt": [
+          "IngestionLambdaTESTC02B3E43",
+          "Arn",
+        ],
+      },
+    },
   },
   "Parameters": {
     "AMINewswires": {

--- a/cdk/lib/__snapshots__/whole-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/whole-stack.test.ts.snap
@@ -537,6 +537,18 @@ exports[`createStacks should create WiresFeeds and Newswires stacks with correct
         ],
       },
     },
+    "NewswiresIngestionLambdaArnOutput": {
+      "Description": "ARN of the ingestion lambda function",
+      "Export": {
+        "Name": "NewswiresIngestionLambdaFunctionArn-TEST",
+      },
+      "Value": {
+        "Fn::GetAtt": [
+          "IngestionLambdaTESTC02B3E43",
+          "Arn",
+        ],
+      },
+    },
   },
   "Parameters": {
     "AMINewswires": {

--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -10,7 +10,7 @@ import { GuGetS3ObjectsPolicy } from '@guardian/cdk/lib/constructs/iam';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 import type { App } from 'aws-cdk-lib';
-import { aws_logs, Duration } from 'aws-cdk-lib';
+import { aws_logs, CfnOutput, Duration } from 'aws-cdk-lib';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import {
 	AllowedMethods,
@@ -336,5 +336,11 @@ export class Newswires extends GuStack {
 		newswiresApp.autoScalingGroup.connections.addSecurityGroup(
 			database.accessSecurityGroup,
 		);
+
+		new CfnOutput(this, 'NewswiresIngestionLambdaArnOutput', {
+			value: ingestionLambda.functionArn,
+			description: 'ARN of the ingestion lambda function',
+			exportName: `NewswiresIngestionLambdaFunctionArn-${this.stage}`,
+		});
 	}
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Export ingestion lambda arn as a cloudformation output, to allow for SES integration in followup PR: https://github.com/guardian/editorial-wires/pull/180
- If the ingestion lambda is invoked with an SES message, just log the input and exit (actual handling logic to be added in a followup PR)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
