### PR TITLE
increase size of prod db instance

### DIFF
--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -61,12 +61,18 @@ export class Newswires extends GuStack {
 
 		const databaseName = 'newswires';
 
+		const instanceSize =
+			this.stage === 'PROD' ? InstanceSize.MEDIUM : InstanceSize.SMALL;
+
+		// multiAz on if this is PROD
+		const multiAz = this.stage === 'PROD';
+
 		const database = new GuDatabase(this, 'NewswiresDB', {
 			app,
-			instanceType: InstanceType.of(InstanceClass.T4G, InstanceSize.SMALL),
+			instanceType: InstanceType.of(InstanceClass.T4G, instanceSize),
 			allowExternalConnection: true,
 			databaseName,
-			multiAz: false,
+			multiAz,
 			devxBackups: true,
 			vpcSubnets: {
 				subnets: privateSubnets,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We've reserved a multi az medium db instance for this year, and we're starting to move to full production traffic, so let's scale up to use our full reservation and get some extra cpu headroom!

## How to test

Has no effect outside of PROD.
