### PR TITLE
add an extra space at the end of paragraphs for the body text preview

### DIFF
--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -135,7 +135,7 @@ function MaybeSecondaryCardContent({
 		return <p>{subhead}</p>;
 	}
 	const maybeBodyTextPreview = bodyText
-		? sanitizeHtml(bodyText.replace(/<br \/>/g, '&nbsp;'), {
+		? sanitizeHtml(bodyText.replace(/(<br \/>|<\/p>)/g, '&nbsp;'), {
 				allowedTags: [],
 				allowedAttributes: {},
 			}).slice(0, 300)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Before:
<img width="566" alt="image" src="https://github.com/user-attachments/assets/2a6049d6-fd44-4640-b8b9-5f2dea915c6b" />

After:
<img width="540" alt="image" src="https://github.com/user-attachments/assets/343a30f2-6dfc-48ab-aa92-48d243a2d92e" />

