### PR TITLE
Add git commit id to telemetry payload

### DIFF
--- a/newswires/app/controllers/ViteController.scala
+++ b/newswires/app/controllers/ViteController.scala
@@ -19,7 +19,8 @@ import scala.io.Source
 case class ClientConfig(
     switches: Map[String, Boolean],
     stage: String,
-    sendTelemetryAsDev: Boolean
+    sendTelemetryAsDev: Boolean,
+    gitCommitId: String = buildinfo.BuildInfo.gitCommitId
 )
 
 object ClientConfig {

--- a/newswires/client/src/app-configuration.ts
+++ b/newswires/client/src/app-configuration.ts
@@ -15,6 +15,7 @@ const configLookup: AppConfiguration = isJest
 			},
 			stage: 'test',
 			sendTelemetryAsDev: true,
+			gitCommitId: 'test-commit-id',
 		}
 	: window.configuration;
 
@@ -27,3 +28,5 @@ export const SUPPLIERS_TO_EXCLUDE = showGuSuppliers
 export const STAGE = configLookup.stage;
 
 export const SEND_TELEMETRY_AS_DEV = configLookup.sendTelemetryAsDev;
+
+export const GIT_COMMIT_ID = configLookup.gitCommitId;

--- a/newswires/client/src/main.tsx
+++ b/newswires/client/src/main.tsx
@@ -1,6 +1,10 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { SEND_TELEMETRY_AS_DEV, STAGE } from './app-configuration.ts';
+import {
+	GIT_COMMIT_ID,
+	SEND_TELEMETRY_AS_DEV,
+	STAGE,
+} from './app-configuration.ts';
 import { App } from './App.tsx';
 import { KeyboardShortcutsProvider } from './context/KeyboardShortcutsContext.tsx';
 import { SearchContextProvider } from './context/SearchContext.tsx';
@@ -9,10 +13,11 @@ import { UserSettingsContextProvider } from './context/UserSettingsContext.tsx';
 import './icons';
 import { createTelemetryEventSender } from './telemetry.ts';
 
-const { sendTelemetryEvent } = createTelemetryEventSender(
-	STAGE,
-	SEND_TELEMETRY_AS_DEV,
-);
+const { sendTelemetryEvent } = createTelemetryEventSender({
+	stage: STAGE,
+	sendTelemetryAsDev: SEND_TELEMETRY_AS_DEV,
+	gitCommitId: GIT_COMMIT_ID,
+});
 
 const toolsDomain = window.location.hostname.substring(
 	window.location.hostname.indexOf('.'),

--- a/newswires/client/src/telemetry.ts
+++ b/newswires/client/src/telemetry.ts
@@ -16,10 +16,15 @@ export function getTelemetryUrl(stage: string): string {
 	return `https://user-telemetry.${telemetryDomain}`;
 }
 
-export const createTelemetryEventSender = (
-	stage: string,
-	sendTelemetryAsDev: boolean,
-) => {
+export const createTelemetryEventSender = ({
+	stage,
+	sendTelemetryAsDev,
+	gitCommitId,
+}: {
+	stage: string;
+	sendTelemetryAsDev: boolean;
+	gitCommitId: string;
+}) => {
 	const telemetryUrl = getTelemetryUrl(stage);
 	const telemetryEventService = new UserTelemetryEventSender(telemetryUrl, 100);
 
@@ -39,6 +44,7 @@ export const createTelemetryEventSender = (
 			app: 'newswires',
 			stage: stage,
 			eventTime: new Date().toISOString(),
+			gitCommitId,
 			type,
 			value,
 			tags: { ...tags, browserUUID, isDevUser },

--- a/newswires/client/src/windowConfigType.ts
+++ b/newswires/client/src/windowConfigType.ts
@@ -6,6 +6,7 @@ export interface AppConfiguration {
 	switches: FeatureSwitches;
 	stage: string;
 	sendTelemetryAsDev: boolean;
+	gitCommitId: string;
 }
 
 declare global {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Passes the git commit id of the server-side build through to the client, so that it can be included in telemetry events.

The aim is to allow us to more easily work out which code was being executed at the time the telemetry was sent, e.g. to more easily monitor how changes might affect performance (see e.g. #422)

**nb.** One important limitation here is that the commit id in the telemetry will be the id that was sent from the server _when the page was loaded_. Therefore we should expect it to be accurate for determining which client build was running when the telemetry event was sent, but it is _not_ guaranteed to match the build running on the server at that time. And if the user has a long-running tab open that hasn't been refreshed, the two might get out of sync.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
