### PR TITLE
Refactor db utils and content processing; add ingestion handler test

### DIFF
--- a/cleanup-lambda/src/handler.ts
+++ b/cleanup-lambda/src/handler.ts
@@ -1,9 +1,9 @@
 import { getErrorMessage } from '../../shared/getErrorMessage';
-import { createDbConnection } from '../../shared/rds';
+import { initialiseDbConnection } from '../../shared/rds';
 import { TABLE_NAME } from './database';
 
 export const main = async (): Promise<void> => {
-	const sql = await createDbConnection();
+	const { sql, closeDbConnection } = await initialiseDbConnection();
 
 	try {
 		const result = await sql`
@@ -16,6 +16,6 @@ export const main = async (): Promise<void> => {
 	} catch (error) {
 		console.error('Error deleting old records:', getErrorMessage(error));
 	} finally {
-		await sql.end();
+		await closeDbConnection();
 	}
 };

--- a/ingestion-lambda/src/categoryCodes.test.ts
+++ b/ingestion-lambda/src/categoryCodes.test.ts
@@ -9,7 +9,7 @@ import {
 	processUnknownFingerpostCategoryCodes,
 	remapReutersCountryCodes,
 } from './categoryCodes';
-import { processCategoryCodes } from './handler';
+import { processCategoryCodes } from './processContentObject';
 
 describe('processReutersDestinationCodes', () => {
 	it('should return formatted custom cat codes for known destinations and ignores the rest', () => {

--- a/ingestion-lambda/src/handler.test.ts
+++ b/ingestion-lambda/src/handler.test.ts
@@ -1,140 +1,228 @@
-import {
-	extractFieldFromString,
-	processKeywords,
-	safeBodyParse,
-} from './handler';
+import type { SQSEvent, SQSRecord } from 'aws-lambda';
+import type postgres from 'postgres';
+import type { Row, RowList } from 'postgres';
+import * as rdsModule from '../../shared/rds';
+import * as s3Module from '../../shared/s3';
+import type { OperationResult } from '../../shared/types';
+import { main } from './handler';
 
-describe('processKeywords', () => {
-	it('should return an empty array if provided with `undefined`', () => {
-		expect(
-			Array.isArray(processKeywords(undefined)) &&
-				processKeywords(undefined).length === 0,
-		).toBe(true);
+type SuccessfulSqlInsertReturnType = RowList<Row[]> | Promise<RowList<Row[]>>;
+
+// mock the s3 sdk module
+jest.mock('../../shared/s3', () => ({
+	getFromS3: jest.fn(),
+	putToS3: jest.fn(),
+	BUCKET_NAME: 'test-bucket',
+}));
+// and the postgres sql module
+jest.mock('../../shared/rds', () => ({
+	initialiseDbConnection: jest.fn(),
+}));
+
+const mockGetFromS3 = s3Module.getFromS3 as jest.MockedFunction<
+	typeof s3Module.getFromS3
+>;
+const mockInitialiseDbConnection =
+	rdsModule.initialiseDbConnection as jest.MockedFunction<
+		typeof rdsModule.initialiseDbConnection
+	>;
+
+const validJsonFromSuccessfulS3: OperationResult<{ body: string }> = {
+	status: 'success',
+	body: JSON.stringify({
+		'source-feed': 'AP-Newswires',
+		slug: 'test-slug',
+	}),
+};
+
+function generateMockSQSRecord({
+	bodyPayload,
+	externalId,
+	messageId = '123',
+}: {
+	bodyPayload: Record<string, string> | string;
+	externalId: string;
+	messageId: string;
+}): SQSRecord {
+	return {
+		messageAttributes: {
+			'Message-Id': {
+				stringValue: externalId,
+			},
+		},
+		messageId,
+		body:
+			typeof bodyPayload === 'string'
+				? bodyPayload
+				: JSON.stringify(bodyPayload),
+	} as unknown as SQSRecord;
+}
+
+describe('handler.main', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		jest.resetAllMocks();
 	});
 
-	it('should return an array of keywords if provided with a string', () => {
-		expect(processKeywords('keyword1+keyword2')).toEqual([
-			'keyword1',
-			'keyword2',
-		]);
-	});
+	it('should process SQS messages and return no batchItemFailures if everything succeeds', async () => {
+		// Mock S3 to return a valid JSON body
+		mockGetFromS3.mockResolvedValue(validJsonFromSuccessfulS3);
 
-	it('should remove duplicates from the array', () => {
-		expect(processKeywords('keyword1+keyword1')).toEqual(['keyword1']);
-	});
-
-	it('should handle empty strings', () => {
-		expect(processKeywords('')).toEqual([]);
-		expect(processKeywords('+')).toEqual([]);
-	});
-
-	it('should strip leading and trailing whitespace', () => {
-		expect(processKeywords(' keyword1 + keyword2 ')).toEqual([
-			'keyword1',
-			'keyword2',
-		]);
-	});
-
-	it('should not remove whitespace within keywords', () => {
-		expect(processKeywords('keyword 1+keyword 2')).toEqual([
-			'keyword 1',
-			'keyword 2',
-		]);
-	});
-
-	it('should handle arrays of strings, removing duplicates and empty strings', () => {
-		expect(processKeywords(['keyword1', 'keyword2', 'keyword1', ''])).toEqual([
-			'keyword1',
-			'keyword2',
-		]);
-	});
-});
-
-describe('safeBodyParse', () => {
-	it('should fix over-escaped characters', () => {
-		const body = `{
-			"version": "1",
-			"firstVersion": "2025-03-13T15:45:04.000Z",
-			"versionCreated": "2025-03-13T15:45:04.000Z",
-			"keywords": "keyword1+keyword2",
-			"body_text": "\\n \\n  <p>test paragraph 1.</p>\\n\\n<p>test paragraph 2. \\u00a0 \\n</p>\\n\\n<p>test paragraph 3.<p>"
-		}`;
-
-		expect(safeBodyParse(body)).toEqual({
-			firstVersion: '2025-03-13T15:45:04.000Z',
-			imageIds: [],
-			keywords: ['keyword1', 'keyword2'],
-			body_text:
-				'<br /><p>test paragraph 1.</p><br /><p>test paragraph 2.   <br /></p><br /><p>test paragraph 3.<p>',
-			version: '1',
-			versionCreated: '2025-03-13T15:45:04.000Z',
+		// Mock database to simulate successful insertion
+		mockInitialiseDbConnection.mockResolvedValue({
+			sql: (() =>
+				Promise.resolve([
+					{ id: 1 },
+				] as unknown as SuccessfulSqlInsertReturnType)) as unknown as postgres.Sql,
+			closeDbConnection: jest.fn(),
 		});
-	});
 
-	it('should fix incorrectly escaped curly quotes in json strings', () => {
-		const body = `{
-			"version": "1",
-			"firstVersion": "2025-03-13T15:45:04.000Z",
-			"versionCreated": "2025-03-13T15:45:04.000Z",
-			"keywords": "keyword1+keyword2",
-			"body_text": "bla \\“bla bla\\”."
-		}`;
-
-		expect(safeBodyParse(body)).toEqual({
-			firstVersion: '2025-03-13T15:45:04.000Z',
-			imageIds: [],
-			keywords: ['keyword1', 'keyword2'],
-			body_text: 'bla “bla bla”.',
-			version: '1',
-			versionCreated: '2025-03-13T15:45:04.000Z',
+		const validSQSRecord: SQSRecord = generateMockSQSRecord({
+			bodyPayload: {
+				slug: 'slug-123',
+			},
+			externalId: 'ext-123',
+			messageId: 'VALID_RECORD_ID',
 		});
+
+		const mockSQSEvent: SQSEvent = {
+			Records: [validSQSRecord],
+		};
+
+		const result = await main(mockSQSEvent);
+
+		expect(result).toBeDefined();
+		expect(result?.batchItemFailures.length).toBe(0);
 	});
 
-	it('should fix unescaped tab literals in json strings', () => {
-		const body = `{
-			"version": "1",
-			"firstVersion": "2025-03-13T15:45:04.000Z",
-			"versionCreated": "2025-03-13T15:45:04.000Z",
-			"keywords": "keyword1+keyword2",
-			"body_text": "bla	bla bla."
-		}`; //             ^
-		// bad char here   |
-		expect(safeBodyParse(body)).toEqual({
-			firstVersion: '2025-03-13T15:45:04.000Z',
-			imageIds: [],
-			keywords: ['keyword1', 'keyword2'],
-			body_text: 'bla bla bla.', // note tab char is now space char
-			version: '1',
-			versionCreated: '2025-03-13T15:45:04.000Z',
+	it('should handle mixed success and failure scenarios', async () => {
+		// Mock database to simulate successful insertion
+		mockInitialiseDbConnection.mockResolvedValue({
+			sql: (() =>
+				Promise.resolve([
+					{ id: 1 },
+				] as unknown as SuccessfulSqlInsertReturnType)) as unknown as postgres.Sql,
+			closeDbConnection: jest.fn(),
 		});
-	});
 
-	it('should fix unescaped newline literals in json strings', () => {
-		const body = `{
-			"version": "1",
-			"firstVersion": "2025-03-13T15:45:04.000Z",
-			"versionCreated": "2025-03-13T15:45:04.000Z",
-			"keywords": "keyword1+keyword2",
-			"body_text": "bla
-bla
-bla."
-		}`;
-		expect(safeBodyParse(body)).toEqual({
-			firstVersion: '2025-03-13T15:45:04.000Z',
-			imageIds: [],
-			keywords: ['keyword1', 'keyword2'],
-			body_text: 'bla bla bla.', // note newline char is now space char
-			version: '1',
-			versionCreated: '2025-03-13T15:45:04.000Z',
+		// Create a valid record and a failing record (missing externalId)
+		const validSQSRecord: SQSRecord = generateMockSQSRecord({
+			bodyPayload: {
+				externalId: 'ext-123',
+				objectKey: 'path/to/object.json',
+			},
+			externalId: 'ext-123',
+			messageId: 'VALID_RECORD_ID',
 		});
+
+		const failingSQSRecord: SQSRecord = generateMockSQSRecord({
+			bodyPayload: '{ invalid json content',
+			externalId: 'ext-failing',
+			messageId: 'FAILING_RECORD_ID',
+		});
+
+		const mockSQSEvent: SQSEvent = {
+			Records: [validSQSRecord, failingSQSRecord],
+		};
+
+		const result = await main(mockSQSEvent);
+
+		expect(result).toBeDefined();
+		expect(result?.batchItemFailures.length).toBe(1);
+		expect(result?.batchItemFailures[0]?.itemIdentifier).toBe(
+			'FAILING_RECORD_ID',
+		);
 	});
-});
 
-describe('extractFieldFromString', () => {
-	it('should extract a field value from broken JSON', () => {
-		const body = `{
-			"slug": "test-slug",`;
+	it('should handle missing external ids', async () => {
+		// Mock database to simulate successful insertion
+		mockInitialiseDbConnection.mockResolvedValue({
+			sql: (() =>
+				Promise.resolve([
+					{ id: 1 },
+				] as unknown as SuccessfulSqlInsertReturnType)) as unknown as postgres.Sql,
+			closeDbConnection: jest.fn(),
+		});
 
-		expect(extractFieldFromString(body, 'slug')).toEqual('test-slug');
+		// Create a valid record and a record that will fail due to invalid JSON from S3
+		const validSQSRecord: SQSRecord = generateMockSQSRecord({
+			bodyPayload: {
+				externalId: 'ext-valid',
+				objectKey: 'path/to/valid-object.json',
+			},
+			externalId: 'ext-valid',
+			messageId: 'VALID_RECORD_ID',
+		});
+
+		const invalidJsonRecord: SQSRecord = generateMockSQSRecord({
+			bodyPayload: {
+				externalId: 'ext-invalid',
+				objectKey: 'path/to/invalid-object.json',
+			},
+			externalId: '',
+			messageId: 'FAILING_RECORD_ID',
+		});
+
+		const mockSQSEvent: SQSEvent = {
+			Records: [validSQSRecord, invalidJsonRecord],
+		};
+
+		const result = await main(mockSQSEvent);
+
+		expect(result).toBeDefined();
+		expect(result?.batchItemFailures.length).toBe(1);
+		expect(result?.batchItemFailures[0]?.itemIdentifier).toBe(
+			'FAILING_RECORD_ID',
+		);
+	});
+
+	it('should handle database writing failures', async () => {
+		// Mock S3 to return valid JSON for both records
+		mockGetFromS3.mockResolvedValue(validJsonFromSuccessfulS3);
+
+		const mockSql = jest.fn();
+		mockSql
+			.mockResolvedValueOnce('table-name') // First call to format table name
+			.mockResolvedValueOnce([{ id: 1 }]) // Second call to insert first item (successful)
+			.mockResolvedValueOnce('table-name') // First call to format table name for the second record
+			.mockRejectedValueOnce(new Error('Database write failed')); // Second call to insert second item (failed)
+
+		// Mock database to simulate successful insertion
+		mockInitialiseDbConnection.mockResolvedValue({
+			sql: mockSql as unknown as postgres.Sql,
+			closeDbConnection: jest.fn(),
+		});
+
+		// Create two valid records that will both pass S3 and processing steps
+		const successRecord: SQSRecord = generateMockSQSRecord({
+			bodyPayload: {
+				externalId: 'ext-success',
+				objectKey: 'path/to/success-object.json',
+			},
+			externalId: 'ext-success',
+			messageId: 'SUCCESS_RECORD_ID',
+		});
+
+		const dbFailRecord: SQSRecord = generateMockSQSRecord({
+			bodyPayload: {
+				externalId: 'ext-db-fail',
+				objectKey: 'path/to/db-fail-object.json',
+			},
+			externalId: 'ext-db-fail',
+			messageId: 'DB_FAIL_RECORD_ID',
+		});
+		const mockSQSEvent: SQSEvent = {
+			Records: [successRecord, dbFailRecord],
+		};
+
+		const result = await main(mockSQSEvent);
+
+		expect(result).toBeDefined();
+		expect(result?.batchItemFailures.length).toBe(1);
+		expect(result?.batchItemFailures[0]?.itemIdentifier).toBe(
+			'DB_FAIL_RECORD_ID',
+		);
+
+		expect(mockSql).toHaveBeenCalledTimes(4); // Each insert operation calls the sql function twice (to format table name and then run the query)
 	});
 });

--- a/ingestion-lambda/src/handler.ts
+++ b/ingestion-lambda/src/handler.ts
@@ -1,62 +1,16 @@
 import type { SESEvent, SQSBatchResponse, SQSEvent } from 'aws-lambda';
 import {
+	FAILED_INGESTION_EVENT_TYPE,
 	INGESTION_PROCESSING_SQS_MESSAGE_EVENT_TYPE,
 	SUCCESSFUL_INGESTION_EVENT_TYPE,
 } from '../../shared/constants';
 import { getErrorMessage } from '../../shared/getErrorMessage';
 import { createLogger } from '../../shared/lambda-logging';
-import { createDbConnection } from '../../shared/rds';
+import { initialiseDbConnection } from '../../shared/rds';
 import { BUCKET_NAME, putToS3 } from '../../shared/s3';
-import type { IngestorInputBody } from '../../shared/types';
-import { IngestorInputBodySchema } from '../../shared/types';
-import {
-	dedupeStrings,
-	inferGBCategoryFromText,
-	inferGeographicalCategoriesFromText,
-	processFingerpostAAPCategoryCodes,
-	processFingerpostAFPCategoryCodes,
-	processFingerpostAPCategoryCodes,
-	processFingerpostPACategoryCodes,
-	processReutersDestinationCodes,
-	processReutersTopicCodes,
-	processUnknownFingerpostCategoryCodes,
-	remapReutersCountryCodes,
-} from './categoryCodes';
-import { cleanBodyTextMarkup } from './cleanMarkup';
+import type { BatchItemFailure, BatchItemResult } from '../../shared/types';
 import { tableName } from './database';
-import { lookupSupplier } from './suppliers';
-
-interface OperationFailure {
-	sqsMessageId: string;
-	status: 'failure';
-	storyIdentifier?: string;
-	reason?: string;
-}
-
-interface OperationSuccess {
-	sqsMessageId: string;
-	status: 'success';
-}
-
-type OperationResult = OperationFailure | OperationSuccess;
-
-const isCurlyQuoteFailure = (e: SyntaxError): boolean => {
-	return !!e.message.match(/Unexpected token '[“‘”’]'/);
-};
-
-const isBadControlChar = (e: SyntaxError): boolean => {
-	return !!e.message.match(/Bad control character in string literal in JSON/);
-};
-
-function cleanAndDedupeKeywords(keywords: string[]): string[] {
-	return [
-		...new Set(
-			keywords
-				.map((keyword) => keyword.trim())
-				.filter((keyword) => keyword.length > 0),
-		),
-	];
-}
+import { processContent } from './processContentObject';
 
 // Retrieve a value from a JSON-like string regardless of its validity.
 export const extractFieldFromString = (
@@ -66,157 +20,6 @@ export const extractFieldFromString = (
 	const regex = new RegExp(`"${targetField}"\\s*:\\s*"([^"]*)"`); // Capture a value from a "key": "value" pattern.
 	const match = input.match(regex);
 	return match ? match[1] : undefined;
-};
-
-export const processKeywords = (
-	keywords: string | string[] | undefined,
-): string[] => {
-	if (keywords === undefined) {
-		return [];
-	}
-	if (Array.isArray(keywords)) {
-		return cleanAndDedupeKeywords(keywords);
-	}
-	return cleanAndDedupeKeywords(keywords.split('+'));
-};
-
-export const processCategoryCodes = (
-	supplier: string,
-	subjectCodes: string[],
-	destinationCodes: string[],
-	bodyText?: string,
-	priority?: string,
-) => {
-	const catCodes: string[] = priority === '1' ? ['HIGH_PRIORITY'] : [];
-	const regionCodes = inferGeographicalCategoriesFromText(bodyText);
-
-	switch (supplier) {
-		case 'REUTERS': {
-			const extractedDestinationCodes =
-				processReutersDestinationCodes(destinationCodes);
-			return [
-				...catCodes,
-				...subjectCodes,
-				...extractedDestinationCodes,
-				...processReutersTopicCodes(subjectCodes, extractedDestinationCodes),
-				...regionCodes,
-				...remapReutersCountryCodes(subjectCodes),
-			];
-		}
-		case 'AP':
-			return [
-				...catCodes,
-				...processFingerpostAPCategoryCodes(subjectCodes),
-				...regionCodes,
-			];
-		case 'AAP':
-			return [
-				...catCodes,
-				...processFingerpostAAPCategoryCodes(subjectCodes),
-				...regionCodes,
-			];
-		case 'AFP':
-			return [
-				...catCodes,
-				...processFingerpostAFPCategoryCodes(subjectCodes),
-				...regionCodes,
-			];
-		case 'PA':
-			return [...catCodes, ...processFingerpostPACategoryCodes(subjectCodes)];
-		case 'MINOR_AGENCIES': {
-			const updatedSubjectCodes = [
-				...subjectCodes,
-				...catCodes,
-				...regionCodes,
-				...inferGBCategoryFromText(bodyText),
-			];
-			return updatedSubjectCodes.filter((_) => _.length > 0);
-		}
-		default:
-			return [
-				...catCodes,
-				...processUnknownFingerpostCategoryCodes(subjectCodes, supplier),
-				...regionCodes,
-			];
-	}
-};
-
-export const decodeBodyTextContent = (
-	text: string | undefined,
-): string | undefined =>
-	text
-		?.replace(
-			/\\u([0-9a-fA-F]{4})/g,
-			(_: string, hex: string) => String.fromCharCode(parseInt(hex, 16)), // Replace Unicode escape sequences, e.g. \u00a0 → non-breaking space.
-		)
-		.replace(/\\([\\nrt"'])/g, (_: string, group1: string) => {
-			switch (group1) {
-				case 'n':
-					return '\n';
-				case 'r':
-					return '\r';
-				case 't':
-					return '\t';
-				default:
-					return group1;
-			}
-		})
-		.replace(/(?:\n\s*)+/g, '<br />'); // Replaces consecutive newlines (and spaces) with one <br />.
-
-export const safeJsonParse = (body: string): Record<string, unknown> => {
-	try {
-		return JSON.parse(body) as Record<string, unknown>;
-	} catch (e) {
-		if (e instanceof SyntaxError && isCurlyQuoteFailure(e)) {
-			console.warn('Stripping badly escaped curly quote');
-			// naïve regex to delete a backslash before a curly quote - isn't a fully correct solution.
-			// what if a string had 2 backslashes then a curly quote? that would be a correct string, that
-			// we'd make incorrect by deleting the second backslash. We could fix that, but then what about
-			// 3 backslashes then a curly quote? etc. infinitely
-			// Generally it seems pretty unlikely that text would include literal backslashes before curly quotes,
-			// if we start finding some then we should investigate improvements...
-			//
-			// I got to this monstrosity:
-			//   .replaceAll(/(?<![^\\]\\(?:\\\\)*)\\(?!["\\/bfnrt]|u[0-9A-Fa-f]{4})/g, '')
-			//
-			// which looks like it should delete all illegal backslashes in a JSON string, but haven't rigorously tested it...
-			return JSON.parse(body.replaceAll(/\\([“‘”’])/g, '$1')) as Record<
-				string,
-				unknown
-			>;
-		}
-		if (e instanceof SyntaxError && isBadControlChar(e)) {
-			console.warn('Attempting to strip unescaped tab chars');
-			// technically, the bad control char warning could appear for any control char that remains unescaped
-			// inside a JSON string; but in practice we've only seen this for tab and newline characters so far. If
-			// other control chars start appearing, this will start firing again, but we'll have to think carefully
-			// about how we strip since this replace will affect all locations in the JSON document, not just inside
-			// string literals.
-			return JSON.parse(body.replaceAll(/[\t\r\n]/g, ' ')) as Record<
-				string,
-				unknown
-			>;
-		}
-		throw e;
-	}
-};
-
-export const safeBodyParse = (body: string): IngestorInputBody => {
-	const json = safeJsonParse(body);
-
-	const preprocessedKeywords = processKeywords(
-		json.keywords as string | string[] | undefined,
-	); // if it's not one of these, we probably want to throw an error
-
-	const preprocessedBodyTextContent = decodeBodyTextContent(
-		json.body_text as string | undefined,
-	);
-
-	return IngestorInputBodySchema.parse({
-		...json,
-		body_text: preprocessedBodyTextContent,
-		keywords: preprocessedKeywords,
-	});
 };
 
 function isSESEvent(event: SQSEvent | SESEvent): event is SESEvent {
@@ -235,7 +38,7 @@ export const main = async (
 
 	const records = event.Records;
 
-	const sql = await createDbConnection();
+	const { sql, closeDbConnection } = await initialiseDbConnection();
 
 	try {
 		console.log(`Processing ${records.length} messages`);
@@ -246,7 +49,7 @@ export const main = async (
 					messageId: sqsMessageId,
 					messageAttributes,
 					body,
-				}): Promise<OperationResult> => {
+				}): Promise<BatchItemResult> => {
 					logger.log({
 						message: `Processing message for ${sqsMessageId}`,
 						eventType: INGESTION_PROCESSING_SQS_MESSAGE_EVENT_TYPE,
@@ -277,28 +80,17 @@ export const main = async (
 							body,
 						});
 
-						const snsMessageContent = safeBodyParse(body);
+						const processedObjectResult = processContent(body);
 
-						const content = {
-							...snsMessageContent,
-							body_text: cleanBodyTextMarkup(
-								snsMessageContent.body_text ?? '',
-								logger,
-							),
-						};
+						if (processedObjectResult.status === 'failure') {
+							return {
+								status: 'failure',
+								reason: processedObjectResult.reason,
+								sqsMessageId,
+							};
+						}
 
-						const supplier =
-							lookupSupplier(content['source-feed']) ?? 'Unknown';
-
-						const categoryCodes = dedupeStrings(
-							processCategoryCodes(
-								supplier,
-								content.subjects?.code ?? [],
-								content.destinations?.code ?? [],
-								`${content.headline ?? ''} ${content.abstract ?? ''} ${content.body_text}`,
-								content.priority,
-							),
-						);
+						const { supplier, content, categoryCodes } = processedObjectResult;
 
 						const result = await sql`
                             INSERT INTO ${sql(tableName)}
@@ -324,27 +116,30 @@ export const main = async (
 						}
 					} catch (e) {
 						const reason = getErrorMessage(e);
+						const storyIdentifier =
+							extractFieldFromString(body, 'slug') ?? 'unknown slug';
 						return {
 							status: 'failure',
-							reason,
+							reason: `Failed to process message for ${sqsMessageId} (${storyIdentifier}): ${reason}`,
 							sqsMessageId,
-							storyIdentifier: extractFieldFromString(body, 'slug'),
 						};
 					}
 
-					return { sqsMessageId, status: 'success' };
+					return { status: 'success' };
 				},
 			),
 		);
 
 		const batchItemFailures = results
 			.filter(
-				(result): result is OperationFailure => result.status === 'failure',
+				(result): result is BatchItemFailure => result.status === 'failure',
 			)
-			.map(({ sqsMessageId, storyIdentifier, reason }) => {
-				console.error(
-					`Failed to process message for ${sqsMessageId}${storyIdentifier ? ` (${storyIdentifier})` : ''}: ${reason}`,
-				);
+			.map(({ sqsMessageId, reason }) => {
+				console.error({
+					sqsMessageId,
+					message: reason,
+					eventType: FAILED_INGESTION_EVENT_TYPE,
+				});
 				return { itemIdentifier: sqsMessageId };
 			});
 
@@ -354,6 +149,6 @@ export const main = async (
 
 		return { batchItemFailures };
 	} finally {
-		await sql.end();
+		await closeDbConnection();
 	}
 };

--- a/ingestion-lambda/src/processContentObject.test.ts
+++ b/ingestion-lambda/src/processContentObject.test.ts
@@ -1,0 +1,140 @@
+import {
+	extractFieldFromString,
+	processKeywords,
+	safeBodyParse,
+} from './processContentObject';
+
+describe('processKeywords', () => {
+	it('should return an empty array if provided with `undefined`', () => {
+		expect(
+			Array.isArray(processKeywords(undefined)) &&
+				processKeywords(undefined).length === 0,
+		).toBe(true);
+	});
+
+	it('should return an array of keywords if provided with a string', () => {
+		expect(processKeywords('keyword1+keyword2')).toEqual([
+			'keyword1',
+			'keyword2',
+		]);
+	});
+
+	it('should remove duplicates from the array', () => {
+		expect(processKeywords('keyword1+keyword1')).toEqual(['keyword1']);
+	});
+
+	it('should handle empty strings', () => {
+		expect(processKeywords('')).toEqual([]);
+		expect(processKeywords('+')).toEqual([]);
+	});
+
+	it('should strip leading and trailing whitespace', () => {
+		expect(processKeywords(' keyword1 + keyword2 ')).toEqual([
+			'keyword1',
+			'keyword2',
+		]);
+	});
+
+	it('should not remove whitespace within keywords', () => {
+		expect(processKeywords('keyword 1+keyword 2')).toEqual([
+			'keyword 1',
+			'keyword 2',
+		]);
+	});
+
+	it('should handle arrays of strings, removing duplicates and empty strings', () => {
+		expect(processKeywords(['keyword1', 'keyword2', 'keyword1', ''])).toEqual([
+			'keyword1',
+			'keyword2',
+		]);
+	});
+});
+
+describe('safeBodyParse', () => {
+	it('should fix over-escaped characters', () => {
+		const body = `{
+			"version": "1",
+			"firstVersion": "2025-03-13T15:45:04.000Z",
+			"versionCreated": "2025-03-13T15:45:04.000Z",
+			"keywords": "keyword1+keyword2",
+			"body_text": "\\n \\n  <p>test paragraph 1.</p>\\n\\n<p>test paragraph 2. \\u00a0 \\n</p>\\n\\n<p>test paragraph 3.<p>"
+		}`;
+
+		expect(safeBodyParse(body)).toEqual({
+			firstVersion: '2025-03-13T15:45:04.000Z',
+			imageIds: [],
+			keywords: ['keyword1', 'keyword2'],
+			body_text:
+				'<br /><p>test paragraph 1.</p><br /><p>test paragraph 2.   <br /></p><br /><p>test paragraph 3.<p>',
+			version: '1',
+			versionCreated: '2025-03-13T15:45:04.000Z',
+		});
+	});
+
+	it('should fix incorrectly escaped curly quotes in json strings', () => {
+		const body = `{
+			"version": "1",
+			"firstVersion": "2025-03-13T15:45:04.000Z",
+			"versionCreated": "2025-03-13T15:45:04.000Z",
+			"keywords": "keyword1+keyword2",
+			"body_text": "bla \\“bla bla\\”."
+		}`;
+
+		expect(safeBodyParse(body)).toEqual({
+			firstVersion: '2025-03-13T15:45:04.000Z',
+			imageIds: [],
+			keywords: ['keyword1', 'keyword2'],
+			body_text: 'bla “bla bla”.',
+			version: '1',
+			versionCreated: '2025-03-13T15:45:04.000Z',
+		});
+	});
+
+	it('should fix unescaped tab literals in json strings', () => {
+		const body = `{
+			"version": "1",
+			"firstVersion": "2025-03-13T15:45:04.000Z",
+			"versionCreated": "2025-03-13T15:45:04.000Z",
+			"keywords": "keyword1+keyword2",
+			"body_text": "bla	bla bla."
+		}`; //             ^
+		// bad char here   |
+		expect(safeBodyParse(body)).toEqual({
+			firstVersion: '2025-03-13T15:45:04.000Z',
+			imageIds: [],
+			keywords: ['keyword1', 'keyword2'],
+			body_text: 'bla bla bla.', // note tab char is now space char
+			version: '1',
+			versionCreated: '2025-03-13T15:45:04.000Z',
+		});
+	});
+
+	it('should fix unescaped newline literals in json strings', () => {
+		const body = `{
+			"version": "1",
+			"firstVersion": "2025-03-13T15:45:04.000Z",
+			"versionCreated": "2025-03-13T15:45:04.000Z",
+			"keywords": "keyword1+keyword2",
+			"body_text": "bla
+bla
+bla."
+		}`;
+		expect(safeBodyParse(body)).toEqual({
+			firstVersion: '2025-03-13T15:45:04.000Z',
+			imageIds: [],
+			keywords: ['keyword1', 'keyword2'],
+			body_text: 'bla bla bla.', // note newline char is now space char
+			version: '1',
+			versionCreated: '2025-03-13T15:45:04.000Z',
+		});
+	});
+});
+
+describe('extractFieldFromString', () => {
+	it('should extract a field value from broken JSON', () => {
+		const body = `{
+			"slug": "test-slug",`;
+
+		expect(extractFieldFromString(body, 'slug')).toEqual('test-slug');
+	});
+});

--- a/ingestion-lambda/src/processContentObject.ts
+++ b/ingestion-lambda/src/processContentObject.ts
@@ -1,0 +1,239 @@
+import { getErrorMessage } from '../../shared/getErrorMessage';
+import type {
+	IngestorInputBody,
+	OperationResult,
+	ProcessedObject,
+} from '../../shared/types';
+import { IngestorInputBodySchema } from '../../shared/types';
+import {
+	dedupeStrings,
+	inferGBCategoryFromText,
+	inferGeographicalCategoriesFromText,
+	processFingerpostAAPCategoryCodes,
+	processFingerpostAFPCategoryCodes,
+	processFingerpostAPCategoryCodes,
+	processFingerpostPACategoryCodes,
+	processReutersDestinationCodes,
+	processReutersTopicCodes,
+	processUnknownFingerpostCategoryCodes,
+	remapReutersCountryCodes,
+} from './categoryCodes';
+import { cleanBodyTextMarkup } from './cleanMarkup';
+import { lookupSupplier } from './suppliers';
+
+const isCurlyQuoteFailure = (e: SyntaxError): boolean => {
+	return !!e.message.match(/Unexpected token '[“‘”’]'/);
+};
+
+const isBadControlChar = (e: SyntaxError): boolean => {
+	return !!e.message.match(/Bad control character in string literal in JSON/);
+};
+
+function cleanAndDedupeKeywords(keywords: string[]): string[] {
+	return [
+		...new Set(
+			keywords
+				.map((keyword) => keyword.trim())
+				.filter((keyword) => keyword.length > 0),
+		),
+	];
+}
+
+// Retrieve a value from a JSON-like string regardless of its validity.
+export const extractFieldFromString = (
+	input: string,
+	targetField: string,
+): string | undefined => {
+	const regex = new RegExp(`"${targetField}"\\s*:\\s*"([^"]*)"`); // Capture a value from a "key": "value" pattern.
+	const match = input.match(regex);
+	return match ? match[1] : undefined;
+};
+
+export const processKeywords = (
+	keywords: string | string[] | undefined,
+): string[] => {
+	if (keywords === undefined) {
+		return [];
+	}
+	if (Array.isArray(keywords)) {
+		return cleanAndDedupeKeywords(keywords);
+	}
+	return cleanAndDedupeKeywords(keywords.split('+'));
+};
+
+export const processCategoryCodes = (
+	supplier: string,
+	subjectCodes: string[],
+	destinationCodes: string[],
+	bodyText?: string,
+	priority?: string,
+) => {
+	const catCodes: string[] = priority === '1' ? ['HIGH_PRIORITY'] : [];
+	const regionCodes = inferGeographicalCategoriesFromText(bodyText);
+
+	switch (supplier) {
+		case 'REUTERS': {
+			const extractedDestinationCodes =
+				processReutersDestinationCodes(destinationCodes);
+			return [
+				...catCodes,
+				...subjectCodes,
+				...extractedDestinationCodes,
+				...processReutersTopicCodes(subjectCodes, extractedDestinationCodes),
+				...regionCodes,
+				...remapReutersCountryCodes(subjectCodes),
+			];
+		}
+		case 'AP':
+			return [
+				...catCodes,
+				...processFingerpostAPCategoryCodes(subjectCodes),
+				...regionCodes,
+			];
+		case 'AAP':
+			return [
+				...catCodes,
+				...processFingerpostAAPCategoryCodes(subjectCodes),
+				...regionCodes,
+			];
+		case 'AFP':
+			return [
+				...catCodes,
+				...processFingerpostAFPCategoryCodes(subjectCodes),
+				...regionCodes,
+			];
+		case 'PA':
+			return [...catCodes, ...processFingerpostPACategoryCodes(subjectCodes)];
+		case 'MINOR_AGENCIES': {
+			const updatedSubjectCodes = [
+				...subjectCodes,
+				...catCodes,
+				...regionCodes,
+				...inferGBCategoryFromText(bodyText),
+			];
+			return updatedSubjectCodes.filter((_) => _.length > 0);
+		}
+		default:
+			return [
+				...catCodes,
+				...processUnknownFingerpostCategoryCodes(subjectCodes, supplier),
+				...regionCodes,
+			];
+	}
+};
+
+export const decodeBodyTextContent = (
+	text: string | undefined,
+): string | undefined =>
+	text
+		?.replace(
+			/\\u([0-9a-fA-F]{4})/g,
+			(_: string, hex: string) => String.fromCharCode(parseInt(hex, 16)), // Replace Unicode escape sequences, e.g. \u00a0 → non-breaking space.
+		)
+		.replace(/\\([\\nrt"'])/g, (_: string, group1: string) => {
+			switch (group1) {
+				case 'n':
+					return '\n';
+				case 'r':
+					return '\r';
+				case 't':
+					return '\t';
+				default:
+					return group1;
+			}
+		})
+		.replace(/(?:\n\s*)+/g, '<br />'); // Replaces consecutive newlines (and spaces) with one <br />.
+
+export const safeJsonParse = (body: string): Record<string, unknown> => {
+	try {
+		return JSON.parse(body) as Record<string, unknown>;
+	} catch (e) {
+		if (e instanceof SyntaxError && isCurlyQuoteFailure(e)) {
+			console.warn('Stripping badly escaped curly quote');
+			// naïve regex to delete a backslash before a curly quote - isn't a fully correct solution.
+			// what if a string had 2 backslashes then a curly quote? that would be a correct string, that
+			// we'd make incorrect by deleting the second backslash. We could fix that, but then what about
+			// 3 backslashes then a curly quote? etc. infinitely
+			// Generally it seems pretty unlikely that text would include literal backslashes before curly quotes,
+			// if we start finding some then we should investigate improvements...
+			//
+			// I got to this monstrosity:
+			//   .replaceAll(/(?<![^\\]\\(?:\\\\)*)\\(?!["\\/bfnrt]|u[0-9A-Fa-f]{4})/g, '')
+			//
+			// which looks like it should delete all illegal backslashes in a JSON string, but haven't rigorously tested it...
+			return JSON.parse(body.replaceAll(/\\([“‘”’])/g, '$1')) as Record<
+				string,
+				unknown
+			>;
+		}
+		if (e instanceof SyntaxError && isBadControlChar(e)) {
+			console.warn('Attempting to strip unescaped tab chars');
+			// technically, the bad control char warning could appear for any control char that remains unescaped
+			// inside a JSON string; but in practice we've only seen this for tab and newline characters so far. If
+			// other control chars start appearing, this will start firing again, but we'll have to think carefully
+			// about how we strip since this replace will affect all locations in the JSON document, not just inside
+			// string literals.
+			return JSON.parse(body.replaceAll(/[\t\r\n]/g, ' ')) as Record<
+				string,
+				unknown
+			>;
+		}
+		throw e;
+	}
+};
+
+export const safeBodyParse = (body: string): IngestorInputBody => {
+	const json = safeJsonParse(body);
+
+	const preprocessedKeywords = processKeywords(
+		json.keywords as string | string[] | undefined,
+	); // if it's not one of these, we probably want to throw an error
+
+	const preprocessedBodyTextContent = decodeBodyTextContent(
+		json.body_text as string | undefined,
+	);
+
+	return IngestorInputBodySchema.parse({
+		...json,
+		body_text: preprocessedBodyTextContent,
+		keywords: preprocessedKeywords,
+	});
+};
+
+export function processContent(body: string): OperationResult<ProcessedObject> {
+	try {
+		const parsedContent = safeBodyParse(body);
+
+		const content = {
+			...parsedContent,
+			body_text: cleanBodyTextMarkup(parsedContent.body_text ?? ''),
+		};
+
+		const supplier = lookupSupplier(content['source-feed']) ?? 'Unknown';
+
+		const categoryCodes = dedupeStrings(
+			processCategoryCodes(
+				supplier,
+				content.subjects?.code ?? [],
+				content.destinations?.code ?? [],
+				`${content.headline ?? ''} ${content.abstract ?? ''} ${content.body_text}`,
+				content.priority,
+			),
+		);
+		return {
+			status: 'success' as const,
+			content,
+			supplier,
+			categoryCodes,
+		};
+	} catch (error) {
+		const errorMessage = getErrorMessage(error);
+		return {
+			status: 'failure' as const,
+			reason: `Error processing message for (storyIdentifier: ${extractFieldFromString(
+				body,
+				'slug',
+			)}): ${errorMessage}`,
+		};
+	}
+}

--- a/shared/rds.ts
+++ b/shared/rds.ts
@@ -24,11 +24,11 @@ const sharedConfig = {
 
 const signer = new Signer(sharedConfig);
 
-export async function createDbConnection() {
+export async function initialiseDbConnection() {
 	const token = isRunningLocally ? 'postgres' : await signer.getAuthToken();
 	const ssl = isRunningLocally ? 'prefer' : 'require';
 
-	return postgres({
+	const sql = postgres({
 		...sharedConfig,
 		database: DATABASE_NAME,
 		password: token,
@@ -36,4 +36,12 @@ export async function createDbConnection() {
 		idle_timeout: 10,
 		max_lifetime: 60 * 15, // todo -- import from cdk max lambda timeout config?
 	});
+
+	async function closeDbConnection() {
+		await sql.end();
+	}
+	return {
+		sql,
+		closeDbConnection,
+	};
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Extract the main wire item processing functionality from the body of the handler, and put it in `processContentObject.ts` (along with the various supporting functions)
- Slightly refactor the db connection export from `rds.ts` to make it easier to mock
- Add tests to cover the main branches of the ingestion-lambda handler. Move pre-existing content processing tests from `handler.test.ts` to `processContentObject.test.ts`

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Deploy to CODE, check that ingestion continues to work as expected
- [x] Read and run the new unit tests

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
