### PR TITLE
Add logging-only email filter lambda

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -60,6 +60,12 @@ jobs:
           npm run build
           zip -FSjr "dist/cleanup-lambda.zip" "dist/handler.js"
 
+      - name: Build email-filter-lambda
+        working-directory: email-filter-lambda
+        run: |
+          npm run build
+          zip -FSjr "dist/email-filter-lambda.zip" "dist/handler.js"
+
       - name: Build poller-lambdas
         working-directory: poller-lambdas
         run: |
@@ -85,6 +91,8 @@ jobs:
               - ingestion-lambda/dist/ingestion-lambda.zip
             cleanup-lambda:
               - cleanup-lambda/dist/cleanup-lambda.zip
+            email-filter-lambda:
+              - email-filter-lambda/dist/email-filter-lambda.zip
             poller-lambdas:
               - poller-lambdas/dist/poller-lambdas.zip
             newswires:

--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -63,30 +63,6 @@ exports[`The Newswires stack matches the snapshot 1`] = `
         ],
       },
     },
-    "NewswiresEmailFilterLambdaArnOutput": {
-      "Description": "ARN of the email filter lambda function",
-      "Export": {
-        "Name": "NewswiresEmailFilterLambdaFunctionArn-TEST",
-      },
-      "Value": {
-        "Fn::GetAtt": [
-          "EmailFilterLambdaTEST857F2A66",
-          "Arn",
-        ],
-      },
-    },
-    "NewswiresIngestionLambdaArnOutput": {
-      "Description": "ARN of the ingestion lambda function",
-      "Export": {
-        "Name": "NewswiresIngestionLambdaFunctionArn-TEST",
-      },
-      "Value": {
-        "Fn::GetAtt": [
-          "IngestionLambdaTESTC02B3E43",
-          "Arn",
-        ],
-      },
-    },
   },
   "Parameters": {
     "AMINewswires": {

--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -13,6 +13,8 @@ exports[`The Newswires stack matches the snapshot 1`] = `
       "GuS3Bucket",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
+      "GuLambdaFunction",
+      "GuStringParameter",
       "GuScheduledLambda",
       "GuParameter",
       "GuParameter",
@@ -58,6 +60,18 @@ exports[`The Newswires stack matches the snapshot 1`] = `
         "Fn::GetAtt": [
           "LoadBalancerNewswires3B8BBCB3",
           "DNSName",
+        ],
+      },
+    },
+    "NewswiresEmailFilterLambdaArnOutput": {
+      "Description": "ARN of the email filter lambda function",
+      "Export": {
+        "Name": "NewswiresEmailFilterLambdaFunctionArn-TEST",
+      },
+      "Value": {
+        "Fn::GetAtt": [
+          "EmailFilterLambdaTEST857F2A66",
+          "Arn",
         ],
       },
     },
@@ -108,6 +122,10 @@ exports[`The Newswires stack matches the snapshot 1`] = `
       "Default": "/account/vpc/primary/id",
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
+    },
+    "incomingcopyemailaddress": {
+      "Default": "/fingerpost/TEST/incomingCopyEmailAddress",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "newswiresPrivateSubnets": {
       "Default": "/account/vpc/primary/subnets/private",
@@ -392,6 +410,236 @@ exports[`The Newswires stack matches the snapshot 1`] = `
         "TTL": 60,
       },
       "Type": "Guardian::DNS::RecordSet",
+    },
+    "EmailFilterLambdaTEST857F2A66": {
+      "DependsOn": [
+        "EmailFilterLambdaTESTServiceRoleDefaultPolicyB576E11D",
+        "EmailFilterLambdaTESTServiceRole30894B90",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "editorial-feeds/TEST/email-filter-lambda/email-filter-lambda.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "email-filter-lambda",
+            "STACK": "editorial-feeds",
+            "STAGE": "TEST",
+          },
+        },
+        "Handler": "handler.main",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+        },
+        "MemorySize": 512,
+        "ReservedConcurrentExecutions": 2,
+        "Role": {
+          "Fn::GetAtt": [
+            "EmailFilterLambdaTESTServiceRole30894B90",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs22.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "email-filter-lambda",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "EmailFilterLambdaTESTAllowSes64B087DC": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "EmailFilterLambdaTEST857F2A66",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+        "SourceAccount": {
+          "Ref": "AWS::AccountId",
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "EmailFilterLambdaTESTServiceRole30894B90": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "email-filter-lambda",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "EmailFilterLambdaTESTServiceRoleDefaultPolicyB576E11D": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/editorial-feeds/TEST/email-filter-lambda/email-filter-lambda.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/editorial-feeds/email-filter-lambda",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:",
+                    {
+                      "Ref": "AWS::Region",
+                    },
+                    ":",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/editorial-feeds/email-filter-lambda/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "EmailFilterLambdaTESTServiceRoleDefaultPolicyB576E11D",
+        "Roles": [
+          {
+            "Ref": "EmailFilterLambdaTESTServiceRole30894B90",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "GetDistributablePolicyNewswires3D555C70": {
       "Properties": {
@@ -4490,6 +4738,38 @@ dpkg -i /newswires/newswires.deb",
       },
       "Type": "AWS::SecretsManager::Secret",
       "UpdateReplacePolicy": "Delete",
+    },
+    "sesrulesetincomingcopyemailrule9911D056": {
+      "DependsOn": [
+        "EmailFilterLambdaTESTAllowSes64B087DC",
+      ],
+      "Properties": {
+        "Rule": {
+          "Actions": [
+            {
+              "LambdaAction": {
+                "FunctionArn": {
+                  "Fn::GetAtt": [
+                    "EmailFilterLambdaTEST857F2A66",
+                    "Arn",
+                  ],
+                },
+                "InvocationType": "Event",
+              },
+            },
+          ],
+          "Enabled": true,
+          "Name": "newswires-incoming-copy-email-rule-TEST",
+          "Recipients": [
+            {
+              "Ref": "incomingcopyemailaddress",
+            },
+          ],
+          "ScanEnabled": true,
+        },
+        "RuleSetName": "default",
+      },
+      "Type": "AWS::SES::ReceiptRule",
     },
   },
 }

--- a/cdk/lib/__snapshots__/riffraff.test.ts.snap
+++ b/cdk/lib/__snapshots__/riffraff.test.ts.snap
@@ -31,6 +31,20 @@ deployments:
       fileName: ingestion-lambda.zip
     actions:
       - uploadLambda
+  lambda-upload-eu-west-1-editorial-feeds-email-filter-lambda:
+    type: aws-lambda
+    stacks:
+      - editorial-feeds
+    regions:
+      - eu-west-1
+    app: email-filter-lambda
+    contentDirectory: email-filter-lambda
+    parameters:
+      bucketSsmLookup: true
+      lookupByTags: true
+      fileName: email-filter-lambda.zip
+    actions:
+      - uploadLambda
   lambda-upload-eu-west-1-editorial-feeds-cleanup-lambda:
     type: aws-lambda
     stacks:
@@ -106,6 +120,7 @@ deployments:
           Encrypted: 'true'
     dependencies:
       - lambda-upload-eu-west-1-editorial-feeds-ingestion-lambda
+      - lambda-upload-eu-west-1-editorial-feeds-email-filter-lambda
       - lambda-upload-eu-west-1-editorial-feeds-cleanup-lambda
       - lambda-upload-eu-west-1-editorial-feeds-reuters_poller_lambda
       - lambda-upload-eu-west-1-editorial-feeds-apPoller_poller_lambda
@@ -124,6 +139,22 @@ deployments:
       bucketSsmLookup: true
       lookupByTags: true
       fileName: ingestion-lambda.zip
+    actions:
+      - updateLambda
+    dependencies:
+      - cfn-eu-west-1-editorial-feeds-newswires
+  lambda-update-eu-west-1-editorial-feeds-email-filter-lambda:
+    type: aws-lambda
+    stacks:
+      - editorial-feeds
+    regions:
+      - eu-west-1
+    app: email-filter-lambda
+    contentDirectory: email-filter-lambda
+    parameters:
+      bucketSsmLookup: true
+      lookupByTags: true
+      fileName: email-filter-lambda.zip
     actions:
       - updateLambda
     dependencies:

--- a/cdk/lib/__snapshots__/whole-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/whole-stack.test.ts.snap
@@ -540,30 +540,6 @@ exports[`createStacks should create WiresFeeds and Newswires stacks with correct
         ],
       },
     },
-    "NewswiresEmailFilterLambdaArnOutput": {
-      "Description": "ARN of the email filter lambda function",
-      "Export": {
-        "Name": "NewswiresEmailFilterLambdaFunctionArn-TEST",
-      },
-      "Value": {
-        "Fn::GetAtt": [
-          "EmailFilterLambdaTEST857F2A66",
-          "Arn",
-        ],
-      },
-    },
-    "NewswiresIngestionLambdaArnOutput": {
-      "Description": "ARN of the ingestion lambda function",
-      "Export": {
-        "Name": "NewswiresIngestionLambdaFunctionArn-TEST",
-      },
-      "Value": {
-        "Fn::GetAtt": [
-          "IngestionLambdaTESTC02B3E43",
-          "Arn",
-        ],
-      },
-    },
   },
   "Parameters": {
     "AMINewswires": {

--- a/cdk/lib/__snapshots__/whole-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/whole-stack.test.ts.snap
@@ -490,6 +490,8 @@ exports[`createStacks should create WiresFeeds and Newswires stacks with correct
       "GuS3Bucket",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
+      "GuLambdaFunction",
+      "GuStringParameter",
       "GuScheduledLambda",
       "GuParameter",
       "GuParameter",
@@ -535,6 +537,18 @@ exports[`createStacks should create WiresFeeds and Newswires stacks with correct
         "Fn::GetAtt": [
           "LoadBalancerNewswires3B8BBCB3",
           "DNSName",
+        ],
+      },
+    },
+    "NewswiresEmailFilterLambdaArnOutput": {
+      "Description": "ARN of the email filter lambda function",
+      "Export": {
+        "Name": "NewswiresEmailFilterLambdaFunctionArn-TEST",
+      },
+      "Value": {
+        "Fn::GetAtt": [
+          "EmailFilterLambdaTEST857F2A66",
+          "Arn",
         ],
       },
     },
@@ -585,6 +599,10 @@ exports[`createStacks should create WiresFeeds and Newswires stacks with correct
       "Default": "/account/vpc/primary/id",
       "Description": "Virtual Private Cloud to run EC2 instances within. Should NOT be the account default VPC.",
       "Type": "AWS::SSM::Parameter::Value<AWS::EC2::VPC::Id>",
+    },
+    "incomingcopyemailaddress": {
+      "Default": "/fingerpost/TEST/incomingCopyEmailAddress",
+      "Type": "AWS::SSM::Parameter::Value<String>",
     },
     "newswiresPrivateSubnets": {
       "Default": "/account/vpc/primary/subnets/private",
@@ -869,6 +887,228 @@ exports[`createStacks should create WiresFeeds and Newswires stacks with correct
         "TTL": 60,
       },
       "Type": "Guardian::DNS::RecordSet",
+    },
+    "EmailFilterLambdaTEST857F2A66": {
+      "DependsOn": [
+        "EmailFilterLambdaTESTServiceRoleDefaultPolicyB576E11D",
+        "EmailFilterLambdaTESTServiceRole30894B90",
+      ],
+      "Properties": {
+        "Architectures": [
+          "arm64",
+        ],
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DistributionBucketName",
+          },
+          "S3Key": "editorial-feeds/TEST/email-filter-lambda/email-filter-lambda.zip",
+        },
+        "Environment": {
+          "Variables": {
+            "APP": "email-filter-lambda",
+            "STACK": "editorial-feeds",
+            "STAGE": "TEST",
+          },
+        },
+        "Handler": "handler.main",
+        "LoggingConfig": {
+          "LogFormat": "Text",
+        },
+        "MemorySize": 512,
+        "ReservedConcurrentExecutions": 2,
+        "Role": {
+          "Fn::GetAtt": [
+            "EmailFilterLambdaTESTServiceRole30894B90",
+            "Arn",
+          ],
+        },
+        "Runtime": "nodejs22.x",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "email-filter-lambda",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "Timeout": 30,
+      },
+      "Type": "AWS::Lambda::Function",
+    },
+    "EmailFilterLambdaTESTAllowSes64B087DC": {
+      "Properties": {
+        "Action": "lambda:InvokeFunction",
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "EmailFilterLambdaTEST857F2A66",
+            "Arn",
+          ],
+        },
+        "Principal": "ses.amazonaws.com",
+        "SourceAccount": {
+          "Ref": "AWS::AccountId",
+        },
+      },
+      "Type": "AWS::Lambda::Permission",
+    },
+    "EmailFilterLambdaTESTServiceRole30894B90": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": "sts:AssumeRole",
+              "Effect": "Allow",
+              "Principal": {
+                "Service": "lambda.amazonaws.com",
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "ManagedPolicyArns": [
+          {
+            "Fn::Join": [
+              "",
+              [
+                "arn:",
+                {
+                  "Ref": "AWS::Partition",
+                },
+                ":iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+              ],
+            ],
+          },
+        ],
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "email-filter-lambda",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Role",
+    },
+    "EmailFilterLambdaTESTServiceRoleDefaultPolicyB576E11D": {
+      "Properties": {
+        "PolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "s3:GetObject*",
+                "s3:GetBucket*",
+                "s3:List*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                    ],
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      "arn:",
+                      {
+                        "Ref": "AWS::Partition",
+                      },
+                      ":s3:::",
+                      {
+                        "Ref": "DistributionBucketName",
+                      },
+                      "/editorial-feeds/TEST/email-filter-lambda/email-filter-lambda.zip",
+                    ],
+                  ],
+                },
+              ],
+            },
+            {
+              "Action": "ssm:GetParametersByPath",
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/editorial-feeds/email-filter-lambda",
+                  ],
+                ],
+              },
+            },
+            {
+              "Action": [
+                "ssm:GetParameters",
+                "ssm:GetParameter",
+              ],
+              "Effect": "Allow",
+              "Resource": {
+                "Fn::Join": [
+                  "",
+                  [
+                    "arn:aws:ssm:eu-west-1:",
+                    {
+                      "Ref": "AWS::AccountId",
+                    },
+                    ":parameter/TEST/editorial-feeds/email-filter-lambda/*",
+                  ],
+                ],
+              },
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+        "PolicyName": "EmailFilterLambdaTESTServiceRoleDefaultPolicyB576E11D",
+        "Roles": [
+          {
+            "Ref": "EmailFilterLambdaTESTServiceRole30894B90",
+          },
+        ],
+      },
+      "Type": "AWS::IAM::Policy",
     },
     "GetDistributablePolicyNewswires3D555C70": {
       "Properties": {
@@ -4839,6 +5079,38 @@ dpkg -i /newswires/newswires.deb",
       },
       "Type": "AWS::SecretsManager::Secret",
       "UpdateReplacePolicy": "Delete",
+    },
+    "sesrulesetincomingcopyemailrule9911D056": {
+      "DependsOn": [
+        "EmailFilterLambdaTESTAllowSes64B087DC",
+      ],
+      "Properties": {
+        "Rule": {
+          "Actions": [
+            {
+              "LambdaAction": {
+                "FunctionArn": {
+                  "Fn::GetAtt": [
+                    "EmailFilterLambdaTEST857F2A66",
+                    "Arn",
+                  ],
+                },
+                "InvocationType": "Event",
+              },
+            },
+          ],
+          "Enabled": true,
+          "Name": "newswires-incoming-copy-email-rule-TEST",
+          "Recipients": [
+            {
+              "Ref": "incomingcopyemailaddress",
+            },
+          ],
+          "ScanEnabled": true,
+        },
+        "RuleSetName": "default",
+      },
+      "Type": "AWS::SES::ReceiptRule",
     },
   },
 }

--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -14,7 +14,7 @@ import { GuGetS3ObjectsPolicy } from '@guardian/cdk/lib/constructs/iam';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
 import type { App } from 'aws-cdk-lib';
-import { aws_logs, CfnOutput, Duration } from 'aws-cdk-lib';
+import { aws_logs, Duration } from 'aws-cdk-lib';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
 import {
 	AllowedMethods,
@@ -403,17 +403,5 @@ export class Newswires extends GuStack {
 		newswiresApp.autoScalingGroup.connections.addSecurityGroup(
 			database.accessSecurityGroup,
 		);
-
-		new CfnOutput(this, 'NewswiresIngestionLambdaArnOutput', {
-			value: ingestionLambda.functionArn,
-			description: 'ARN of the ingestion lambda function',
-			exportName: `NewswiresIngestionLambdaFunctionArn-${this.stage}`,
-		});
-
-		new CfnOutput(this, 'NewswiresEmailFilterLambdaArnOutput', {
-			value: emailFilterLambda.functionArn,
-			description: 'ARN of the email filter lambda function',
-			exportName: `NewswiresEmailFilterLambdaFunctionArn-${this.stage}`,
-		});
 	}
 }

--- a/email-filter-lambda/package.json
+++ b/email-filter-lambda/package.json
@@ -5,7 +5,7 @@
 	"scripts": {
 		"typecheck": "tsc -noEmit",
 		"build": "esbuild src/handler.ts --bundle --minify --outfile=dist/handler.js --external:@aws-sdk --external:aws-sdk --platform=node",
-		"test": "jest --detectOpenHandles --config ../jest.config.js --selectProjects ingestion-lambda",
+		"test": "jest --detectOpenHandles --config ../jest.config.js --selectProjects email-filter-lambda",
 		"lint": "eslint src/** --no-error-on-unmatched-pattern --fix",
 		"lint:ci": "eslint src/** --no-error-on-unmatched-pattern"
 	},

--- a/email-filter-lambda/package.json
+++ b/email-filter-lambda/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "email-filter-lambda",
+	"version": "1.0.0",
+	"description": "",
+	"scripts": {
+		"typecheck": "tsc -noEmit",
+		"build": "esbuild src/handler.ts --bundle --minify --outfile=dist/handler.js --external:@aws-sdk --external:aws-sdk --platform=node",
+		"test": "jest --detectOpenHandles --config ../jest.config.js --selectProjects ingestion-lambda",
+		"lint": "eslint src/** --no-error-on-unmatched-pattern --fix",
+		"lint:ci": "eslint src/** --no-error-on-unmatched-pattern"
+	},
+	"dependencies": {},
+	"devDependencies": {
+		"@types/aws-lambda": "8.10.150"
+	}
+}

--- a/email-filter-lambda/src/findVerificationFailures.test.ts
+++ b/email-filter-lambda/src/findVerificationFailures.test.ts
@@ -1,0 +1,35 @@
+import type { SESReceipt } from 'aws-lambda';
+import { findVerificationFailures } from './findVerificationFailures';
+
+describe('findVerificationFailures', () => {
+	it('should return hasFailures false and empty failedChecks for all PASS verdicts', () => {
+		const receipt = {
+			spamVerdict: { status: 'PASS' },
+			virusVerdict: { status: 'PASS' },
+			spfVerdict: { status: 'PASS' },
+			dkimVerdict: { status: 'PASS' },
+			dmarcVerdict: { status: 'PASS' },
+		} as unknown as SESReceipt;
+		const result = findVerificationFailures(receipt);
+		expect(result.hasFailures).toBe(false);
+		expect(result.failedChecks).toEqual([]);
+	});
+
+	it('should return hasFailures true and failedChecks for ALL failing verdicts', () => {
+		const receipt = {
+			spamVerdict: { status: 'FAIL' },
+			virusVerdict: { status: 'PASS' },
+			spfVerdict: { status: 'FAIL' },
+			dkimVerdict: { status: 'PASS' },
+			dmarcVerdict: { status: 'FAIL' },
+		} as unknown as SESReceipt;
+
+		const result = findVerificationFailures(receipt);
+		expect(result.hasFailures).toBe(true);
+		expect(result.failedChecks).toEqual([
+			{ name: 'spamVerdict', status: 'FAIL' },
+			{ name: 'spfVerdict', status: 'FAIL' },
+			{ name: 'dmarcVerdict', status: 'FAIL' },
+		]);
+	});
+});

--- a/email-filter-lambda/src/findVerificationFailures.ts
+++ b/email-filter-lambda/src/findVerificationFailures.ts
@@ -1,0 +1,18 @@
+import type { SESReceipt } from 'aws-lambda';
+
+export function findVerificationFailures(receipt: SESReceipt) {
+	const verdictChecks = [
+		{ name: 'spamVerdict', status: receipt.spamVerdict.status },
+		{ name: 'virusVerdict', status: receipt.virusVerdict.status },
+		{ name: 'spfVerdict', status: receipt.spfVerdict.status },
+		{ name: 'dkimVerdict', status: receipt.dkimVerdict.status },
+		{ name: 'dmarcVerdict', status: receipt.dmarcVerdict.status },
+	];
+
+	const failedChecks = verdictChecks.filter(({ status }) => status !== 'PASS');
+
+	return {
+		hasFailures: failedChecks.length !== 0,
+		failedChecks,
+	};
+}

--- a/email-filter-lambda/src/handler.ts
+++ b/email-filter-lambda/src/handler.ts
@@ -1,0 +1,41 @@
+import type { SESEvent, SESHandler, SESReceipt } from 'aws-lambda';
+import { createLogger } from '../../shared/lambda-logging';
+
+const logger = createLogger({});
+
+export const main: SESHandler = (event: SESEvent) => {
+	for (const record of event.Records) {
+		const receipt = record.ses.receipt;
+
+		const { hasFailures, failedChecks } = findVerificationFailures(receipt);
+
+		if (hasFailures) {
+			logger.error({
+				message: 'Email verification failed',
+				failedChecks: failedChecks.map(
+					(check) => `${check.name}: ${check.status}`,
+				),
+			});
+			continue;
+		}
+
+		console.log('Email verification passed');
+	}
+};
+
+function findVerificationFailures(receipt: SESReceipt) {
+	const verdictChecks = [
+		{ name: 'spamVerdict', status: receipt.spamVerdict.status },
+		{ name: 'virusVerdict', status: receipt.virusVerdict.status },
+		{ name: 'spfVerdict', status: receipt.spfVerdict.status },
+		{ name: 'dkimVerdict', status: receipt.dkimVerdict.status },
+		{ name: 'dmarcVerdict', status: receipt.dmarcVerdict.status },
+	];
+
+	const failedChecks = verdictChecks.filter(({ status }) => status !== 'PASS');
+
+	return {
+		hasFailures: failedChecks.length !== 0,
+		failedChecks,
+	};
+}

--- a/email-filter-lambda/src/handler.ts
+++ b/email-filter-lambda/src/handler.ts
@@ -1,5 +1,6 @@
-import type { SESEvent, SESHandler, SESReceipt } from 'aws-lambda';
+import type { SESEvent, SESHandler } from 'aws-lambda';
 import { createLogger } from '../../shared/lambda-logging';
+import { findVerificationFailures } from './findVerificationFailures';
 
 const logger = createLogger({});
 
@@ -22,20 +23,3 @@ export const main: SESHandler = (event: SESEvent) => {
 		console.log('Email verification passed');
 	}
 };
-
-function findVerificationFailures(receipt: SESReceipt) {
-	const verdictChecks = [
-		{ name: 'spamVerdict', status: receipt.spamVerdict.status },
-		{ name: 'virusVerdict', status: receipt.virusVerdict.status },
-		{ name: 'spfVerdict', status: receipt.spfVerdict.status },
-		{ name: 'dkimVerdict', status: receipt.dkimVerdict.status },
-		{ name: 'dmarcVerdict', status: receipt.dmarcVerdict.status },
-	];
-
-	const failedChecks = verdictChecks.filter(({ status }) => status !== 'PASS');
-
-	return {
-		hasFailures: failedChecks.length !== 0,
-		failedChecks,
-	};
-}

--- a/email-filter-lambda/tsconfig.json
+++ b/email-filter-lambda/tsconfig.json
@@ -1,0 +1,3 @@
+{
+	"extends": "../tsconfig.json"
+}

--- a/jest.config.js
+++ b/jest.config.js
@@ -17,7 +17,11 @@ const generateProject = (name) => {
 module.exports = {
 	verbose: true,
 	testEnvironment: 'node',
-	projects: ['cdk', 'ingestion-lambda', 'poller-lambdas', 'shared'].map(
-		generateProject,
-	),
+	projects: [
+		'cdk',
+		'ingestion-lambda',
+		'poller-lambdas',
+		'shared',
+		'email-filter-lambda',
+	].map(generateProject),
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
 				"ingestion-lambda",
 				"cleanup-lambda",
 				"poller-lambdas",
-				"newswires/client"
+				"newswires/client",
+				"email-filter-lambda"
 			],
 			"dependencies": {
 				"node-html-parser": "7.0.1",
@@ -56,6 +57,19 @@
 			"devDependencies": {
 				"@types/aws-lambda": "8.10.152"
 			}
+		},
+		"email-filter-lambda": {
+			"version": "1.0.0",
+			"devDependencies": {
+				"@types/aws-lambda": "8.10.150"
+			}
+		},
+		"email-filter-lambda/node_modules/@types/aws-lambda": {
+			"version": "8.10.150",
+			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.150.tgz",
+			"integrity": "sha512-AX+AbjH/rH5ezX1fbK8onC/a+HyQHo7QGmvoxAE42n22OsciAxvZoZNEr22tbXs8WfP1nIsBjKDpgPm3HjOZbA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"ingestion-lambda": {
 			"version": "1.0.0",
@@ -8846,6 +8860,10 @@
 			"integrity": "sha512-QPWqHL0BglzPYyJJ1zSSmwFFL6MFXhbACOCcsCdUMCkzPdS9/OIBVxg516X/Ado2qwAq8k0nJJ7phQPCqiaFAw==",
 			"dev": true,
 			"license": "ISC"
+		},
+		"node_modules/email-filter-lambda": {
+			"resolved": "email-filter-lambda",
+			"link": true
 		},
 		"node_modules/emittery": {
 			"version": "0.13.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
 		"ingestion-lambda",
 		"cleanup-lambda",
 		"poller-lambdas",
-		"newswires/client"
+		"newswires/client",
+		"email-filter-lambda"
 	],
 	"scripts": {
 		"test": "npm run test --workspaces --if-present",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add new SES receipt rule that invokes a lambda. The lambda itself just checks some of the metadata from AWS's scan of the email, and logs the result. Once we've checked that it operates as expected in PROD, we can get it to reject messages which fail these checks (see this [example of spam filtering from the docs](https://docs.aws.amazon.com/ses/latest/dg/receiving-email-action-lambda-example-functions.html)).

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Deploy to CODE
- [x] Send an email, check that the logging shows up
- [x] Check that the message still gets through to the existing receipt rule (i.e. the one that sends the email for consumption via the Fingerpost app).

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
