### PR TITLE
Implement a different json library

### DIFF
--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -1,7 +1,7 @@
 package conf
 
 import conf.Suppliers._
-import db.SearchParams
+import models.SearchParams
 
 // Increase max line length to improve readability of search presets
 // scalafmt: { maxColumn = 120 }

--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -5,6 +5,7 @@ import com.gu.pandomainauth.action.UserRequest
 import com.gu.permissions.PermissionsProvider
 import conf.{SearchPresets, SearchTerm}
 import db.{FingerpostWireEntry, SearchParams}
+import io.circe.syntax.EncoderOps
 import play.api.libs.json.{Json, OFormat}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -65,16 +66,14 @@ class QueryController(
     )
 
     Ok(
-      Json.toJson(
-        FingerpostWireEntry.query(
-          searchParams = queryParams,
-          savedSearchParamList = maybePreset.getOrElse(Nil),
-          maybeSearchTerm = maybeSearchTerm,
-          maybeBeforeId = maybeBeforeId,
-          maybeSinceId = maybeSinceId,
-          pageSize = 30
-        )
-      )
+      FingerpostWireEntry.query(
+        searchParams = queryParams,
+        savedSearchParamList = maybePreset.getOrElse(Nil),
+        maybeSearchTerm = maybeSearchTerm,
+        maybeBeforeId = maybeBeforeId,
+        maybeSinceId = maybeSinceId,
+        pageSize = 30
+      ).asJson.spaces2
     )
   }
 

--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -82,7 +82,7 @@ class QueryController(
       maybeLimit: Option[Int]
   ): Action[AnyContent] = apiAuthAction {
     val results = FingerpostWireEntry.getKeywords(maybeInLastHours, maybeLimit)
-    Ok(Json.toJson(results))
+    Ok(results.asJson.spaces2)
   }
 
   def item(id: Int, maybeFreeTextQuery: Option[String]): Action[AnyContent] =

--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -6,7 +6,8 @@ import com.gu.permissions.PermissionsProvider
 import conf.{SearchPresets, SearchTerm}
 import io.circe.syntax.EncoderOps
 import db.FingerpostWireEntry._
-import db.{FingerpostWireEntry, NextPage, QueryParams, SearchParams}
+import db.FingerpostWireEntry
+import models.{NextPage, QueryParams, SearchParams}
 import play.api.libs.json.{Json, OFormat}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -76,9 +77,12 @@ class QueryController(
     )
 
     Ok(
-        FingerpostWireEntry.query(
+      FingerpostWireEntry
+        .query(
           queryParams
-        ).asJson.spaces2
+        )
+        .asJson
+        .spaces2
     )
   }
 

--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -88,7 +88,7 @@ class QueryController(
   def item(id: Int, maybeFreeTextQuery: Option[String]): Action[AnyContent] =
     apiAuthAction {
       FingerpostWireEntry.get(id, maybeFreeTextQuery) match {
-        case Some(entry) => Ok(Json.toJson(entry))
+        case Some(entry) => Ok(entry.asJson.spaces2)
         case None        => NotFound
       }
     }

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -1,15 +1,14 @@
 package db
 
-import conf.{SearchConfig, SearchField, SearchTerm}
+import conf.{SearchField, SearchTerm}
 import db.CustomMappers.textArray
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
-import models.{FingerpostWire, FingerpostWireSubjects}
+import models.FingerpostWire
 import play.api.Logging
-import play.api.libs.json._
 import scalikejdbc._
-
-import java.time.{Instant, ZonedDateTime}
+import io.circe.parser._
+import java.time.Instant
 
 case class FingerpostWireEntry(
     id: Long,
@@ -62,7 +61,7 @@ object FingerpostWireEntry
   def apply(
       fm: ResultName[FingerpostWireEntry]
   )(rs: WrappedResultSet): FingerpostWireEntry = {
-    val fingerpostContent = Json.parse(rs.string(fm.content)).as[FingerpostWire]
+    val fingerpostContent = decode[FingerpostWire](rs.string(fm.content)).toOption.get
     val maybeCategoryCodes = rs.arrayOpt(fm.categoryCodes)
     val categoryCodes = maybeCategoryCodes match {
       case Some(array) =>

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -27,7 +27,7 @@ object FingerpostWireEntry
     with Logging {
 
   implicit val jsonEncoder: Encoder[FingerpostWireEntry] =
-    deriveEncoder[FingerpostWireEntry]
+    deriveEncoder[FingerpostWireEntry].mapJson(_.dropNullValues)
 
   implicit val jsonDecoder: Decoder[FingerpostWireEntry] =
     deriveDecoder[FingerpostWireEntry]

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -120,7 +120,11 @@ object FingerpostWireEntry
   )
 
   private object QueryResponse {
-    implicit val writes: OWrites[QueryResponse] = Json.writes[QueryResponse]
+    implicit val jsonEncoder: Encoder[QueryResponse] =
+      deriveEncoder[QueryResponse]
+
+    implicit val jsonDecoder: Decoder[QueryResponse] =
+      deriveDecoder[QueryResponse]
   }
 
   private def processSearchParams(

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -27,9 +27,6 @@ object FingerpostWireEntry
     extends SQLSyntaxSupport[FingerpostWireEntry]
     with Logging {
 
-  implicit val format: OFormat[FingerpostWireEntry] =
-    Json.format[FingerpostWireEntry]
-
   implicit val jsonEncoder: Encoder[FingerpostWireEntry] =
     deriveEncoder[FingerpostWireEntry]
 

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -4,10 +4,17 @@ import conf.{SearchField, SearchTerm}
 import db.CustomMappers.textArray
 import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
-import models.FingerpostWire
+import models.{
+  FingerpostWire,
+  NextPage,
+  QueryParams,
+  QueryResponse,
+  SearchParams
+}
 import play.api.Logging
 import scalikejdbc._
 import io.circe.parser._
+
 import java.time.Instant
 
 case class FingerpostWireEntry(
@@ -62,7 +69,9 @@ object FingerpostWireEntry
       fm: ResultName[FingerpostWireEntry]
   )(rs: WrappedResultSet): Option[FingerpostWireEntry] = {
     for {
-      fingerpostContent <- decode[FingerpostWire](rs.string(fm.content)).toOption
+      fingerpostContent <- decode[FingerpostWire](
+        rs.string(fm.content)
+      ).toOption
       maybeCategoryCodes = rs.arrayOpt(fm.categoryCodes)
       categoryCodes = maybeCategoryCodes match {
         case Some(array) =>
@@ -109,7 +118,7 @@ object FingerpostWireEntry
       .map(FingerpostWireEntry(syn.resultName))
       .single()
       .apply()
-      .collect({case Some(fingerPostWireEntry) => fingerPostWireEntry})
+      .collect({ case Some(fingerPostWireEntry) => fingerPostWireEntry })
   }
 
   private def processSearchParams(
@@ -364,7 +373,7 @@ object FingerpostWireEntry
       .map(FingerpostWireEntry(syn.resultName))
       .list()
       .apply()
-      .collect({case Some(fingerpostWireEntry) => fingerpostWireEntry})
+      .collect({ case Some(fingerpostWireEntry) => fingerpostWireEntry })
 
     val countQuery =
       sql"""| SELECT COUNT(*)

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -2,7 +2,9 @@ package db
 
 import conf.{SearchConfig, SearchField, SearchTerm}
 import db.CustomMappers.textArray
-import models.FingerpostWire
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import models.{FingerpostWire, FingerpostWireSubjects}
 import play.api.Logging
 import play.api.libs.json._
 import scalikejdbc._
@@ -27,6 +29,12 @@ object FingerpostWireEntry
 
   implicit val format: OFormat[FingerpostWireEntry] =
     Json.format[FingerpostWireEntry]
+
+  implicit val jsonEncoder: Encoder[FingerpostWireEntry] =
+    deriveEncoder[FingerpostWireEntry]
+
+  implicit val jsonDecoder: Decoder[FingerpostWireEntry] =
+    deriveDecoder[FingerpostWireEntry]
 
   override val columns =
     Seq(

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -2,77 +2,12 @@ package db
 
 import conf.{SearchConfig, SearchField, SearchTerm}
 import db.CustomMappers.textArray
+import models.FingerpostWire
 import play.api.Logging
 import play.api.libs.json._
 import scalikejdbc._
 
 import java.time.{Instant, ZonedDateTime}
-
-case class FingerpostWireSubjects(
-    code: List[String]
-)
-object FingerpostWireSubjects {
-  // some wires arrive with no code, but represent that by an empty string
-  // instead of an empty array :( preprocess them into an empty array
-  private val reads =
-    Json.reads[FingerpostWireSubjects].preprocess { case JsObject(obj) =>
-      JsObject(obj.map {
-        case ("code", JsString("")) => ("code", JsArray.empty)
-        case other                  => other
-      })
-    }
-  private val writes = Json.writes[FingerpostWireSubjects]
-  implicit val format: Format[FingerpostWireSubjects] =
-    Format(reads, writes)
-}
-
-case class Dataformat(
-    noOfColumns: Option[String],
-    notFipTopusCategory: Option[String],
-    indesignTags: Option[String]
-)
-
-object Dataformat {
-  implicit val format: OFormat[Dataformat] = Json.format[Dataformat]
-}
-
-case class FingerpostWire(
-    uri: Option[String],
-    sourceFeed: Option[String],
-    usn: Option[String],
-    version: Option[String],
-    status: Option[String],
-    firstVersion: Option[String],
-    versionCreated: Option[String],
-    dateTimeSent: Option[String],
-    slug: Option[String],
-    headline: Option[String],
-    subhead: Option[String],
-    byline: Option[String],
-    priority: Option[String],
-    subjects: Option[FingerpostWireSubjects],
-    keywords: Option[List[String]],
-    usage: Option[String],
-    ednote: Option[String],
-    mediaCatCodes: Option[String],
-    `abstract`: Option[String],
-    bodyText: Option[String],
-    composerCompatible: Option[Boolean],
-    dataformat: Option[Dataformat]
-)
-object FingerpostWire {
-  // rename a couple of fields
-  private val reads: Reads[FingerpostWire] =
-    Json.reads[FingerpostWire].preprocess { case JsObject(obj) =>
-      JsObject(obj.map {
-        case ("source-feed", value) => ("sourceFeed", value)
-        case ("body_text", value)   => ("bodyText", value)
-        case other                  => other
-      })
-    }
-  private val writes = Json.writes[FingerpostWire]
-  implicit val format: Format[FingerpostWire] = Format(reads, writes)
-}
 
 case class FingerpostWireEntry(
     id: Long,

--- a/newswires/app/models/Dataformat.scala
+++ b/newswires/app/models/Dataformat.scala
@@ -11,5 +11,5 @@ case class Dataformat(
 
 object Dataformat {
   implicit val jsonDecoder: Decoder[Dataformat] = deriveDecoder[Dataformat]
-  implicit val jsonEncoder: Encoder[Dataformat] = deriveEncoder[Dataformat]
+  implicit val jsonEncoder: Encoder[Dataformat] = deriveEncoder[Dataformat].mapJson(_.dropNullValues)
 }

--- a/newswires/app/models/Dataformat.scala
+++ b/newswires/app/models/Dataformat.scala
@@ -11,5 +11,6 @@ case class Dataformat(
 
 object Dataformat {
   implicit val jsonDecoder: Decoder[Dataformat] = deriveDecoder[Dataformat]
-  implicit val jsonEncoder: Encoder[Dataformat] = deriveEncoder[Dataformat].mapJson(_.dropNullValues)
+  implicit val jsonEncoder: Encoder[Dataformat] =
+    deriveEncoder[Dataformat].mapJson(_.dropNullValues)
 }

--- a/newswires/app/models/Dataformat.scala
+++ b/newswires/app/models/Dataformat.scala
@@ -1,5 +1,7 @@
 package models
 
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.{Decoder, Encoder}
 import play.api.libs.json.{Json, OFormat}
 
 case class Dataformat(
@@ -9,5 +11,7 @@ case class Dataformat(
 )
 
 object Dataformat {
+  implicit val jsonDecoder: Decoder[Dataformat] = deriveDecoder[Dataformat]
+  implicit val jsonEncoder: Encoder[Dataformat] = deriveEncoder[Dataformat]
   implicit val format: OFormat[Dataformat] = Json.format[Dataformat]
 }

--- a/newswires/app/models/Dataformat.scala
+++ b/newswires/app/models/Dataformat.scala
@@ -2,7 +2,6 @@ package models
 
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
-import play.api.libs.json.{Json, OFormat}
 
 case class Dataformat(
     noOfColumns: Option[String],
@@ -13,5 +12,4 @@ case class Dataformat(
 object Dataformat {
   implicit val jsonDecoder: Decoder[Dataformat] = deriveDecoder[Dataformat]
   implicit val jsonEncoder: Encoder[Dataformat] = deriveEncoder[Dataformat]
-  implicit val format: OFormat[Dataformat] = Json.format[Dataformat]
 }

--- a/newswires/app/models/Dataformat.scala
+++ b/newswires/app/models/Dataformat.scala
@@ -1,0 +1,13 @@
+package models
+
+import play.api.libs.json.{Json, OFormat}
+
+case class Dataformat(
+    noOfColumns: Option[String],
+    notFipTopusCategory: Option[String],
+    indesignTags: Option[String]
+)
+
+object Dataformat {
+  implicit val format: OFormat[Dataformat] = Json.format[Dataformat]
+}

--- a/newswires/app/models/FingerpostWire.scala
+++ b/newswires/app/models/FingerpostWire.scala
@@ -2,8 +2,6 @@ package models
 
 import io.circe._
 import io.circe.generic.semiauto._
-import io.circe.generic.extras._
-import play.api.libs.json.{Format, JsObject, Json, Reads}
 
 case class FingerpostWire(
     uri: Option[String],
@@ -30,17 +28,6 @@ case class FingerpostWire(
     dataformat: Option[Dataformat]
 )
 object FingerpostWire {
-  // rename a couple of fields
-  private val reads: Reads[FingerpostWire] =
-    Json.reads[FingerpostWire].preprocess { case JsObject(obj) =>
-      JsObject(obj.map {
-        case ("source-feed", value) => ("sourceFeed", value)
-        case ("body_text", value)   => ("bodyText", value)
-        case other                  => other
-      })
-    }
-  private val writes = Json.writes[FingerpostWire]
-  implicit val format: Format[FingerpostWire] = Format(reads, writes)
   implicit val jsonDecoder: Decoder[FingerpostWire] =
     deriveDecoder[FingerpostWire].prepare(
       _.withFocus {

--- a/newswires/app/models/FingerpostWire.scala
+++ b/newswires/app/models/FingerpostWire.scala
@@ -1,0 +1,41 @@
+package models
+
+import play.api.libs.json.{Format, JsObject, Json, Reads}
+
+case class FingerpostWire(
+    uri: Option[String],
+    sourceFeed: Option[String],
+    usn: Option[String],
+    version: Option[String],
+    status: Option[String],
+    firstVersion: Option[String],
+    versionCreated: Option[String],
+    dateTimeSent: Option[String],
+    slug: Option[String],
+    headline: Option[String],
+    subhead: Option[String],
+    byline: Option[String],
+    priority: Option[String],
+    subjects: Option[FingerpostWireSubjects],
+    keywords: Option[List[String]],
+    usage: Option[String],
+    ednote: Option[String],
+    mediaCatCodes: Option[String],
+    `abstract`: Option[String],
+    bodyText: Option[String],
+    composerCompatible: Option[Boolean],
+    dataformat: Option[Dataformat]
+)
+object FingerpostWire {
+  // rename a couple of fields
+  private val reads: Reads[FingerpostWire] =
+    Json.reads[FingerpostWire].preprocess { case JsObject(obj) =>
+      JsObject(obj.map {
+        case ("source-feed", value) => ("sourceFeed", value)
+        case ("body_text", value)   => ("bodyText", value)
+        case other                  => other
+      })
+    }
+  private val writes = Json.writes[FingerpostWire]
+  implicit val format: Format[FingerpostWire] = Format(reads, writes)
+}

--- a/newswires/app/models/FingerpostWire.scala
+++ b/newswires/app/models/FingerpostWire.scala
@@ -51,5 +51,5 @@ object FingerpostWire {
       }
     )
   implicit val jsonEncoder: Encoder[FingerpostWire] =
-    deriveEncoder[FingerpostWire]
+    deriveEncoder[FingerpostWire].mapJson(_.dropNullValues)
 }

--- a/newswires/app/models/FingerpostWire.scala
+++ b/newswires/app/models/FingerpostWire.scala
@@ -1,5 +1,8 @@
 package models
 
+import io.circe._
+import io.circe.generic.semiauto._
+import io.circe.generic.extras._
 import play.api.libs.json.{Format, JsObject, Json, Reads}
 
 case class FingerpostWire(
@@ -38,4 +41,28 @@ object FingerpostWire {
     }
   private val writes = Json.writes[FingerpostWire]
   implicit val format: Format[FingerpostWire] = Format(reads, writes)
+  implicit val jsonDecoder: Decoder[FingerpostWire] =
+    deriveDecoder[FingerpostWire].prepare(
+      _.withFocus {
+        _.mapObject(obj => {
+          obj
+            .add(
+              "sourceFeed",
+              obj("source-feed").getOrElse(
+                obj("sourceFeed").getOrElse(io.circe.Json.Null)
+              )
+            )
+            .add(
+              "bodyText",
+              obj("body_text").getOrElse(
+                obj("bodyText").getOrElse(io.circe.Json.Null)
+              )
+            )
+            .remove("source-feed")
+            .remove("body_text")
+        })
+      }
+    )
+  implicit val jsonEncoder: Encoder[FingerpostWire] =
+    deriveEncoder[FingerpostWire]
 }

--- a/newswires/app/models/FingerpostWireSubjects.scala
+++ b/newswires/app/models/FingerpostWireSubjects.scala
@@ -1,32 +1,12 @@
 package models
 
-import io.circe.Json.JString
-import io.circe.{Decoder, Encoder, Json, JsonObject}
+import io.circe.{Decoder, Encoder, Json}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
-import play.api.libs.json.{
-  Format,
-  JsArray,
-  JsObject,
-  JsString,
-  Json => PlayJson
-}
 
 case class FingerpostWireSubjects(
     code: List[String]
 )
 object FingerpostWireSubjects {
-  // some wires arrive with no code, but represent that by an empty string
-  // instead of an empty array :( preprocess them into an empty array
-  private val reads =
-    PlayJson.reads[FingerpostWireSubjects].preprocess { case JsObject(obj) =>
-      JsObject(obj.map {
-        case ("code", JsString("")) => ("code", JsArray.empty)
-        case other                  => other
-      })
-    }
-  private val writes = PlayJson.writes[FingerpostWireSubjects]
-  implicit val format: Format[FingerpostWireSubjects] =
-    Format(reads, writes)
 
   implicit val jsonDecoder: Decoder[FingerpostWireSubjects] =
     deriveDecoder[FingerpostWireSubjects].prepare(

--- a/newswires/app/models/FingerpostWireSubjects.scala
+++ b/newswires/app/models/FingerpostWireSubjects.scala
@@ -1,8 +1,15 @@
 package models
 
-import io.circe.{Decoder, Encoder, JsonObject, _}
+import io.circe.Json.JString
+import io.circe.{Decoder, Encoder, Json, JsonObject}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
-import play.api.libs.json.{Format, JsArray, JsObject, JsString, Json}
+import play.api.libs.json.{
+  Format,
+  JsArray,
+  JsObject,
+  JsString,
+  Json => PlayJson
+}
 
 case class FingerpostWireSubjects(
     code: List[String]
@@ -11,17 +18,29 @@ object FingerpostWireSubjects {
   // some wires arrive with no code, but represent that by an empty string
   // instead of an empty array :( preprocess them into an empty array
   private val reads =
-    Json.reads[FingerpostWireSubjects].preprocess { case JsObject(obj) =>
+    PlayJson.reads[FingerpostWireSubjects].preprocess { case JsObject(obj) =>
       JsObject(obj.map {
         case ("code", JsString("")) => ("code", JsArray.empty)
         case other                  => other
       })
     }
-  private val writes = Json.writes[FingerpostWireSubjects]
+  private val writes = PlayJson.writes[FingerpostWireSubjects]
   implicit val format: Format[FingerpostWireSubjects] =
     Format(reads, writes)
 
-  implicit val jsonDecoder: Decoder[FingerpostWireSubjects] = deriveDecoder
+  implicit val jsonDecoder: Decoder[FingerpostWireSubjects] =
+    deriveDecoder[FingerpostWireSubjects].prepare(
+      _.withFocus {
+        _.mapObject(obj => {
+          obj.mapValues(json =>
+            json.asString match {
+              case Some("") => Json.arr()
+              case _        => json
+            }
+          )
+        })
+      }
+    )
 
   implicit val jsonEncoder: Encoder[FingerpostWireSubjects] =
     deriveEncoder[FingerpostWireSubjects]

--- a/newswires/app/models/FingerpostWireSubjects.scala
+++ b/newswires/app/models/FingerpostWireSubjects.scala
@@ -23,5 +23,5 @@ object FingerpostWireSubjects {
     )
 
   implicit val jsonEncoder: Encoder[FingerpostWireSubjects] =
-    deriveEncoder[FingerpostWireSubjects]
+    deriveEncoder[FingerpostWireSubjects].mapJson(_.dropNullValues)
 }

--- a/newswires/app/models/FingerpostWireSubjects.scala
+++ b/newswires/app/models/FingerpostWireSubjects.scala
@@ -1,5 +1,7 @@
 package models
 
+import io.circe.{Decoder, Encoder, JsonObject, _}
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import play.api.libs.json.{Format, JsArray, JsObject, JsString, Json}
 
 case class FingerpostWireSubjects(
@@ -18,4 +20,9 @@ object FingerpostWireSubjects {
   private val writes = Json.writes[FingerpostWireSubjects]
   implicit val format: Format[FingerpostWireSubjects] =
     Format(reads, writes)
+
+  implicit val jsonDecoder: Decoder[FingerpostWireSubjects] = deriveDecoder
+
+  implicit val jsonEncoder: Encoder[FingerpostWireSubjects] =
+    deriveEncoder[FingerpostWireSubjects]
 }

--- a/newswires/app/models/FingerpostWireSubjects.scala
+++ b/newswires/app/models/FingerpostWireSubjects.scala
@@ -1,0 +1,21 @@
+package models
+
+import play.api.libs.json.{Format, JsArray, JsObject, JsString, Json}
+
+case class FingerpostWireSubjects(
+    code: List[String]
+)
+object FingerpostWireSubjects {
+  // some wires arrive with no code, but represent that by an empty string
+  // instead of an empty array :( preprocess them into an empty array
+  private val reads =
+    Json.reads[FingerpostWireSubjects].preprocess { case JsObject(obj) =>
+      JsObject(obj.map {
+        case ("code", JsString("")) => ("code", JsArray.empty)
+        case other                  => other
+      })
+    }
+  private val writes = Json.writes[FingerpostWireSubjects]
+  implicit val format: Format[FingerpostWireSubjects] =
+    Format(reads, writes)
+}

--- a/newswires/app/models/QueryParams.scala
+++ b/newswires/app/models/QueryParams.scala
@@ -1,4 +1,4 @@
-package db
+package models
 
 import conf.SearchTerm
 

--- a/newswires/app/models/QueryResponse.scala
+++ b/newswires/app/models/QueryResponse.scala
@@ -1,5 +1,6 @@
-package db
+package models
 
+import db.FingerpostWireEntry
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
 

--- a/newswires/app/models/SearchParams.scala
+++ b/newswires/app/models/SearchParams.scala
@@ -1,4 +1,4 @@
-package db
+package models
 
 import conf.SearchTerm
 

--- a/newswires/build.sbt
+++ b/newswires/build.sbt
@@ -20,8 +20,6 @@ libraryDependencies += "org.postgresql" % "postgresql" % "42.7.7"
 libraryDependencies += "software.amazon.jdbc" % "aws-advanced-jdbc-wrapper" % "2.3.7"
 libraryDependencies += "io.circe" %% "circe-generic" % "0.14.14"
 libraryDependencies += "io.circe" %% "circe-parser" % "0.14.14"
-libraryDependencies += "io.circe" %% "circe-generic-extras" % "0.14.4"
-libraryDependencies += "io.circe" %% "circe-config" % "0.10.2"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.9" % "test"
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % Test

--- a/newswires/build.sbt
+++ b/newswires/build.sbt
@@ -18,6 +18,10 @@ libraryDependencies += "net.logstash.logback" % "logstash-logback-encoder" % "8.
 libraryDependencies += "org.scalikejdbc" %% "scalikejdbc" % "3.5.0"
 libraryDependencies += "org.postgresql" % "postgresql" % "42.7.7"
 libraryDependencies += "software.amazon.jdbc" % "aws-advanced-jdbc-wrapper" % "2.3.7"
+libraryDependencies += "io.circe" %% "circe-generic" % "0.14.14"
+libraryDependencies += "io.circe" %% "circe-parser" % "0.14.14"
+libraryDependencies += "io.circe" %% "circe-generic-extras" % "0.14.4"
+libraryDependencies += "io.circe" %% "circe-config" % "0.10.2"
 
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.0.9" % "test"
 libraryDependencies += "org.scalatestplus.play" %% "scalatestplus-play" % "7.0.1" % Test

--- a/newswires/test/db/FingerpostWireEntrySpec.scala
+++ b/newswires/test/db/FingerpostWireEntrySpec.scala
@@ -1,27 +1,25 @@
 package db
 
 import conf.{SearchField, SearchTerm}
-import db.FingerpostWireEntry.QueryResponse
+import io.circe.parser.decode
 import helpers.WhereClauseMatcher.matchWhereClause
 import helpers.models
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
-import play.api.libs.json.{JsSuccess, Json}
+import io.circe.syntax.EncoderOps
 
 class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
 
   behavior of "FingerpostWireEntry Json encoders / decoders"
 
   it should "serialise json" in {
-    Json.prettyPrint(
-      Json.toJson[FingerpostWireEntry](fingerpostWireEntry)
-    ) shouldEqual fingerpostWireEntryJson
+    fingerpostWireEntry.asJson.spaces2 shouldEqual fingerpostWireEntryJson
   }
 
   it should "deserialise json" in {
-    Json.fromJson[FingerpostWireEntry](
-      Json.parse(fingerpostWireEntryJson)
-    ) shouldEqual JsSuccess(fingerpostWireEntry)
+    decode[FingerpostWireEntry](fingerpostWireEntryJson) shouldEqual Right(
+      fingerpostWireEntry
+    )
   }
 
   behavior of "FingerpostWireEntry.generateWhereClause"

--- a/newswires/test/db/FingerpostWireEntrySpec.scala
+++ b/newswires/test/db/FingerpostWireEntrySpec.scala
@@ -7,6 +7,7 @@ import helpers.models
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import io.circe.syntax.EncoderOps
+import models.{MostRecent, NextPage, QueryParams, SearchParams}
 import scalikejdbc.scalikejdbcSQLInterpolationImplicitDef
 
 class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {

--- a/newswires/test/db/FingerpostWireEntrySpec.scala
+++ b/newswires/test/db/FingerpostWireEntrySpec.scala
@@ -1,11 +1,28 @@
 package db
 
 import conf.{SearchField, SearchTerm}
+import db.FingerpostWireEntry.QueryResponse
 import helpers.WhereClauseMatcher.matchWhereClause
+import helpers.models
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
+import play.api.libs.json.{JsSuccess, Json}
 
-class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers {
+class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
+
+  behavior of "FingerpostWireEntry Json encoders / decoders"
+
+  it should "serialise json" in {
+    Json.prettyPrint(
+      Json.toJson[FingerpostWireEntry](fingerpostWireEntry)
+    ) shouldEqual fingerpostWireEntryJson
+  }
+
+  it should "deserialise json" in {
+    Json.fromJson[FingerpostWireEntry](
+      Json.parse(fingerpostWireEntryJson)
+    ) shouldEqual JsSuccess(fingerpostWireEntry)
+  }
 
   behavior of "FingerpostWireEntry.generateWhereClause"
 

--- a/newswires/test/helpers/models.scala
+++ b/newswires/test/helpers/models.scala
@@ -1,0 +1,166 @@
+package helpers
+
+import db.FingerpostWireEntry
+import db.FingerpostWireEntry.QueryResponse
+import models.{Dataformat, FingerpostWire, FingerpostWireSubjects}
+
+import java.time.Instant
+
+trait models {
+
+  val exampleWire = FingerpostWire(
+    uri = Some("https://example.com/news/12345"),
+    sourceFeed = Some("newswire-feed"),
+    usn = Some("USN123456"),
+    version = Some("1.0"),
+    status = Some("published"),
+    firstVersion = Some("2025-07-01T12:00:00Z"),
+    versionCreated = Some("2025-07-22T09:15:00Z"),
+    dateTimeSent = Some("2025-07-22T09:20:00Z"),
+    slug = Some("breaking-news-event"),
+    headline = Some("Major Event Unfolds in Capital"),
+    subhead = Some("Authorities respond to unfolding situation"),
+    byline = Some("Jane Doe"),
+    priority = Some("high"),
+    subjects = Some(
+      FingerpostWireSubjects(
+        code = List("POL", "INT", "UK")
+      )
+    ),
+    keywords = Some(List("breaking", "government", "security")),
+    usage = Some("editorial"),
+    ednote = Some("Sensitive content – embargo until 10 AM"),
+    mediaCatCodes = Some("MC123"),
+    `abstract` =
+      Some("A major incident is currently being managed by local authorities."),
+    bodyText = Some(
+      """Local authorities have confirmed that a major security incident
+        |has occurred in the city centre. Citizens are advised to avoid the area.""".stripMargin
+    ),
+    composerCompatible = Some(true),
+    dataformat = Some(
+      Dataformat(
+        noOfColumns = Some("3"),
+        notFipTopusCategory = Some("general-news"),
+        indesignTags = Some("<p><b>BREAKING:</b></p>")
+      )
+    )
+  )
+  val emptyWire = FingerpostWire(
+    uri = None,
+    sourceFeed = None,
+    usn = None,
+    version = None,
+    status = None,
+    firstVersion = None,
+    versionCreated = None,
+    dateTimeSent = None,
+    slug = None,
+    headline = None,
+    subhead = None,
+    byline = None,
+    priority = None,
+    subjects = None,
+    keywords = None,
+    usage = None,
+    ednote = None,
+    mediaCatCodes = None,
+    `abstract` = None,
+    bodyText = None,
+    composerCompatible = None,
+    dataformat = None
+  )
+  val exampleWireJson = """{
+                          |  "uri" : "https://example.com/news/12345",
+                          |  "sourceFeed" : "newswire-feed",
+                          |  "usn" : "USN123456",
+                          |  "version" : "1.0",
+                          |  "status" : "published",
+                          |  "firstVersion" : "2025-07-01T12:00:00Z",
+                          |  "versionCreated" : "2025-07-22T09:15:00Z",
+                          |  "dateTimeSent" : "2025-07-22T09:20:00Z",
+                          |  "slug" : "breaking-news-event",
+                          |  "headline" : "Major Event Unfolds in Capital",
+                          |  "subhead" : "Authorities respond to unfolding situation",
+                          |  "byline" : "Jane Doe",
+                          |  "priority" : "high",
+                          |  "subjects" : {
+                          |    "code" : [
+                          |      "POL",
+                          |      "INT",
+                          |      "UK"
+                          |    ]
+                          |  },
+                          |  "keywords" : [
+                          |    "breaking",
+                          |    "government",
+                          |    "security"
+                          |  ],
+                          |  "usage" : "editorial",
+                          |  "ednote" : "Sensitive content – embargo until 10 AM",
+                          |  "mediaCatCodes" : "MC123",
+                          |  "abstract" : "A major incident is currently being managed by local authorities.",
+                          |  "bodyText" : "Local authorities have confirmed that a major security incident\nhas occurred in the city centre. Citizens are advised to avoid the area.",
+                          |  "composerCompatible" : true,
+                          |  "dataformat" : {
+                          |    "noOfColumns" : "3",
+                          |    "notFipTopusCategory" : "general-news",
+                          |    "indesignTags" : "<p><b>BREAKING:</b></p>"
+                          |  }
+                          |}""".stripMargin
+
+  val fingerpostWireEntry = FingerpostWireEntry(
+    id = 1L,
+    supplier = "Supplier",
+    externalId = "ExternalId",
+    ingestedAt = Instant.ofEpochMilli(1753370061967L),
+    content = exampleWire,
+    composerId = Some("composerId"),
+    composerSentBy = Some("composerSentBy"),
+    categoryCodes = List("code"),
+    highlight = Some("highlight")
+  )
+
+  val fingerpostWireEntryJson =
+    """{
+      |  "id" : 1,
+      |  "supplier" : "Supplier",
+      |  "externalId" : "ExternalId",
+      |  "ingestedAt" : "2025-07-24T15:14:21.967Z",
+      |  "content" : {
+      |    "uri" : "https://example.com/news/12345",
+      |    "sourceFeed" : "newswire-feed",
+      |    "usn" : "USN123456",
+      |    "version" : "1.0",
+      |    "status" : "published",
+      |    "firstVersion" : "2025-07-01T12:00:00Z",
+      |    "versionCreated" : "2025-07-22T09:15:00Z",
+      |    "dateTimeSent" : "2025-07-22T09:20:00Z",
+      |    "slug" : "breaking-news-event",
+      |    "headline" : "Major Event Unfolds in Capital",
+      |    "subhead" : "Authorities respond to unfolding situation",
+      |    "byline" : "Jane Doe",
+      |    "priority" : "high",
+      |    "subjects" : {
+      |      "code" : [ "POL", "INT", "UK" ]
+      |    },
+      |    "keywords" : [ "breaking", "government", "security" ],
+      |    "usage" : "editorial",
+      |    "ednote" : "Sensitive content – embargo until 10 AM",
+      |    "mediaCatCodes" : "MC123",
+      |    "abstract" : "A major incident is currently being managed by local authorities.",
+      |    "bodyText" : "Local authorities have confirmed that a major security incident\nhas occurred in the city centre. Citizens are advised to avoid the area.",
+      |    "composerCompatible" : true,
+      |    "dataformat" : {
+      |      "noOfColumns" : "3",
+      |      "notFipTopusCategory" : "general-news",
+      |      "indesignTags" : "<p><b>BREAKING:</b></p>"
+      |    }
+      |  },
+      |  "composerId" : "composerId",
+      |  "composerSentBy" : "composerSentBy",
+      |  "categoryCodes" : [ "code" ],
+      |  "highlight" : "highlight"
+      |}""".stripMargin
+
+}

--- a/newswires/test/helpers/models.scala
+++ b/newswires/test/helpers/models.scala
@@ -142,9 +142,17 @@ trait models {
       |    "byline" : "Jane Doe",
       |    "priority" : "high",
       |    "subjects" : {
-      |      "code" : [ "POL", "INT", "UK" ]
+      |      "code" : [
+      |        "POL",
+      |        "INT",
+      |        "UK"
+      |      ]
       |    },
-      |    "keywords" : [ "breaking", "government", "security" ],
+      |    "keywords" : [
+      |      "breaking",
+      |      "government",
+      |      "security"
+      |    ],
       |    "usage" : "editorial",
       |    "ednote" : "Sensitive content – embargo until 10 AM",
       |    "mediaCatCodes" : "MC123",
@@ -159,7 +167,9 @@ trait models {
       |  },
       |  "composerId" : "composerId",
       |  "composerSentBy" : "composerSentBy",
-      |  "categoryCodes" : [ "code" ],
+      |  "categoryCodes" : [
+      |    "code"
+      |  ],
       |  "highlight" : "highlight"
       |}""".stripMargin
 

--- a/newswires/test/models/FingerpostWireSpec.scala
+++ b/newswires/test/models/FingerpostWireSpec.scala
@@ -7,7 +7,7 @@ import play.api.libs.json.{JsSuccess, Json}
 import io.circe.parser.decode
 import io.circe.syntax.EncoderOps
 
-class FingerpostWireTest extends AnyFlatSpec with models {
+class FingerpostWireSpec extends AnyFlatSpec with models {
 
   it should "serialise json" in {
     exampleWire.asJson.spaces2 shouldEqual exampleWireJson

--- a/newswires/test/models/FingerpostWireSubjectsSpec.scala
+++ b/newswires/test/models/FingerpostWireSubjectsSpec.scala
@@ -5,7 +5,7 @@ import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import io.circe.parser.decode
 import io.circe.syntax.EncoderOps
 
-class FingerpostWireSubjectsTest extends AnyFlatSpec {
+class FingerpostWireSubjectsSpec extends AnyFlatSpec {
   val exampleFingerpostWireSubjects =
     FingerpostWireSubjects(code = List("a", "b"))
   val exampleJson = """{

--- a/newswires/test/models/FingerpostWireSubjectsTest.scala
+++ b/newswires/test/models/FingerpostWireSubjectsTest.scala
@@ -1,0 +1,34 @@
+package models
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import play.api.libs.json.{JsSuccess, Json}
+
+class FingerpostWireSubjectsTest extends AnyFlatSpec {
+  val exampleFingerpostWireSubjects =
+    FingerpostWireSubjects(code = List("a", "b"))
+  val exampleJson = """{
+                      |  "code" : [ "a", "b" ]
+                      |}""".stripMargin
+  it should "serialise json" in {
+    Json.prettyPrint(
+      Json.toJson(exampleFingerpostWireSubjects)
+    ) shouldEqual exampleJson
+
+  }
+
+  it should "deserialise json" in {
+    Json.fromJson[FingerpostWireSubjects](
+      Json.parse(exampleJson)
+    ) shouldEqual JsSuccess(exampleFingerpostWireSubjects)
+  }
+
+  it should "deserialise json with an empty code" in {
+    Json.fromJson[FingerpostWireSubjects](Json.parse("""{
+        | "code": ""
+        |}""".stripMargin)) shouldEqual JsSuccess(
+      FingerpostWireSubjects(code = List())
+    )
+  }
+
+}

--- a/newswires/test/models/FingerpostWireSubjectsTest.scala
+++ b/newswires/test/models/FingerpostWireSubjectsTest.scala
@@ -3,24 +3,26 @@ package models
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import play.api.libs.json.{JsSuccess, Json}
+import io.circe.parser.decode
+import io.circe.syntax.EncoderOps
 
 class FingerpostWireSubjectsTest extends AnyFlatSpec {
   val exampleFingerpostWireSubjects =
     FingerpostWireSubjects(code = List("a", "b"))
   val exampleJson = """{
-                      |  "code" : [ "a", "b" ]
+                      |  "code" : [
+                      |    "a",
+                      |    "b"
+                      |  ]
                       |}""".stripMargin
   it should "serialise json" in {
-    Json.prettyPrint(
-      Json.toJson(exampleFingerpostWireSubjects)
-    ) shouldEqual exampleJson
-
+    exampleFingerpostWireSubjects.asJson.spaces2 shouldEqual exampleJson
   }
 
   it should "deserialise json" in {
-    Json.fromJson[FingerpostWireSubjects](
-      Json.parse(exampleJson)
-    ) shouldEqual JsSuccess(exampleFingerpostWireSubjects)
+    decode[FingerpostWireSubjects](
+      exampleJson
+    ) shouldEqual Right(exampleFingerpostWireSubjects)
   }
 
   it should "deserialise json with an empty code" in {

--- a/newswires/test/models/FingerpostWireSubjectsTest.scala
+++ b/newswires/test/models/FingerpostWireSubjectsTest.scala
@@ -2,7 +2,6 @@ package models
 
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
-import play.api.libs.json.{JsSuccess, Json}
 import io.circe.parser.decode
 import io.circe.syntax.EncoderOps
 

--- a/newswires/test/models/FingerpostWireSubjectsTest.scala
+++ b/newswires/test/models/FingerpostWireSubjectsTest.scala
@@ -26,9 +26,9 @@ class FingerpostWireSubjectsTest extends AnyFlatSpec {
   }
 
   it should "deserialise json with an empty code" in {
-    Json.fromJson[FingerpostWireSubjects](Json.parse("""{
+    decode[FingerpostWireSubjects]("""{
         | "code": ""
-        |}""".stripMargin)) shouldEqual JsSuccess(
+        |}""".stripMargin) shouldEqual Right(
       FingerpostWireSubjects(code = List())
     )
   }

--- a/newswires/test/models/FingerpostWireTest.scala
+++ b/newswires/test/models/FingerpostWireTest.scala
@@ -1,0 +1,130 @@
+package models
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import play.api.libs.json.{JsSuccess, Json}
+
+class FingerpostWireTest extends AnyFlatSpec {
+
+  val exampleWire = FingerpostWire(
+    uri = Some("https://example.com/news/12345"),
+    sourceFeed = Some("newswire-feed"),
+    usn = Some("USN123456"),
+    version = Some("1.0"),
+    status = Some("published"),
+    firstVersion = Some("2025-07-01T12:00:00Z"),
+    versionCreated = Some("2025-07-22T09:15:00Z"),
+    dateTimeSent = Some("2025-07-22T09:20:00Z"),
+    slug = Some("breaking-news-event"),
+    headline = Some("Major Event Unfolds in Capital"),
+    subhead = Some("Authorities respond to unfolding situation"),
+    byline = Some("Jane Doe"),
+    priority = Some("high"),
+    subjects = Some(
+      FingerpostWireSubjects(
+        code = List("POL", "INT", "UK")
+      )
+    ),
+    keywords = Some(List("breaking", "government", "security")),
+    usage = Some("editorial"),
+    ednote = Some("Sensitive content – embargo until 10 AM"),
+    mediaCatCodes = Some("MC123"),
+    `abstract` =
+      Some("A major incident is currently being managed by local authorities."),
+    bodyText = Some(
+      """Local authorities have confirmed that a major security incident
+        |has occurred in the city centre. Citizens are advised to avoid the area.""".stripMargin
+    ),
+    composerCompatible = Some(true),
+    dataformat = Some(
+      Dataformat(
+        noOfColumns = Some("3"),
+        notFipTopusCategory = Some("general-news"),
+        indesignTags = Some("<p><b>BREAKING:</b></p>")
+      )
+    )
+  )
+  val emptyWire = FingerpostWire(
+    uri = None,
+    sourceFeed = None,
+    usn = None,
+    version = None,
+    status = None,
+    firstVersion = None,
+    versionCreated = None,
+    dateTimeSent = None,
+    slug = None,
+    headline = None,
+    subhead = None,
+    byline = None,
+    priority = None,
+    subjects = None,
+    keywords = None,
+    usage = None,
+    ednote = None,
+    mediaCatCodes = None,
+    `abstract` = None,
+    bodyText = None,
+    composerCompatible = None,
+    dataformat = None
+  )
+  val exampleWireJson = """{
+                          |  "uri" : "https://example.com/news/12345",
+                          |  "sourceFeed" : "newswire-feed",
+                          |  "usn" : "USN123456",
+                          |  "version" : "1.0",
+                          |  "status" : "published",
+                          |  "firstVersion" : "2025-07-01T12:00:00Z",
+                          |  "versionCreated" : "2025-07-22T09:15:00Z",
+                          |  "dateTimeSent" : "2025-07-22T09:20:00Z",
+                          |  "slug" : "breaking-news-event",
+                          |  "headline" : "Major Event Unfolds in Capital",
+                          |  "subhead" : "Authorities respond to unfolding situation",
+                          |  "byline" : "Jane Doe",
+                          |  "priority" : "high",
+                          |  "subjects" : {
+                          |    "code" : [ "POL", "INT", "UK" ]
+                          |  },
+                          |  "keywords" : [ "breaking", "government", "security" ],
+                          |  "usage" : "editorial",
+                          |  "ednote" : "Sensitive content – embargo until 10 AM",
+                          |  "mediaCatCodes" : "MC123",
+                          |  "abstract" : "A major incident is currently being managed by local authorities.",
+                          |  "bodyText" : "Local authorities have confirmed that a major security incident\nhas occurred in the city centre. Citizens are advised to avoid the area.",
+                          |  "composerCompatible" : true,
+                          |  "dataformat" : {
+                          |    "noOfColumns" : "3",
+                          |    "notFipTopusCategory" : "general-news",
+                          |    "indesignTags" : "<p><b>BREAKING:</b></p>"
+                          |  }
+                          |}""".stripMargin
+  it should "serialise json" in {
+    Json.prettyPrint(Json.toJson(exampleWire)) shouldEqual exampleWireJson
+  }
+
+  it should "deserialise json" in {
+    Json.fromJson[FingerpostWire](
+      Json.parse(exampleWireJson)
+    ) shouldEqual JsSuccess(exampleWire)
+  }
+
+  it should "transform source-feed to sourceFeed" in {
+    Json.fromJson[FingerpostWire](
+      Json.parse(
+        """{
+        |"source-feed": "newswire-feed"
+        |}""".stripMargin
+      )
+    ) shouldEqual JsSuccess(emptyWire.copy(sourceFeed = Some("newswire-feed")))
+  }
+
+  it should "transform body_text to bodyText" in {
+    Json.fromJson[FingerpostWire](
+      Json.parse(
+        """{
+        |"body_text": "body text"
+        |}""".stripMargin
+      )
+    ) shouldEqual JsSuccess(emptyWire.copy(bodyText = Some("body text")))
+  }
+}

--- a/newswires/test/models/FingerpostWireTest.scala
+++ b/newswires/test/models/FingerpostWireTest.scala
@@ -13,6 +13,10 @@ class FingerpostWireTest extends AnyFlatSpec with models {
     exampleWire.asJson.spaces2 shouldEqual exampleWireJson
   }
 
+  it should "serialise json and remove null fields" in {
+    emptyWire.asJson.noSpaces shouldEqual "{}"
+  }
+
   it should "deserialise json" in {
     decode[FingerpostWire](exampleWireJson) shouldEqual Right(exampleWire)
   }

--- a/newswires/test/models/FingerpostWireTest.scala
+++ b/newswires/test/models/FingerpostWireTest.scala
@@ -3,6 +3,8 @@ package models
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import play.api.libs.json.{JsSuccess, Json}
+import io.circe.parser.decode
+import io.circe.syntax.EncoderOps
 
 class FingerpostWireTest extends AnyFlatSpec {
 
@@ -83,9 +85,17 @@ class FingerpostWireTest extends AnyFlatSpec {
                           |  "byline" : "Jane Doe",
                           |  "priority" : "high",
                           |  "subjects" : {
-                          |    "code" : [ "POL", "INT", "UK" ]
+                          |    "code" : [
+                          |      "POL",
+                          |      "INT",
+                          |      "UK"
+                          |    ]
                           |  },
-                          |  "keywords" : [ "breaking", "government", "security" ],
+                          |  "keywords" : [
+                          |    "breaking",
+                          |    "government",
+                          |    "security"
+                          |  ],
                           |  "usage" : "editorial",
                           |  "ednote" : "Sensitive content – embargo until 10 AM",
                           |  "mediaCatCodes" : "MC123",
@@ -99,32 +109,26 @@ class FingerpostWireTest extends AnyFlatSpec {
                           |  }
                           |}""".stripMargin
   it should "serialise json" in {
-    Json.prettyPrint(Json.toJson(exampleWire)) shouldEqual exampleWireJson
+    exampleWire.asJson.spaces2 shouldEqual exampleWireJson
   }
 
   it should "deserialise json" in {
-    Json.fromJson[FingerpostWire](
-      Json.parse(exampleWireJson)
-    ) shouldEqual JsSuccess(exampleWire)
+    decode[FingerpostWire](exampleWireJson) shouldEqual Right(exampleWire)
   }
 
   it should "transform source-feed to sourceFeed" in {
-    Json.fromJson[FingerpostWire](
-      Json.parse(
-        """{
+    decode[FingerpostWire](
+      """{
         |"source-feed": "newswire-feed"
         |}""".stripMargin
-      )
-    ) shouldEqual JsSuccess(emptyWire.copy(sourceFeed = Some("newswire-feed")))
+    ) shouldEqual Right(emptyWire.copy(sourceFeed = Some("newswire-feed")))
   }
 
   it should "transform body_text to bodyText" in {
-    Json.fromJson[FingerpostWire](
-      Json.parse(
-        """{
+    decode[FingerpostWire](
+      """{
         |"body_text": "body text"
         |}""".stripMargin
-      )
-    ) shouldEqual JsSuccess(emptyWire.copy(bodyText = Some("body text")))
+    ) shouldEqual Right(emptyWire.copy(bodyText = Some("body text")))
   }
 }

--- a/newswires/test/models/FingerpostWireTest.scala
+++ b/newswires/test/models/FingerpostWireTest.scala
@@ -1,113 +1,14 @@
 package models
 
+import helpers.models
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import play.api.libs.json.{JsSuccess, Json}
 import io.circe.parser.decode
 import io.circe.syntax.EncoderOps
 
-class FingerpostWireTest extends AnyFlatSpec {
+class FingerpostWireTest extends AnyFlatSpec with models {
 
-  val exampleWire = FingerpostWire(
-    uri = Some("https://example.com/news/12345"),
-    sourceFeed = Some("newswire-feed"),
-    usn = Some("USN123456"),
-    version = Some("1.0"),
-    status = Some("published"),
-    firstVersion = Some("2025-07-01T12:00:00Z"),
-    versionCreated = Some("2025-07-22T09:15:00Z"),
-    dateTimeSent = Some("2025-07-22T09:20:00Z"),
-    slug = Some("breaking-news-event"),
-    headline = Some("Major Event Unfolds in Capital"),
-    subhead = Some("Authorities respond to unfolding situation"),
-    byline = Some("Jane Doe"),
-    priority = Some("high"),
-    subjects = Some(
-      FingerpostWireSubjects(
-        code = List("POL", "INT", "UK")
-      )
-    ),
-    keywords = Some(List("breaking", "government", "security")),
-    usage = Some("editorial"),
-    ednote = Some("Sensitive content – embargo until 10 AM"),
-    mediaCatCodes = Some("MC123"),
-    `abstract` =
-      Some("A major incident is currently being managed by local authorities."),
-    bodyText = Some(
-      """Local authorities have confirmed that a major security incident
-        |has occurred in the city centre. Citizens are advised to avoid the area.""".stripMargin
-    ),
-    composerCompatible = Some(true),
-    dataformat = Some(
-      Dataformat(
-        noOfColumns = Some("3"),
-        notFipTopusCategory = Some("general-news"),
-        indesignTags = Some("<p><b>BREAKING:</b></p>")
-      )
-    )
-  )
-  val emptyWire = FingerpostWire(
-    uri = None,
-    sourceFeed = None,
-    usn = None,
-    version = None,
-    status = None,
-    firstVersion = None,
-    versionCreated = None,
-    dateTimeSent = None,
-    slug = None,
-    headline = None,
-    subhead = None,
-    byline = None,
-    priority = None,
-    subjects = None,
-    keywords = None,
-    usage = None,
-    ednote = None,
-    mediaCatCodes = None,
-    `abstract` = None,
-    bodyText = None,
-    composerCompatible = None,
-    dataformat = None
-  )
-  val exampleWireJson = """{
-                          |  "uri" : "https://example.com/news/12345",
-                          |  "sourceFeed" : "newswire-feed",
-                          |  "usn" : "USN123456",
-                          |  "version" : "1.0",
-                          |  "status" : "published",
-                          |  "firstVersion" : "2025-07-01T12:00:00Z",
-                          |  "versionCreated" : "2025-07-22T09:15:00Z",
-                          |  "dateTimeSent" : "2025-07-22T09:20:00Z",
-                          |  "slug" : "breaking-news-event",
-                          |  "headline" : "Major Event Unfolds in Capital",
-                          |  "subhead" : "Authorities respond to unfolding situation",
-                          |  "byline" : "Jane Doe",
-                          |  "priority" : "high",
-                          |  "subjects" : {
-                          |    "code" : [
-                          |      "POL",
-                          |      "INT",
-                          |      "UK"
-                          |    ]
-                          |  },
-                          |  "keywords" : [
-                          |    "breaking",
-                          |    "government",
-                          |    "security"
-                          |  ],
-                          |  "usage" : "editorial",
-                          |  "ednote" : "Sensitive content – embargo until 10 AM",
-                          |  "mediaCatCodes" : "MC123",
-                          |  "abstract" : "A major incident is currently being managed by local authorities.",
-                          |  "bodyText" : "Local authorities have confirmed that a major security incident\nhas occurred in the city centre. Citizens are advised to avoid the area.",
-                          |  "composerCompatible" : true,
-                          |  "dataformat" : {
-                          |    "noOfColumns" : "3",
-                          |    "notFipTopusCategory" : "general-news",
-                          |    "indesignTags" : "<p><b>BREAKING:</b></p>"
-                          |  }
-                          |}""".stripMargin
   it should "serialise json" in {
     exampleWire.asJson.spaces2 shouldEqual exampleWireJson
   }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This swaps out the json serialising and deserialsing library from play json to using the circe library. This is because the `FingerpostWire` case class is already at 21 fields and adding an extra field causes the play library to break. Since we may want to add new fields in the future, using the circe library means we would not hit the same 22 field constraint. 


## How to test

I've run it locally at tested that the U.I still works at that filtering yields the same results locally as it does in the code environment. 


## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
