### PR TITLE
Preserve unrecognised fields in ingestion, and add dataformatting fields to API

### DIFF
--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -26,6 +26,16 @@ object FingerpostWireSubjects {
     Format(reads, writes)
 }
 
+case class Dataformat(
+    noOfColumns: Option[String],
+    notFipTopusCategory: Option[String],
+    indesignTags: Option[String]
+)
+
+object Dataformat {
+  implicit val format: OFormat[Dataformat] = Json.format[Dataformat]
+}
+
 case class FingerpostWire(
     uri: Option[String],
     sourceFeed: Option[String],
@@ -42,13 +52,13 @@ case class FingerpostWire(
     priority: Option[String],
     subjects: Option[FingerpostWireSubjects],
     keywords: Option[List[String]],
-    language: Option[String],
     usage: Option[String],
-    location: Option[String],
     ednote: Option[String],
     mediaCatCodes: Option[String],
     `abstract`: Option[String],
-    bodyText: Option[String]
+    bodyText: Option[String],
+    composerCompatible: Option[Boolean],
+    dataformat: Option[Dataformat]
 )
 object FingerpostWire {
   // rename a couple of fields

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -1,7 +1,11 @@
 import { z } from 'zod/v4';
 
+/**
+ * looseObject because we want to preserve additional properties that are not defined in the schema
+ * Useful to be able to test new fields
+ */
 const FingerpostContentSchema = z
-	.object({
+	.looseObject({
 		uri: z.string(),
 		sourceFeed: z.string(),
 		usn: z.string(),

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { z } from 'zod/v4';
 
 const OptionalStringOrArrayAsArrayOfStrings = z
 	.union([z.string(), z.array(z.string())])
@@ -13,7 +13,11 @@ const OptionalStringOrArrayAsArrayOfStrings = z
 		return [val];
 	});
 
-const FingerpostFeedPayloadSchema = z.object({
+/**
+ * looseObject because we want to preserve additional properties that are not defined in the schema
+ * Useful to be able to test new fields
+ */
+const FingerpostFeedPayloadSchema = z.looseObject({
 	uri: z.string().optional(),
 	'source-feed': z.string().optional(),
 	usn: z.string().optional(),
@@ -61,10 +65,10 @@ const FingerpostFeedPayloadSchema = z.object({
 
 export const IngestorInputBodySchema = FingerpostFeedPayloadSchema.extend({
 	originalContentText: z.string().optional(),
-	imageIds:  z.array(z.string()).default([]),
+	imageIds: z.array(z.string()).default([]),
 });
 
-const WireEntryContentSchema = IngestorInputBodySchema.omit({
+const _WireEntryContentSchema = IngestorInputBodySchema.omit({
 	keywords: true,
 }).extend({
 	keywords: z.array(z.string()),
@@ -72,4 +76,4 @@ const WireEntryContentSchema = IngestorInputBodySchema.omit({
 
 export type FingerpostFeedPayload = z.infer<typeof FingerpostFeedPayloadSchema>;
 export type IngestorInputBody = z.infer<typeof IngestorInputBodySchema>;
-export type WireEntryContent = z.infer<typeof WireEntryContentSchema>;
+export type WireEntryContent = z.infer<typeof _WireEntryContentSchema>;


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Change the ingestion lambda and client-side types to be 'looseObjects', so that they will validate the fields they are expecting, but (if validation passes) just pass through any unrecognised fields.
- Update the API to send through the new `composerCompatible` and `dataformat` fields. **nb.** this required temporarily removing the 'language' and 'location' fields, because we hit the 22 field limit after which Play's serialisation magic breaks. These two fields aren't currently being used by the client, but I've created a ticket to find a better solution to the 22 field limit and to restore these fields when we've done so.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
