### PR TITLE
Lifetime for cloudfront logs more comparable to our other logs

### DIFF
--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -3438,7 +3438,7 @@ dpkg -i /newswires/newswires.deb",
         "LifecycleConfiguration": {
           "Rules": [
             {
-              "ExpirationInDays": 90,
+              "ExpirationInDays": 30,
               "Status": "Enabled",
             },
           ],

--- a/cdk/lib/__snapshots__/whole-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/whole-stack.test.ts.snap
@@ -3827,7 +3827,7 @@ dpkg -i /newswires/newswires.deb",
         "LifecycleConfiguration": {
           "Rules": [
             {
-              "ExpirationInDays": 90,
+              "ExpirationInDays": 30,
               "Status": "Enabled",
             },
           ],

--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -293,7 +293,7 @@ export class Newswires extends GuStack {
 				app: appName,
 				lifecycleRules: [
 					{
-						expiration: Duration.days(90),
+						expiration: Duration.days(30),
 					},
 				],
 				objectOwnership: ObjectOwnership.OBJECT_WRITER,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We don't keep application logs for all that long, so it seems reasonable to bring the cloudfront logs retention more into line too.

Also, the prompt for this particular change is that we need to make a non-trivial change to the Cloudformation template in order to trigger creation of the Cfn output added in #358 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
