### PR TITLE
Use checkbox styling for supplier filters

### DIFF
--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -12,6 +12,7 @@ import {
 	EuiText,
 	EuiTitle,
 	useEuiMinBreakpoint,
+	useEuiTheme,
 	useIsWithinBreakpoints,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
@@ -54,6 +55,7 @@ export const SideNav = ({ navIsDocked }: { navIsDocked: boolean }) => {
 	const largeMinBreakpoint = useEuiMinBreakpoint('l');
 	const isLargeScreen = useIsWithinBreakpoints(['l']);
 	const isExtraSmallScreen = useIsWithinBreakpoints(['xs']);
+	const theme = useEuiTheme();
 
 	const {
 		state,
@@ -86,7 +88,7 @@ export const SideNav = ({ navIsDocked }: { navIsDocked: boolean }) => {
 	const suppliers = useMemo(
 		() => [
 			{
-				label: 'All',
+				label: 'All suppliers',
 				isActive:
 					activeSuppliers.length === 0 ||
 					activeSuppliers.length === recognisedSuppliers.length,
@@ -132,12 +134,14 @@ export const SideNav = ({ navIsDocked }: { navIsDocked: boolean }) => {
 				iconType: () => (
 					<div
 						css={css`
-							width: 0.5rem;
-							height: 1.5rem;
+							width: 1rem;
+							height: 1rem;
+							border-radius: 50%;
 
 							margin-right: 12px;
+							border: 2px solid ${theme.euiTheme.colors.primary};
 							background-color: ${isActive
-								? 'rgb(0, 119, 204)'
+								? theme.euiTheme.colors.primary
 								: 'transparent'};
 						`}
 					/>
@@ -155,24 +159,58 @@ export const SideNav = ({ navIsDocked }: { navIsDocked: boolean }) => {
 				},
 			};
 		}) as EuiPinnableListGroupItemProps[];
-	}, [activePreset, config, handleEnterQuery, openTicker]);
+	}, [
+		activePreset,
+		config,
+		handleEnterQuery,
+		openTicker,
+		theme.euiTheme.colors.primary,
+	]);
 
 	const supplierItems: EuiPinnableListGroupItemProps[] = suppliers.map(
-		({ label, colour, isActive, onClick, onTickerClick }) => ({
+		({ label, colour, isActive, onClick, onTickerClick }, index) => ({
 			id: label,
 			label,
 			onClick,
 			isActive,
 			iconType: () => (
-				<div
-					css={css`
-						width: 0.5rem;
-						height: 1.5rem;
+				<>
+					{index > 0 && (
+						<div
+							css={css`
+								width: calc(12px + 1rem);
+							`}
+						></div>
+					)}
+					<div
+						css={css`
+							width: 1rem;
+							height: 1rem;
 
-						margin-right: 12px;
-						background-color: ${isActive ? colour : 'transparent'};
-					`}
-				/>
+							margin-right: 12px;
+							border: 2px solid ${colour};
+							color: ${isActive ? 'white' : 'transparent'};
+							background-color: ${isActive ? colour : 'transparent'};
+							display: flex;
+							align-items: center;
+							justify-content: center;
+						`}
+					>
+						<svg
+							viewBox="0 0 24 24"
+							width="100%"
+							height="100%"
+							stroke="currentColor"
+							strokeWidth="5"
+							fill="none"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+							className="css-i6dzq1"
+						>
+							<polyline points="20 6 9 17 4 12"></polyline>
+						</svg>
+					</div>
+				</>
 			),
 			color: isActive ? 'primary' : 'subdued',
 			pinnable: false,
@@ -257,7 +295,7 @@ export const SideNav = ({ navIsDocked }: { navIsDocked: boolean }) => {
 							listItems={presetItems}
 							maxWidth="none"
 							color="subdued"
-							gutterSize="s"
+							gutterSize="none"
 							size="s"
 						/>
 					</EuiCollapsibleNavGroup>
@@ -267,7 +305,7 @@ export const SideNav = ({ navIsDocked }: { navIsDocked: boolean }) => {
 							listItems={supplierItems}
 							maxWidth="none"
 							color="subdued"
-							gutterSize="s"
+							gutterSize="none"
 							size="s"
 						/>
 					</EuiCollapsibleNavGroup>
@@ -298,7 +336,7 @@ export const SideNav = ({ navIsDocked }: { navIsDocked: boolean }) => {
 					</EuiCollapsibleNavGroup>
 				</div>
 
-				<div style={{ padding: '20px 10px' }}>
+				<div style={{ padding: '10px 5px' }}>
 					<EuiSwitch
 						label="Auto-update"
 						checked={state.autoUpdate}

--- a/newswires/client/src/icons.ts
+++ b/newswires/client/src/icons.ts
@@ -11,6 +11,8 @@ import { icon as boxesHorizontal } from '@elastic/eui/es/components/icon/assets/
 import { icon as boxesVertical } from '@elastic/eui/es/components/icon/assets/boxes_vertical';
 import { icon as calendar } from '@elastic/eui/es/components/icon/assets/calendar';
 import { icon as check } from '@elastic/eui/es/components/icon/assets/check';
+import { icon as checkCircle } from '@elastic/eui/es/components/icon/assets/checkCircle';
+import { icon as checkInCircleFilled } from '@elastic/eui/es/components/icon/assets/checkInCircleFilled';
 import { icon as clock } from '@elastic/eui/es/components/icon/assets/clock';
 import { icon as copyClipboard } from '@elastic/eui/es/components/icon/assets/copy_clipboard';
 import { icon as cross } from '@elastic/eui/es/components/icon/assets/cross';
@@ -80,6 +82,8 @@ const icons = {
 	error,
 	gear,
 	flask,
+	checkCircle,
+	checkInCircleFilled,
 };
 
 // One or more icons are passed in as an object of iconKey (string): IconComponent

--- a/newswires/client/src/presets.ts
+++ b/newswires/client/src/presets.ts
@@ -59,7 +59,7 @@ export const sportPresets: Preset[] = [
 ];
 
 export const presets = [
-	{ id: 'all-presets', name: 'All', filterOptions: [] },
+	{ id: 'all-presets', name: 'Everything', filterOptions: [] },
 	{ id: 'all-world', name: 'World', filterOptions: [] },
 	{ id: 'all-uk', name: 'UK', filterOptions: [] },
 	{ id: 'all-business', name: 'Business', filterOptions: [] },


### PR DESCRIPTION
You can select multiple of them, so checkbox styling makes more 'semantic' sense.

At the same time, change the `presets` styling so that it uses round selection indicators, to suggest radio-button behaviour

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
