### PR TITLE
CDK: Poller lambda can write to feeds bucket

### DIFF
--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -2931,6 +2931,9 @@ exports[`The Newswires stack matches the snapshot 1`] = `
         "Environment": {
           "Variables": {
             "APP": "apPoller_poller_lambda",
+            "FEEDS_BUCKET_NAME": {
+              "Ref": "feedsbucketTESTNewswires116BDB0E",
+            },
             "INGESTION_LAMBDA_QUEUE_URL": {
               "Fn::ImportValue": "mockWiresFeeds:ExportsOutputRefMockSourceQueue20B4D8C006FBA8DA",
             },
@@ -3459,6 +3462,40 @@ exports[`The Newswires stack matches the snapshot 1`] = `
               "Resource": {
                 "Ref": "apPollerSecret4DA8E7BD",
               },
+            },
+            {
+              "Action": [
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "feedsbucketTESTNewswires116BDB0E",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "feedsbucketTESTNewswires116BDB0E",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
             },
             {
               "Action": [
@@ -4146,6 +4183,9 @@ dpkg -i /newswires/newswires.deb",
         "Environment": {
           "Variables": {
             "APP": "reuters_poller_lambda",
+            "FEEDS_BUCKET_NAME": {
+              "Ref": "feedsbucketTESTNewswires116BDB0E",
+            },
             "INGESTION_LAMBDA_QUEUE_URL": {
               "Fn::ImportValue": "mockWiresFeeds:ExportsOutputRefMockSourceQueue20B4D8C006FBA8DA",
             },
@@ -4674,6 +4714,40 @@ dpkg -i /newswires/newswires.deb",
               "Resource": {
                 "Ref": "reutersSecretA9E37489",
               },
+            },
+            {
+              "Action": [
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "feedsbucketTESTNewswires116BDB0E",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "feedsbucketTESTNewswires116BDB0E",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
             },
             {
               "Action": [

--- a/cdk/lib/__snapshots__/whole-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/whole-stack.test.ts.snap
@@ -3344,6 +3344,9 @@ exports[`createStacks should create WiresFeeds and Newswires stacks with correct
         "Environment": {
           "Variables": {
             "APP": "apPoller_poller_lambda",
+            "FEEDS_BUCKET_NAME": {
+              "Ref": "feedsbucketTESTNewswires116BDB0E",
+            },
             "INGESTION_LAMBDA_QUEUE_URL": {
               "Fn::ImportValue": "WiresFeeds-TEST:ExportsOutputRefsourcequeue87B8A5585572F786",
             },
@@ -3848,6 +3851,40 @@ exports[`createStacks should create WiresFeeds and Newswires stacks with correct
               "Resource": {
                 "Ref": "apPollerSecret4DA8E7BD",
               },
+            },
+            {
+              "Action": [
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "feedsbucketTESTNewswires116BDB0E",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "feedsbucketTESTNewswires116BDB0E",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
             },
             {
               "Action": [
@@ -4519,6 +4556,9 @@ dpkg -i /newswires/newswires.deb",
         "Environment": {
           "Variables": {
             "APP": "reuters_poller_lambda",
+            "FEEDS_BUCKET_NAME": {
+              "Ref": "feedsbucketTESTNewswires116BDB0E",
+            },
             "INGESTION_LAMBDA_QUEUE_URL": {
               "Fn::ImportValue": "WiresFeeds-TEST:ExportsOutputRefsourcequeue87B8A5585572F786",
             },
@@ -5023,6 +5063,40 @@ dpkg -i /newswires/newswires.deb",
               "Resource": {
                 "Ref": "reutersSecretA9E37489",
               },
+            },
+            {
+              "Action": [
+                "s3:DeleteObject*",
+                "s3:PutObject",
+                "s3:PutObjectLegalHold",
+                "s3:PutObjectRetention",
+                "s3:PutObjectTagging",
+                "s3:PutObjectVersionTagging",
+                "s3:Abort*",
+              ],
+              "Effect": "Allow",
+              "Resource": [
+                {
+                  "Fn::GetAtt": [
+                    "feedsbucketTESTNewswires116BDB0E",
+                    "Arn",
+                  ],
+                },
+                {
+                  "Fn::Join": [
+                    "",
+                    [
+                      {
+                        "Fn::GetAtt": [
+                          "feedsbucketTESTNewswires116BDB0E",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
             },
             {
               "Action": [

--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -338,6 +338,7 @@ export class Newswires extends GuStack {
 					pollerConfig,
 					ingestionLambdaQueue: props.sourceQueue,
 					alarmSnsTopicName: alarmSnsTopic.topicName,
+					feedsBucket: feedsBucket,
 				}),
 		);
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Follows #400, in preparation for having the fingerpost queueing lambda and the poller lambdas write contents to the feeds bucket for the ingestion lambda to pick up.

Extracting this from a larger branch to make review easier.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Should only be adding new permissions and variables, so not expecting this to make a difference to deployed behaviour.

- [x] Check the snapshot diffs -- is there anything unexpected?

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
