### PR TITLE
Disable CSRF checks for the composer id callback path

### DIFF
--- a/newswires/conf/routes
+++ b/newswires/conf/routes
@@ -12,6 +12,8 @@ GET     /ticker/item/*id            controllers.ViteController.item(id: String)
 GET     /api/search                 controllers.QueryController.query(q: Option[String], keywords: Option[String], supplier: List[String], categoryCode: List[String], categoryCodeExcl: List[String], start: Option[String], end: Option[String], beforeId: Option[Int], sinceId: Option[Int])
 GET     /api/keywords               controllers.QueryController.keywords(inLastHours: Option[Int], limit:Option[Int])
 GET     /api/item/:id               controllers.QueryController.item(id: Int, q: Option[String])
+
++nocsrf # justification: we are only processing very minimal information here -- composer ID and who the article was sent by. And CSRF protections have caused multiple issues for users. But if we ever start processing more information, or loosen CORS configuration, then we should look at adding CSRF protections back.
 PUT     /api/item/:id/composerId    controllers.QueryController.linkToComposer(id: Int)
 
 GET     /oauthCallback              controllers.AuthController.oauthCallback()


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We've had multiple reports of users receiving error messages because the CSRF token in their window has expired when they send an item to Composer, and the composer id callback fails.

This is a confusing user experience, and also means that we can't connect the wire entry with the Composer article.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

- Fewer user-facing errors
- We're able to connect wires to Composer articles, which is useful for editorial workflows

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

PUT requests to this endpoint do trigger a write to the database, but the state change is restricted by the endpoint logic to updating the composer id and the id of the user who sent the wire to Composer.

We've checked that CORS is enabled. And we've documented the reason for the exemption inline in the code, alongside a prompt to reconsider the exemption in the future if either of these conditions change.

We've also weighed up the potential solution of refreshing the CSRF token on the client, given that the app is a single-page application. We aren't aware of any straightforward options here, especially considering that we'd need to make sure the token refresh mechanism wasn't itself vulnerable to CSRF, or otherwise creating new security issues.

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
