### PR TITLE
Start using zod v4

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -27,7 +27,7 @@ import {
 } from '@elastic/eui';
 import { css, Global } from '@emotion/react';
 import { useEffect, useState } from 'react';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { STAGE } from './app-configuration.ts';
 import { AppTitle } from './AppTitle.tsx';
 import { BetaBadge } from './BetaBadge.tsx';

--- a/newswires/client/src/ResizableContainer.tsx
+++ b/newswires/client/src/ResizableContainer.tsx
@@ -1,7 +1,7 @@
 import { EuiEmptyPrompt, EuiResizableContainer } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useRef, useState } from 'react';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import {
 	loadOrSetInLocalStorage,
 	saveToLocalStorage,

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -8,7 +8,7 @@ import {
 	useReducer,
 	useState,
 } from 'react';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { getErrorMessage } from '../../../../shared/getErrorMessage.ts';
 import type { Config, Query } from '../sharedTypes.ts';
 import {
@@ -320,6 +320,7 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 			view: 'feed',
 			query: currentConfig.query,
 			ticker: currentConfig.ticker,
+			itemId: undefined,
 		});
 
 		if (currentConfig.itemId) {

--- a/newswires/client/src/context/UserSettingsContext.tsx
+++ b/newswires/client/src/context/UserSettingsContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useState } from 'react';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { loadOrSetInLocalStorage, saveToLocalStorage } from './localStorage';
 import { useTelemetry } from './TelemetryContext';
 

--- a/newswires/client/src/context/localStorage.tsx
+++ b/newswires/client/src/context/localStorage.tsx
@@ -1,4 +1,4 @@
-import type { z } from 'zod';
+import type { z } from 'zod/v4';
 import { getErrorMessage } from '../../../../shared/getErrorMessage';
 
 function loadFromLocalStorage<T>(

--- a/newswires/client/src/send-to-composer.ts
+++ b/newswires/client/src/send-to-composer.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { pandaFetch } from './panda-session.ts';
 import type { WireData } from './sharedTypes.ts';
 

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 const FingerpostContentSchema = z
 	.object({
@@ -102,11 +102,11 @@ export const QuerySchema = z.object({
 	q: z.string(),
 	supplier: z.array(z.string()).optional(),
 	supplierExcl: z.array(z.string()).optional(),
-	keywords: z.ostring(),
-	keywordsExcl: z.ostring(),
+	keywords: z.string().optional(),
+	keywordsExcl: z.string().optional(),
 	categoryCode: z.array(z.string()).optional(),
 	categoryCodeExcl: z.array(z.string()).optional(),
-	preset: z.ostring(),
+	preset: z.string().optional(),
 	dateRange: DateRange.optional(),
 });
 

--- a/newswires/client/src/telemetry.ts
+++ b/newswires/client/src/telemetry.ts
@@ -1,7 +1,7 @@
 import type { IUserTelemetryEvent } from '@guardian/user-telemetry-client';
 import { UserTelemetryEventSender } from '@guardian/user-telemetry-client';
 import { v4 as uuidv4 } from 'uuid';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { loadOrSetInLocalStorage } from './context/localStorage';
 
 export type TelemetryEventSender = (

--- a/newswires/client/src/urlState.test.ts
+++ b/newswires/client/src/urlState.test.ts
@@ -259,6 +259,7 @@ describe('configToUrl', () => {
 				subject: [],
 			},
 			ticker: false,
+			itemId: undefined,
 		};
 		const url = configToUrl(config);
 		expect(url).toBe('/feed?q=abc&supplier=REUTERS');
@@ -273,6 +274,7 @@ describe('configToUrl', () => {
 				subject: [],
 			},
 			ticker: true,
+			itemId: undefined,
 		};
 		const url = configToUrl(config);
 		expect(url).toBe('/ticker/feed?q=abc&supplier=REUTERS');
@@ -285,6 +287,7 @@ describe('configToUrl', () => {
 			view: 'feed',
 			query: defaultQuery,
 			ticker: false,
+			itemId: undefined,
 		});
 		expect(url).toBe('/feed?start=now%2Fd');
 	});
@@ -367,6 +370,7 @@ describe('configToUrl', () => {
 			view: 'feed' as const,
 			query: { q: 'abc', supplierExcl: ['AP', 'PA', 'REUTERS'] },
 			ticker: false,
+			itemId: undefined,
 		};
 		const url = configToUrl(config);
 		expect(url).toBe(
@@ -379,6 +383,7 @@ describe('configToUrl', () => {
 			view: 'feed' as const,
 			query: { q: 'abc', keywords: 'Sports,Politics' },
 			ticker: false,
+			itemId: undefined,
 		};
 		const url = configToUrl(config);
 		expect(url).toBe('/feed?q=abc&keywords=Sports%2CPolitics');
@@ -389,6 +394,7 @@ describe('configToUrl', () => {
 			view: 'feed' as const,
 			query: { q: 'abc', keywordsExcl: 'Sports,Politics' },
 			ticker: false,
+			itemId: undefined,
 		};
 		const url = configToUrl(config);
 		expect(url).toBe('/feed?q=abc&keywordsExcl=Sports%2CPolitics');
@@ -399,6 +405,7 @@ describe('configToUrl', () => {
 			view: 'feed' as const,
 			query: { q: 'abc', categoryCode: ['medtop:08000000', 'medtop:20001340'] },
 			ticker: false,
+			itemId: undefined,
 		};
 		const url = configToUrl(config);
 		expect(url).toBe(
@@ -414,6 +421,7 @@ describe('configToUrl', () => {
 				categoryCodeExcl: ['medtop:08000000', 'medtop:20001340'],
 			},
 			ticker: false,
+			itemId: undefined,
 		};
 		const url = configToUrl(config);
 		expect(url).toBe(

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -74,7 +74,12 @@ export function urlToConfig(location: {
 	const pageSegments = page.split('/');
 
 	if (page === '' || page.includes('feed')) {
-		return { view: 'feed', query, ticker: page.includes('ticker') };
+		return {
+			view: 'feed',
+			query,
+			ticker: page.includes('ticker'),
+			itemId: undefined,
+		};
 	} else if (
 		page.includes('item/') &&
 		(pageSegments.length === 2 || pageSegments.length === 3)

--- a/poller-lambdas/src/pollers/reuters/auth.ts
+++ b/poller-lambdas/src/pollers/reuters/auth.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { getErrorMessage } from '../../../../shared/getErrorMessage';
 
 const AuthSchema = z.object({

--- a/poller-lambdas/src/pollers/reuters/reutersPoller.ts
+++ b/poller-lambdas/src/pollers/reuters/reutersPoller.ts
@@ -1,5 +1,5 @@
 import { parse } from 'node-html-parser';
-import { z } from 'zod';
+import { z } from 'zod/v4';
 import { POLLER_FAILURE_EVENT_TYPE } from '../../../../shared/constants';
 import { REUTERS_POLLING_FREQUENCY_IN_SECONDS } from '../../../../shared/pollers';
 import type { IngestorInputBody } from '../../../../shared/types';
@@ -292,7 +292,7 @@ export const reutersPoller = (async ({
 					externalId: itemId,
 					supplier: 'Reuters',
 					eventType: POLLER_FAILURE_EVENT_TYPE,
-					errors: parsedItemResult.error.errors,
+					errors: z.treeifyError(parsedItemResult.error),
 					message: `Failed to parse item response for ${itemId}; retrying`,
 				});
 				await new Promise((resolve) => setTimeout(resolve, 5000));
@@ -303,7 +303,7 @@ export const reutersPoller = (async ({
 						externalId: itemId,
 						supplier: 'Reuters',
 						eventType: POLLER_FAILURE_EVENT_TYPE,
-						errors: retryParsedItemResult.error.errors,
+						errors: z.treeifyError(retryParsedItemResult.error),
 						message: `Failed to parse item response for ${itemId} on retry`,
 					});
 					return;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Starts importing zod from `zod/v4` instead of `zod`. It doesn't require a package.json change, because v4 is exported from >=v3.25:

> To simplify the migration process both for users and Zod's ecosystem of associated libraries, Zod 4 will initially published alongside Zod 3 as part of the zod@3.25 release. Despite the version number, it is considered stable and ready for production use. ([zod docs](https://zod.dev/v4))

As we can see above, v4 is stable so it seems reasonable to upgrade. More specifically I found myself being about to add some new code which uses a now-deprecated zod v3 function, so thought it might be a good time to upgrade now to avoid starting using a function that we know we're going to have to replace.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Typechecks pass
- [x] I've tested a bunch of the functionality locally and nothing surprising happened

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
