### PR TITLE
Cleanup lambda deletes old tool links

### DIFF
--- a/cleanup-lambda/src/handler.ts
+++ b/cleanup-lambda/src/handler.ts
@@ -1,15 +1,25 @@
-import { DATABASE_TABLE_NAME } from '../../shared/constants';
+import {
+	DATABASE_TABLE_NAME,
+	TOOL_LINK_TABLE_NAME,
+} from '../../shared/constants';
 import { getErrorMessage } from '../../shared/getErrorMessage';
 import { initialiseDbConnection } from '../../shared/rds';
 
 export const main = async (): Promise<void> => {
 	const { sql, closeDbConnection } = await initialiseDbConnection();
 	try {
+		// delete wire and any associated tool links
 		const result = await sql`
-            DELETE
-            FROM ${sql(DATABASE_TABLE_NAME)}
-            WHERE ingested_at < NOW() - INTERVAL '14 days';
-        `;
+			WITH deleted_wire AS (
+				DELETE FROM ${sql(DATABASE_TABLE_NAME)}
+				WHERE ingested_at < NOW() - INTERVAL '14 days'
+				RETURNING id
+			)
+			DELETE FROM ${sql(TOOL_LINK_TABLE_NAME)}
+			WHERE wire_id IN (
+				SELECT id FROM deleted_wire
+			);
+		`;
 
 		console.log(`Deleted ${result.count} records`);
 	} catch (error) {

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -11,3 +11,4 @@ export const POLLER_FAILURE_EVENT_TYPE = 'POLLER_FAILURE';
 export const POLLER_INVOCATION_EVENT_TYPE = 'POLLER_INVOCATION';
 
 export const DATABASE_TABLE_NAME = 'fingerpost_wire_entry';
+export const TOOL_LINK_TABLE_NAME = 'tool_link';


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Updates the cleanup lambda to also find and delete tool links. Uses "common table expression" (ie. a with-statement) to only delete those links associated with wires that have been deleted in the same run.

## How to test

A bit tough - easiest way is possibly to find the oldest stories in CODE and send to composer, then run the cleanup lambda manually (ie. before its next run scheduled at 5am) and check that the wire and link have both been removed.

- [ ] done
