### PR TITLE
add index for uppercased supplier name

### DIFF
--- a/db/migrations/V16__uppercase_supplier_index.sql
+++ b/db/migrations/V16__uppercase_supplier_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX uppercase_supplier_index ON fingerpost_wire_entry
+  (upper(supplier));


### PR DESCRIPTION
We do lots of querying on supplier name, but in its uppercased form. The existing index doesn't index the uppercased form, so can't be used.
