### PR TITLE
Fix sinceId query: return 'next page', rather than 'most recent'

### DIFF
--- a/newswires/app/AppComponents.scala
+++ b/newswires/app/AppComponents.scala
@@ -1,8 +1,8 @@
+import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.auth.{
   AWSCredentialsProviderChain,
   DefaultAWSCredentialsProviderChain
 }
-import com.amazonaws.auth.profile.ProfileCredentialsProvider
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.gu.pandomainauth.PanDomainAuthSettingsRefresher

--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -4,7 +4,7 @@ import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import com.gu.pandomainauth.action.UserRequest
 import com.gu.permissions.PermissionsProvider
 import conf.{SearchPresets, SearchTerm}
-import db.{FingerpostWireEntry, SearchParams}
+import db.{FingerpostWireEntry, QueryParams, SearchParams}
 import play.api.libs.json.{Json, OFormat}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -48,7 +48,7 @@ class QueryController(
 
     val maybeSearchTerm = maybeFreeTextQuery.map(SearchTerm.English(_))
 
-    val queryParams = SearchParams(
+    val searchParams = SearchParams(
       text = maybeSearchTerm,
       start = maybeStart,
       end = maybeEnd,
@@ -64,15 +64,19 @@ class QueryController(
       hasDataFormatting = hasDataFormatting
     )
 
+    val queryParams = QueryParams(
+      searchParams = searchParams,
+      savedSearchParamList = maybePreset.getOrElse(Nil),
+      maybeSearchTerm = maybeSearchTerm,
+      maybeBeforeId = maybeBeforeId,
+      maybeSinceId = maybeSinceId,
+      pageSize = 30
+    )
+
     Ok(
       Json.toJson(
         FingerpostWireEntry.query(
-          searchParams = queryParams,
-          savedSearchParamList = maybePreset.getOrElse(Nil),
-          maybeSearchTerm = maybeSearchTerm,
-          maybeBeforeId = maybeBeforeId,
-          maybeSinceId = maybeSinceId,
-          pageSize = 30
+          queryParams
         )
       )
     )

--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -4,6 +4,7 @@ import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import com.gu.pandomainauth.action.UserRequest
 import com.gu.permissions.PermissionsProvider
 import conf.{SearchPresets, SearchTerm}
+import db.FingerpostWireEntry._
 import db.{FingerpostWireEntry, QueryParams, SearchParams}
 import play.api.libs.json.{Json, OFormat}
 import play.api.libs.ws.WSClient

--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -5,7 +5,7 @@ import com.gu.pandomainauth.action.UserRequest
 import com.gu.permissions.PermissionsProvider
 import conf.{SearchPresets, SearchTerm}
 import db.FingerpostWireEntry._
-import db.{FingerpostWireEntry, QueryParams, SearchParams}
+import db.{FingerpostWireEntry, NextPage, QueryParams, SearchParams}
 import play.api.libs.json.{Json, OFormat}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -70,7 +70,7 @@ class QueryController(
       savedSearchParamList = maybePreset.getOrElse(Nil),
       maybeSearchTerm = maybeSearchTerm,
       maybeBeforeId = maybeBeforeId,
-      maybeSinceId = maybeSinceId,
+      maybeSinceId = maybeSinceId.map(NextPage(_)),
       pageSize = 30
     )
 

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -389,10 +389,16 @@ object FingerpostWireEntry
       case None => sqls", '' AS ${syn.resultName.highlight}"
     }
 
+    val orderByClause = maybeSinceId match {
+      case Some(NextPage(_)) =>
+        sqls"ORDER BY ${FingerpostWireEntry.syn.ingestedAt} ASC"
+      case _ => sqls"ORDER BY ${FingerpostWireEntry.syn.ingestedAt} DESC"
+    }
+
     sqls"""| SELECT $selectAllStatement $highlightsClause
                       | FROM ${FingerpostWireEntry as syn}
                       | $whereClause
-                      | ORDER BY ${FingerpostWireEntry.syn.ingestedAt} DESC
+                      | $orderByClause
                       | LIMIT $effectivePageSize
                       | """.stripMargin
   }
@@ -404,7 +410,7 @@ object FingerpostWireEntry
       queryParams.searchParams,
       queryParams.savedSearchParamList,
       maybeBeforeId = queryParams.maybeBeforeId,
-      maybeSinceId = queryParams.maybeSinceId
+      maybeSinceId = queryParams.maybeSinceId.map(_.sinceId)
     )
 
     val query = sql"${buildSearchQuery(queryParams, whereClause)}"

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -386,23 +386,18 @@ object FingerpostWireEntry
   }
 
   def query(
-      searchParams: SearchParams,
-      savedSearchParamList: List[SearchParams],
-      maybeSearchTerm: Option[SearchTerm],
-      maybeBeforeId: Option[Int],
-      maybeSinceId: Option[Int],
-      pageSize: Int = 250
+      queryParams: QueryParams
   ): QueryResponse = DB readOnly { implicit session =>
-    val effectivePageSize = clamp(0, pageSize, 250)
+    val effectivePageSize = clamp(0, queryParams.pageSize, 250)
 
     val whereClause = buildWhereClause(
-      searchParams,
-      savedSearchParamList,
-      maybeBeforeId = maybeBeforeId,
-      maybeSinceId = maybeSinceId
+      queryParams.searchParams,
+      queryParams.savedSearchParamList,
+      maybeBeforeId = queryParams.maybeBeforeId,
+      maybeSinceId = queryParams.maybeSinceId
     )
 
-    val highlightsClause = maybeSearchTerm match {
+    val highlightsClause = queryParams.maybeSearchTerm match {
       case Some(SearchTerm.English(query)) =>
         sqls", ts_headline('english', ${syn.content}->>'body_text', websearch_to_tsquery('english', $query), 'StartSel=<mark>, StopSel=</mark>') AS ${syn.resultName.highlight}"
       case None => sqls", '' AS ${syn.resultName.highlight}"

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -392,15 +392,16 @@ object FingerpostWireEntry
     val orderByClause = maybeSinceId match {
       case Some(NextPage(_)) =>
         sqls"ORDER BY ${FingerpostWireEntry.syn.ingestedAt} ASC"
-      case _ => sqls"ORDER BY ${FingerpostWireEntry.syn.ingestedAt} DESC"
+      case _ =>
+        sqls"ORDER BY ${FingerpostWireEntry.syn.ingestedAt} DESC"
     }
 
     sqls"""| SELECT $selectAllStatement $highlightsClause
-                      | FROM ${FingerpostWireEntry as syn}
-                      | $whereClause
-                      | $orderByClause
-                      | LIMIT $effectivePageSize
-                      | """.stripMargin
+           | FROM ${FingerpostWireEntry as syn}
+           | $whereClause
+           | $orderByClause
+           | LIMIT $effectivePageSize
+           | """.stripMargin
   }
 
   def query(
@@ -439,7 +440,10 @@ object FingerpostWireEntry
 //      commonWhereClauses
 //    ) // TODO do this in parallel
 
-    QueryResponse(results, totalCount /*, keywordCounts*/ )
+    QueryResponse(
+      results.sortWith((a, b) => a.ingestedAt.isAfter(b.ingestedAt)),
+      totalCount /*, keywordCounts*/
+    )
   }
 
   def getKeywords(

--- a/newswires/app/db/QueryParams.scala
+++ b/newswires/app/db/QueryParams.scala
@@ -2,11 +2,18 @@ package db
 
 import conf.SearchTerm
 
+sealed trait UpdateType {
+  val sinceId: Int
+}
+
+case class NextPage(sinceId: Int) extends UpdateType
+case class MostRecent(sinceId: Int) extends UpdateType
+
 case class QueryParams(
     searchParams: SearchParams,
     savedSearchParamList: List[SearchParams],
     maybeSearchTerm: Option[SearchTerm],
     maybeBeforeId: Option[Int],
-    maybeSinceId: Option[Int],
+    maybeSinceId: Option[UpdateType],
     pageSize: Int = 250
 )

--- a/newswires/app/db/QueryParams.scala
+++ b/newswires/app/db/QueryParams.scala
@@ -1,0 +1,12 @@
+package db
+
+import conf.SearchTerm
+
+case class QueryParams(
+    searchParams: SearchParams,
+    savedSearchParamList: List[SearchParams],
+    maybeSearchTerm: Option[SearchTerm],
+    maybeBeforeId: Option[Int],
+    maybeSinceId: Option[Int],
+    pageSize: Int = 250
+)

--- a/newswires/app/db/QueryResponse.scala
+++ b/newswires/app/db/QueryResponse.scala
@@ -1,0 +1,13 @@
+package db
+
+import play.api.libs.json.{Json, OWrites}
+
+case class QueryResponse(
+    results: List[FingerpostWireEntry],
+    totalCount: Long = 10
+    //      keywordCounts: Map[String, Int]
+)
+
+object QueryResponse {
+  implicit val writes: OWrites[QueryResponse] = Json.writes[QueryResponse]
+}

--- a/newswires/test/db/FingerpostWireEntrySpec.scala
+++ b/newswires/test/db/FingerpostWireEntrySpec.scala
@@ -236,7 +236,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers {
       savedSearchParamList = Nil,
       maybeSearchTerm = None,
       maybeBeforeId = None,
-      maybeSinceId = Some(123)
+      maybeSinceId = None
     )
     val whereClause = sqls""
     val query = FingerpostWireEntry.buildSearchQuery(queryParams, whereClause)
@@ -244,4 +244,31 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers {
     query.value should include("ORDER BY fm.ingested_at DESC")
   }
 
+  it should "order results by descending ingestion_at when using MostRecent update type with maybeSinceId" in {
+    val queryParams = QueryParams(
+      searchParams = SearchParams(None),
+      savedSearchParamList = Nil,
+      maybeSearchTerm = None,
+      maybeBeforeId = None,
+      maybeSinceId = Some(MostRecent(123))
+    )
+    val whereClause = sqls""
+    val query = FingerpostWireEntry.buildSearchQuery(queryParams, whereClause)
+
+    query.value should include("ORDER BY fm.ingested_at DESC")
+  }
+
+  it should "order results by *ascending* ingestion_at when using NextPage update type with maybeSinceId" in {
+    val queryParams = QueryParams(
+      searchParams = SearchParams(None),
+      savedSearchParamList = Nil,
+      maybeSearchTerm = None,
+      maybeBeforeId = None,
+      maybeSinceId = Some(NextPage(123))
+    )
+    val whereClause = sqls""
+    val query = FingerpostWireEntry.buildSearchQuery(queryParams, whereClause)
+
+    query.value should include("ORDER BY fm.ingested_at ASC")
+  }
 }

--- a/newswires/test/db/FingerpostWireEntrySpec.scala
+++ b/newswires/test/db/FingerpostWireEntrySpec.scala
@@ -4,6 +4,7 @@ import conf.{SearchField, SearchTerm}
 import helpers.WhereClauseMatcher.matchWhereClause
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import scalikejdbc.scalikejdbcSQLInterpolationImplicitDef
 
 class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers {
 
@@ -226,4 +227,21 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers {
       )
     )
   }
+
+  behavior of "FingerpostWireEntry.generateWhereClause"
+
+  it should "order results by descending ingestion_at by default" in {
+    val queryParams = QueryParams(
+      searchParams = SearchParams(None),
+      savedSearchParamList = Nil,
+      maybeSearchTerm = None,
+      maybeBeforeId = None,
+      maybeSinceId = Some(123)
+    )
+    val whereClause = sqls""
+    val query = FingerpostWireEntry.buildSearchQuery(queryParams, whereClause)
+
+    query.value should include("ORDER BY fm.ingested_at DESC")
+  }
+
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The main change here is to distinguish between "next page" vs "most recent" searches in the `QueryParams` class, and to change the ordering of results in the SQL query depending on the search type.

### Paging bug

The feed in the Newswires UI is constructed as follows (when auto-refresh is on):

- On initial search, fetch the `n` most recent items matching the search terms `S`.
- Periodically make requests with the same terms `S`, but with an added parameter of `sinceId` that's set to the most recent id in the client's store.
- If there are new items, merge them with the existing feed results.

This fixes a bug in the existing code, whereby if you search using a `sinceId` parameter (as we do when fetching updates to the feed in the client app) you'll get the `n` most recent items. In the case where there have been more than `n` new items since the item with `sinceId`, the feed will contain a gap.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
