### PR TITLE
Remove start date from url if it matches the default start value

### DIFF
--- a/newswires/client/src/urlState.test.ts
+++ b/newswires/client/src/urlState.test.ts
@@ -289,7 +289,7 @@ describe('configToUrl', () => {
 			ticker: false,
 			itemId: undefined,
 		});
-		expect(url).toBe('/feed?start=now%2Fd');
+		expect(url).toBe('/feed');
 	});
 
 	it('converts item config to querystring', () => {
@@ -453,13 +453,13 @@ describe('paramsToQuerystring', () => {
 		const query = {
 			q: 'abc',
 			dateRange: {
-				start: 'now/d',
-				end: 'now/d',
+				start: 'now-3d',
+				end: 'now',
 			},
 		};
 
 		const url = paramsToQuerystring(query);
-		expect(url).toBe('?q=abc&start=now%2Fd');
+		expect(url).toBe('?q=abc&start=now-3d&end=now');
 	});
 
 	it('converts relative date range to an absolute date range', () => {

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -132,7 +132,11 @@ const processDateRange = (
 	} else {
 		return {
 			...config,
-			start: config.dateRange?.start,
+			start:
+				config.dateRange?.start &&
+				config.dateRange.start !== DEFAULT_DATE_RANGE.start
+					? config.dateRange.start
+					: undefined,
 			end:
 				config.dateRange?.end && config.dateRange.end !== DEFAULT_DATE_RANGE.end
 					? config.dateRange.end


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We already do this for the end date and other defaults.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
