### PR TITLE
UI: improve next story button

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -119,10 +119,16 @@ export function App() {
 	};
 
 	useEffect(() => {
-		window.addEventListener('keyup', handleShortcutKeyUp);
+		window.addEventListener(
+			'keyup',
+			(event: KeyboardEvent) => void handleShortcutKeyUp(event),
+		);
 
 		return () => {
-			window.removeEventListener('keyup', handleShortcutKeyUp);
+			window.removeEventListener(
+				'keyup',
+				(event: KeyboardEvent) => void handleShortcutKeyUp(event),
+			);
 		};
 	}, [handleShortcutKeyUp]);
 

--- a/newswires/client/src/Item.stories.tsx
+++ b/newswires/client/src/Item.stories.tsx
@@ -69,7 +69,7 @@ export const LoadedItem: Story = {
 		error: undefined,
 		handleDeselectItem: () => console.log('deselect clicked'),
 		handlePreviousItem: () => console.log('previous item clicked'),
-		handleNextItem: () => console.log('next item clicked'),
+		handleNextItem: () => Promise.resolve(console.log('next item clicked')),
 	},
 };
 
@@ -79,7 +79,7 @@ export const WithError: Story = {
 		error: 'Failed to load item',
 		handleDeselectItem: () => console.log('deselect clicked'),
 		handlePreviousItem: () => console.log('previous item clicked'),
-		handleNextItem: () => console.log('next item clicked'),
+		handleNextItem: () => Promise.resolve(console.log('next item clicked')),
 	},
 };
 

--- a/newswires/client/src/Item.tsx
+++ b/newswires/client/src/Item.tsx
@@ -3,6 +3,7 @@ import {
 	EuiButtonIcon,
 	EuiFlexGroup,
 	EuiHorizontalRule,
+	EuiLoadingSpinner,
 	EuiSplitPanel,
 	EuiSwitch,
 	EuiText,
@@ -11,6 +12,7 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useEffect, useRef, useState } from 'react';
+import { useSearch } from './context/SearchContext.tsx';
 import { type WireData } from './sharedTypes';
 import { Tooltip } from './Tooltip.tsx';
 import { WireDetail } from './WireDetail';
@@ -26,10 +28,11 @@ export const Item = ({
 	itemData: WireData | undefined;
 	handleDeselectItem: () => void;
 	handlePreviousItem: () => void;
-	handleNextItem: () => void;
+	handleNextItem: () => Promise<void>;
 }) => {
 	const [isShowingJson, setIsShowingJson] = useState<boolean>(false);
 	const isSmallScreen = useIsWithinBreakpoints(['xs', 's']);
+	const { state } = useSearch();
 
 	const headingRef = useRef<HTMLHeadingElement>(null);
 
@@ -105,13 +108,19 @@ export const Item = ({
 									aria-label="Previous story"
 								/>
 							</Tooltip>
-							<Tooltip tooltipContent="Next story">
-								<EuiButtonIcon
-									iconType="arrowRight"
-									onClick={handleNextItem}
-									aria-label="Next story"
-								/>
-							</Tooltip>
+							{state.loadingMore ? (
+								<EuiLoadingSpinner size="m" />
+							) : (
+								<Tooltip tooltipContent="Next story">
+									<EuiButtonIcon
+										iconType="arrowRight"
+										onClick={() => {
+											void handleNextItem();
+										}}
+										aria-label="Next story"
+									/>
+								</Tooltip>
+							)}
 							<EuiFlexGroup justifyContent="flexEnd" alignItems="center">
 								<Tooltip tooltipContent="Close story" position="left">
 									<EuiButtonIcon

--- a/newswires/client/src/Item.tsx
+++ b/newswires/client/src/Item.tsx
@@ -36,6 +36,11 @@ export const Item = ({
 
 	const headingRef = useRef<HTMLHeadingElement>(null);
 
+	const isFirst = state.queryData?.results[0]?.id === itemData?.id;
+	const isLast =
+		state.queryData?.results[state.queryData.totalCount - 1]?.id ===
+		itemData?.id;
+
 	// scroll to heading when a new item is selected
 	useEffect(() => {
 		if (headingRef.current) {
@@ -106,6 +111,7 @@ export const Item = ({
 									iconType="arrowLeft"
 									onClick={handlePreviousItem}
 									aria-label="Previous story"
+									disabled={isFirst}
 								/>
 							</Tooltip>
 							{state.loadingMore ? (
@@ -118,6 +124,7 @@ export const Item = ({
 											void handleNextItem();
 										}}
 										aria-label="Next story"
+										disabled={isLast}
 									/>
 								</Tooltip>
 							)}

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -9,7 +9,7 @@ import {
 } from '@elastic/eui';
 import { css, keyframes } from '@emotion/react';
 import type { ReactNode } from 'react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import sanitizeHtml from 'sanitize-html';
 import { useSearch } from './context/SearchContext.tsx';
 import { useUserSettings } from './context/UserSettingsContext.tsx';
@@ -25,21 +25,14 @@ export const WireItemList = ({
 	wires: WireData[];
 	totalCount: number;
 }) => {
-	const { config, loadMoreResults, previousItemId } = useSearch();
-
-	const [isLoadingMore, setIsLoadingMore] = useState<boolean>(false);
+	const { config, loadMoreResults, previousItemId, state } = useSearch();
 
 	const selectedWireId = config.itemId;
 
 	const handleLoadMoreResults = () => {
 		if (wires.length > 0) {
-			setIsLoadingMore(true);
-
 			const beforeId = Math.min(...wires.map((wire) => wire.id)).toString();
-
-			void loadMoreResults(beforeId).finally(() => {
-				setIsLoadingMore(false);
-			});
+			void loadMoreResults(beforeId);
 		}
 	};
 
@@ -66,13 +59,13 @@ export const WireItemList = ({
 			</ul>
 			{wires.length < totalCount && (
 				<EuiButton
-					isLoading={isLoadingMore}
+					isLoading={state.loadingMore}
 					css={css`
 						margin-top: 12px;
 					`}
 					onClick={handleLoadMoreResults}
 				>
-					{isLoadingMore ? 'Loading' : 'Load more'}
+					{state.loadingMore ? 'Loading' : 'Load more'}
 				</EuiButton>
 			)}
 		</>

--- a/newswires/client/src/context/KeyboardShortcutsContext.tsx
+++ b/newswires/client/src/context/KeyboardShortcutsContext.tsx
@@ -28,7 +28,7 @@ const stopShortcutPropagation = (
 };
 
 type KeyboardShortcutsContextShape = {
-	handleShortcutKeyUp: (event: KeyboardEvent) => void;
+	handleShortcutKeyUp: (event: KeyboardEvent) => Promise<void>;
 	stopShortcutPropagation: KeyboardEventHandler<HTMLElement>;
 };
 
@@ -46,7 +46,7 @@ export function KeyboardShortcutsProvider({
 	const { view } = config;
 
 	const handleShortcutKeyUp = useCallback(
-		(event: KeyboardEvent): void => {
+		async (event: KeyboardEvent): Promise<void> => {
 			const key = event.key;
 
 			if (!isKeyWithShortcut(key)) {
@@ -75,8 +75,7 @@ export function KeyboardShortcutsProvider({
 						handlePreviousItem();
 						break;
 					case 'ArrowRight':
-						handleNextItem();
-						break;
+						return await handleNextItem();
 				}
 			}
 		},

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -408,7 +408,7 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 			.then((data) => {
 				dispatch({ type: 'APPEND_RESULTS', data });
 
-				if (selectNextItem) {
+				if (selectNextItem && data.results.length > 0) {
 					handleSelectItem(data.results[0].id.toString());
 				}
 			})

--- a/newswires/client/src/context/SearchReducer.test.ts
+++ b/newswires/client/src/context/SearchReducer.test.ts
@@ -19,6 +19,7 @@ describe('SearchReducer', () => {
 		status: 'loading',
 		successfulQueryHistory: [],
 		autoUpdate: true,
+		loadingMore: false,
 	};
 
 	const successState: State = {
@@ -39,6 +40,7 @@ describe('SearchReducer', () => {
 		successfulQueryHistory: [],
 		error: 'Network error',
 		autoUpdate: true,
+		loadingMore: false,
 	};
 
 	const errorState: State = {
@@ -50,6 +52,7 @@ describe('SearchReducer', () => {
 		successfulQueryHistory: [],
 		error: 'Fetch error',
 		autoUpdate: true,
+		loadingMore: false,
 	};
 
 	it('should handle FETCH_SUCCESS action in loading state', () => {

--- a/newswires/client/src/context/SearchReducer.ts
+++ b/newswires/client/src/context/SearchReducer.ts
@@ -150,6 +150,7 @@ export const SearchReducer = (state: State, action: Action): State => {
 					...action.data,
 					results: action.data.results,
 				}),
+				loadingMore: false,
 			};
 		case 'FETCH_ERROR':
 			switch (state.status) {
@@ -182,6 +183,11 @@ export const SearchReducer = (state: State, action: Action): State => {
 			return {
 				...state,
 				status: 'loading',
+			};
+		case 'LOADING_MORE':
+			return {
+				...state,
+				loadingMore: true,
 			};
 		default:
 			return state;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Load more stories when the 'Next Story' button is clicked on the last story in the list.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
