### PR TITLE
Fix: don't use inline function definition in removeEventListener

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -119,16 +119,14 @@ export function App() {
 	};
 
 	useEffect(() => {
-		window.addEventListener(
-			'keyup',
-			(event: KeyboardEvent) => void handleShortcutKeyUp(event),
-		);
+		function shortcutKeyHandler(event: KeyboardEvent) {
+			void handleShortcutKeyUp(event);
+		}
+
+		window.addEventListener('keyup', shortcutKeyHandler);
 
 		return () => {
-			window.removeEventListener(
-				'keyup',
-				(event: KeyboardEvent) => void handleShortcutKeyUp(event),
-			);
+			window.removeEventListener('keyup', shortcutKeyHandler);
 		};
 	}, [handleShortcutKeyUp]);
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Fixes a bug introduced by refactoring the 'next' button in #363 -- the shortcut key handler was being defined inline, meaning that the `removeEventListener` call wasn't actually removing anything. So we ended up with proliferating event listeners doing the same thing and fighting with each other.

I don't think I'm _100%_ clear on the conditions under which the reference of the new function would change, but defining it inside the `useEffect` callback seems to do the trick afaict.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

| Before | After |
|-|-|
|<img width="210" alt="image" src="https://github.com/user-attachments/assets/c3f0dc78-9356-4208-978d-6ecb8977792e" />|<img width="243" alt="image" src="https://github.com/user-attachments/assets/92d5be4c-178f-43fa-bc85-9192285eba3d" />|



<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
