### PR TITLE
Add 'copy headline and URL' button

### DIFF
--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -332,9 +332,17 @@ function CopyButton({
 				itemId: id.toString(),
 			});
 			const fullUrl = `${window.location.origin}${wireUrl}`;
-			const textToCopy = `${headlineText}\n${fullUrl}`;
 
-			await navigator.clipboard.writeText(textToCopy);
+			await navigator.clipboard.write([
+				new ClipboardItem({
+					'text/plain': new Blob([`${headlineText}\n${fullUrl}`], {
+						type: 'text/plain',
+					}),
+					'text/html': new Blob([`<a href="${fullUrl}">${headlineText}</a>`], {
+						type: 'text/html',
+					}),
+				}),
+			]);
 			setCopied(true);
 			setTimeout(() => setCopied(false), 2000);
 		} catch (err) {

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -18,7 +18,7 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import type { Moment } from 'moment';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import sanitizeHtml from 'sanitize-html';
 import { lookupCatCodesWideSearch } from './catcodes-lookup';
 import { ComposerConnection } from './ComposerConnection.tsx';
@@ -29,28 +29,53 @@ import type { SupplierInfo, WireData } from './sharedTypes';
 import { SupplierBadge } from './SupplierBadge.tsx';
 import { AP } from './suppliers.ts';
 import { Tooltip } from './Tooltip.tsx';
+import { configToUrl } from './urlState.ts';
 
 function TitleContentForItem({
+	id,
 	slug,
 	headline,
 	ingestedAt,
 	supplier,
 }: {
+	id: number;
 	slug?: string;
 	headline?: string;
 	ingestedAt: Moment;
 	supplier: SupplierInfo;
 }) {
+	const headlineText =
+		headline && headline.length > 0 ? headline : (slug ?? 'No title');
+
 	return (
-		<>
-			<EuiText size={'xs'}>
+		<div
+			css={css`
+				display: flex;
+				flex-direction: column-reverse;
+			`}
+		>
+			<div
+				css={css`
+					display: flex;
+					align-items: center;
+					gap: 0.5rem;
+				`}
+			>
+				<EuiTitle size="xs">
+					<h2>
+						<EuiText size={'xs'}></EuiText>
+						{headlineText}
+					</h2>
+				</EuiTitle>
+				<CopyButton id={id} headlineText={headlineText} />
+			</div>
+			<h3>
 				<SupplierBadge supplier={supplier} /> {slug && <>{slug} &#183; </>}
 				<Tooltip tooltipContent={ingestedAt.format()}>
 					{ingestedAt.fromNow()}
 				</Tooltip>
-			</EuiText>
-			{headline && headline.length > 0 ? headline : (slug ?? 'No title')}
-		</>
+			</h3>
+		</div>
 	);
 }
 
@@ -289,6 +314,49 @@ function MetaTable({ wire }: { wire: WireData }) {
 	);
 }
 
+function CopyButton({
+	id,
+	headlineText,
+}: {
+	id: number;
+	headlineText: string;
+}) {
+	const { config } = useSearch();
+	const [copied, setCopied] = useState(false);
+
+	const handleCopy = async () => {
+		try {
+			const wireUrl = configToUrl({
+				...config,
+				view: 'item',
+				itemId: id.toString(),
+			});
+			const fullUrl = `${window.location.origin}${wireUrl}`;
+			const textToCopy = `${headlineText}\n${fullUrl}`;
+
+			await navigator.clipboard.writeText(textToCopy);
+			setCopied(true);
+			setTimeout(() => setCopied(false), 2000);
+		} catch (err) {
+			console.error('Failed to copy to clipboard:', err);
+		}
+	};
+
+	return (
+		<Tooltip
+			tooltipContent={copied ? 'Copied!' : 'Copy headline and URL'}
+			position="left"
+		>
+			<EuiButtonIcon
+				aria-label="Copy headline and URL"
+				size="xs"
+				iconType={copied ? 'check' : 'link'}
+				onClick={() => void handleCopy()}
+			/>
+		</Tooltip>
+	);
+}
+
 export const WireDetail = ({
 	wire,
 	isShowingJson,
@@ -326,20 +394,20 @@ export const WireDetail = ({
 
 	return (
 		<>
-			<EuiFlexGroup justifyContent="spaceBetween">
-				<EuiFlexItem grow={true}>
-					<EuiTitle size="xs">
-						<h2>
-							<TitleContentForItem
-								headline={headline}
-								slug={slug}
-								ingestedAt={convertToLocalDate(wire.ingestedAt)}
-								supplier={wire.supplier}
-							/>
-						</h2>
-					</EuiTitle>
-				</EuiFlexItem>
-			</EuiFlexGroup>
+			<div
+				css={css`
+					display: flex;
+					align-items: end;
+				`}
+			>
+				<TitleContentForItem
+					id={wire.id}
+					headline={headline}
+					slug={slug}
+					ingestedAt={convertToLocalDate(wire.ingestedAt)}
+					supplier={wire.supplier}
+				/>
+			</div>
 			<EuiSpacer size="s" />
 			{isShowingJson ? (
 				<EuiCodeBlock language="json">

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -23,6 +23,7 @@ import sanitizeHtml from 'sanitize-html';
 import { lookupCatCodesWideSearch } from './catcodes-lookup';
 import { ComposerConnection } from './ComposerConnection.tsx';
 import { useSearch } from './context/SearchContext.tsx';
+import { useTelemetry } from './context/TelemetryContext.tsx';
 import { convertToLocalDate, convertToLocalDateString } from './dateHelpers.ts';
 import { Disclosure } from './Disclosure.tsx';
 import type { SupplierInfo, WireData } from './sharedTypes';
@@ -321,6 +322,7 @@ function CopyButton({
 	id: number;
 	headlineText: string;
 }) {
+	const { sendTelemetryEvent } = useTelemetry();
 	const { config } = useSearch();
 	const [copied, setCopied] = useState(false);
 
@@ -343,6 +345,10 @@ function CopyButton({
 					}),
 				}),
 			]);
+			sendTelemetryEvent('NEWSWIRES_COPY_ITEM_BUTTON', {
+				itemId: id,
+				status: 'success',
+			});
 			setCopied(true);
 			setTimeout(() => setCopied(false), 2000);
 		} catch (err) {

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -335,16 +335,24 @@ function CopyButton({
 			});
 			const fullUrl = `${window.location.origin}${wireUrl}`;
 
+			const htmlLink = document.createElement('a');
+			htmlLink.href = fullUrl;
+			htmlLink.innerText = headlineText;
+
+			const htmlLinkBlob = htmlLink.outerHTML;
+			htmlLink.remove();
+
 			await navigator.clipboard.write([
 				new ClipboardItem({
 					'text/plain': new Blob([`${headlineText}\n${fullUrl}`], {
 						type: 'text/plain',
 					}),
-					'text/html': new Blob([`<a href="${fullUrl}">${headlineText}</a>`], {
+					'text/html': new Blob([htmlLinkBlob], {
 						type: 'text/html',
 					}),
 				}),
 			]);
+
 			sendTelemetryEvent('NEWSWIRES_COPY_ITEM_BUTTON', {
 				itemId: id,
 				status: 'success',


### PR DESCRIPTION
Testing out the idea of having a button that will copy the headline and url for an item:

1. Restructure wire item detail header to be more semantic, and separate out the pieces that sit on different lines, so as to enable (2)
2. Add a copy button for the headline and url:
    - 'text/plain': `${headlineText}\n${fullUrl}`
    - 'text/html': `<a href="${fullUrl}">${headlineText}</a>`

<img width="421" height="98" alt="image" src="https://github.com/user-attachments/assets/bd587afc-9520-4240-9cbe-a6b914fdf8fe" />
