### PR TITLE
fix setup overwrite_config to fully overwrite

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -22,6 +22,9 @@ config_pairs=(
 )
 
 overwrite_config() {
+  # first, delete existing config contents
+  echo > ~/.gu/newswires.conf
+  # then write new contents
   for pair in "${config_pairs[@]}"; do
       echo "$pair" >> ~/.gu/newswires.conf
   done


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

When using the "overwrite" option in the setup script, it's currently just appending the values to the existing config file. This should work as the config lib reads top-to-bottom, so later values will replace earlier ones in memory, but it's still nice to clean up as we go.

## How to test

Use the overwrite option a few times, you should end with a config file that's a little bit neater.
