### PR TITLE
Try a fairly naive 'no sport' preset

### DIFF
--- a/newswires/app/conf/Categories.scala
+++ b/newswires/app/conf/Categories.scala
@@ -44,6 +44,15 @@ private[conf] object CategoryCodes {
     val REUTERS: List[String] = Categories.sportRelatedTopicCodes
   }
 
+  object SportsResults {
+    val PA: List[String] = Categories.sportsResultsCodes
+    val REUTERS: List[String] = List(
+      "M:LB", // Olympics results
+      "M:LJ" // Sports Results
+    )
+    val AP: List[String] = List("apCat:r") // Racing
+  }
+
   object Soccer {
     val REUTERS: List[String] = List("N2:SOCC")
     val PA: List[String] = List("paCat:SSO")
@@ -1531,5 +1540,79 @@ object Categories {
     "subj:15101000",
     "subj:15102000",
     "subj:15103000"
+  )
+
+  private[conf] val sportsResultsCodes = List(
+    // Football results
+    "paCat:RFC",
+    "paCat:RSA",
+    "paCat:RSF",
+    "paCat:RSH",
+    "paCat:RSP",
+    "paCat:RSD",
+    "paCat:RRB",
+    "paCat:SOD",
+    "paCat:SOS",
+    "paCat:RRD",
+    "paCat:SDA",
+    "paCat:SJA",
+    "paCat:SDB",
+    "paCat:SDC",
+    "paCat:SDD",
+    "paCat:SJB",
+    "paCat:STA",
+    "paCat:STB",
+    "paCat:STC",
+    "paCat:STD",
+    "paCat:SSP",
+    // Rugby results
+    "paCat:RRI",
+    "paCat:RRE",
+    "paCat:RRG",
+    "paCat:RRL",
+    "paCat:RRF",
+    "paCat:RRU",
+    "paCat:RDJ",
+    "paCat:SDF",
+    "paCat:SDT",
+    "paCat:STE",
+    "paCat:STF",
+    // Cricket results
+    "paCat:RCK",
+    "paCat:RCB",
+    "paCat:RDG",
+    "paCat:RDC",
+    "paCat:SRX",
+    "paCat:SRY",
+    // Racing results
+    "paCat:RRR",
+    "paCat:RDR",
+    "paCat:SRN",
+    "paCat:RRT",
+    "paCat:SRZ",
+    "paCat:STR",
+    "paCat:SDQ",
+    "paCat:SDP",
+    "paCat:SDR",
+    "paCat:SDS",
+    "paCat:SGN",
+    "paCat:SGR",
+    // General Sports
+    "paCat:RGA",
+    "paCat:RSR",
+    "paCat:SSF",
+    "paCat:RGD",
+    "paCat:RFD",
+    "paCat:RCD",
+    // Minor Results
+    "paCat:NMS",
+    "paCat:RMS",
+    // Fixtures
+    "paCat:SFF",
+    "paCat:SFU",
+    // Other
+    "paCat:SSD",
+    "paCat:SSG",
+    "paCat:SRD"
   )
 }

--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -71,6 +71,7 @@ object SearchPresets {
     case "all-uk"               => Some(AllUk)
     case "all-business"         => Some(AllBusiness)
     case "all-sport"            => Some(AllSport)
+    case "no-sport"             => Some(EverythingExceptSport)
     case "soccer"               => Some(Soccer)
     case "cricket"              => Some(Cricket)
     case "rugby-league"         => Some(RugbyLeague)
@@ -89,32 +90,6 @@ object SearchPresets {
   /*
    * World
    */
-
-  // format: off
-  /**
-   * Main config table for AP world ('NY:for') preset in Fip system.
-   * (nb. 'NY' here is a Fip header, and doesn't seem to stand for New York)
-
-   > ; Category Codes
-   >  2	JC=a*				>w4apapi#NY:for
-   >  2	JC=d*				>w4apapi#NY:fea
-   >  2	JC=e*				>w4apapi#NY:fea
-   >  2	JC=f*				>w4apapi#NY:fin
-   >  2	JC=i*				>w4apapi#NY:for
-   >  2	JC=s*				>w4apapi#NY:spt
-   >  2	JC=t*				>w4apapi#NY:fea
-   >  2	JC=w*				>w4apapi#NY:for
-   > ; Default
-   >  2	JC=*				>w4apapi#NY:for
-
-   * The fingerpost system runs top to bottom, and '>' tells it to stop once it finds a match, so an item with
-   * category code 'JC:ae' would be bucketed as 'NY:for' and not 'NY:fea', and an item with category code 'JC:ew'
-   * would be bucketed as 'NY:fea' rather than 'NY:for'.
-   * We're inclined to exclude sports, entertainment, finance, and technology news from this preset instead, even
-   * if they have e.g. code 'a' (US news) code, because they're likely to be less relevant to International desk.
-   * However, we should remain open to changing this in response to user feedback.
-   */
-  // format: on
   private val ApWorld = List(
     SearchPreset(
       AP,
@@ -208,6 +183,13 @@ object SearchPresets {
     SearchPreset(AFP, CategoryCodes.Sport.AFP),
     SearchPreset(AAP, categoryCodes = CategoryCodes.Sport.AAP),
     SearchPreset(AP, CategoryCodes.Sport.AP)
+  )
+  private val EverythingExceptSport = List(
+    SearchPreset(REUTERS, categoryCodesExcl = CategoryCodes.Sport.REUTERS ++ CategoryCodes.SportsResults.REUTERS),
+    SearchPreset(PA, categoryCodesExcl = CategoryCodes.Sport.PA ++ CategoryCodes.SportsResults.PA),
+    SearchPreset(AFP, categoryCodesExcl = CategoryCodes.Sport.AFP),
+    SearchPreset(AAP, categoryCodesExcl = CategoryCodes.Sport.AAP),
+    SearchPreset(AP, categoryCodesExcl = CategoryCodes.Sport.AP ++ CategoryCodes.SportsResults.AP)
   )
 
   private val Soccer = List(

--- a/newswires/client/src/presets.ts
+++ b/newswires/client/src/presets.ts
@@ -64,6 +64,7 @@ export const presets = [
 	{ id: 'all-uk', name: 'UK', filterOptions: [] },
 	{ id: 'all-business', name: 'Business', filterOptions: [] },
 	{ id: 'all-sport', name: 'Sport', filterOptions: sportPresets },
+	{ id: 'no-sport', name: 'No Sport', filterOptions: [] },
 ];
 
 export const presetFilterOptions = (presetId: string) => {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
