### PR TITLE
Markup cleaner should remove empty p tags that don't have text node children

### DIFF
--- a/ingestion-lambda/src/cleanMarkup.test.ts
+++ b/ingestion-lambda/src/cleanMarkup.test.ts
@@ -73,7 +73,7 @@ describe('cleanBodyTextMarkup', () => {
 	});
 
 	it('should remove empty <p> tags', () => {
-		const input = '<p>  </p><div><p>   </p></div>';
+		const input = '<p>  </p><div><p>   </p></div><p></p>';
 		const expectedOutput = '<div></div>';
 		expect(cleanBodyTextMarkup(input)).toBe(expectedOutput);
 	});

--- a/ingestion-lambda/src/cleanMarkup.ts
+++ b/ingestion-lambda/src/cleanMarkup.ts
@@ -33,7 +33,13 @@ export function cleanBodyTextMarkup(
 
 function flattenBlocks(block: Node): Node[] {
 	if (block.childNodes.length === 0) {
-		if (block instanceof TextNode && block.textContent.trim().length === 0) {
+		const isEmptyTextNode =
+			block instanceof TextNode && block.textContent.trim().length === 0;
+		const isEmptyParagraph =
+			block instanceof HTMLElement &&
+			block.tagName === 'P' &&
+			block.innerHTML.trim().length === 0;
+		if (isEmptyParagraph || isEmptyTextNode) {
 			return [];
 		}
 		const newP = new HTMLElement('p', {});


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The markup cleaner got caught out on the following example:

```
<p><span class="tr-strong">A number of chemicals, plastics and items of machinery </span>have been added to the list of goods EU countries cannot export to Russia.</p><p></p><p>DELAYED APPROVAL</p>
```

Before (incorrect):
```
<p><span class=\"tr-strong\">A number of chemicals, plastics and items of machinery </span>have been added to the list of goods EU countries cannot export to Russia.</p><p><p></p></p><p>DELAYED APPROVAL</p>
```

After (correct):
```
<p><span class=\"tr-strong\">A number of chemicals, plastics and items of machinery </span>have been added to the list of goods EU countries cannot export to Russia.</p><p>DELAYED APPROVAL</p>
```

I've updated one of the existing test cases to test for this, and changed how we handle empty paragraph tags in the 'base case' of the recursive function.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
