### PR TITLE
Need to vary the composer host to match the stage!

### DIFF
--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -109,7 +109,8 @@ class QueryController(
       }
     }
 
-  private val host = configuration.get[String]("host")
+  private val newswiresHost = configuration.get[String]("host")
+  private val composerHost = newswiresHost.replace("newswires", "composer")
 
   def getIncopyImportUrl(id: Int): Action[AnyContent] = apiAuthAction {
     request: UserRequest[AnyContent] =>
@@ -123,7 +124,7 @@ class QueryController(
           val serialised = entry.asJson.spaces2
           val compressedEncodedEntry =
             Base64Encoder.compressAndEncode(serialised)
-          Ok(s"newswires://$host?data=$compressedEncodedEntry")
+          Ok(s"newswires://$newswiresHost?data=$compressedEncodedEntry")
         case None => NotFound
       }
   }
@@ -134,9 +135,10 @@ class QueryController(
         .flatMap(_.asOpt[ComposerLinkRequest])
         .map(params =>
           ToolLink.insertComposerLink(
-            id,
-            params.composerId,
-            request.user.username,
+            newswiresId = id,
+            composerId = params.composerId,
+            composerHost = composerHost,
+            sentBy = request.user.username,
             sentAt = Instant.now()
           )
         ) match {

--- a/newswires/app/db/ToolLink.scala
+++ b/newswires/app/db/ToolLink.scala
@@ -60,11 +60,12 @@ object ToolLink extends SQLSyntaxSupport[ToolLink] {
   def insertComposerLink(
       newswiresId: Int,
       composerId: String,
+      composerHost: String,
       sentBy: String,
       sentAt: Instant
   ): Int = DB localTx { implicit session =>
     val composerUrl =
-      s"https://composer.code.dev-gutools.co.uk/content/$composerId"
+      s"https://$composerHost/content/$composerId"
     val tl = ToolLink.column
     sql"""| INSERT INTO $table
           |  (${tl.wireId}, ${tl.tool}, ${tl.sentBy}, ${tl.sentAt}, ${tl.ref})


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Oversight in #382  - I forgot to come back and fix where I'd hardcoded composer's CODE domain on insertion to the new database 🤦 

Come back and do it quickly, hopefully before anyone notices.

## How to test

Hard to see the fix on CODE, since it already was storing the right URL... At most checking that it hasn't caused a regression should be enough.
