### PR TITLE
do not exclude MCC:SPO-tagged Reuters World stories from World section

### DIFF
--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -133,7 +133,7 @@ object SearchPresets {
   )
 
   private val ReutersWorld = List(
-    SearchPreset(REUTERS, categoryCodes = CategoryCodes.World.REUTERS, categoryCodesExcl = List("MCC:SPO")),
+    SearchPreset(REUTERS, categoryCodes = CategoryCodes.World.REUTERS),
     SearchPreset(
       REUTERS,
       categoryCodes = CategoryCodes.Other.REUTERS,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We're missing a small handful of stories where they have been tagged with REUTERS:WORLD, but then we exclude them as they also contains MCC:SPO. Stories in World may have sports themes, so we should allow them to appear in the feed.