### PR TITLE
Pf/reorient header on small contianer

### DIFF
--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -80,10 +80,10 @@ function TitleContentForItem({
 					gap: 0.5rem;
 				`}
 			>
+				<CopyButton id={id} headlineText={headlineText} />
 				<EuiTitle size="xs">
 					<h2>{headlineText}</h2>
 				</EuiTitle>
-				<CopyButton id={id} headlineText={headlineText} />
 			</div>
 			<h3>
 				<SupplierBadge supplier={supplier} /> {slug && <>{slug} &#183; </>}
@@ -445,20 +445,24 @@ export const WireDetail = ({
 	}, [wire]);
 
 	return (
-		<>
+		<div
+			css={css`
+				container-type: inline-size;
+			`}
+		>
 			<div
 				css={css`
 					display: flex;
+					flex-direction: column;
 					justify-content: space-between;
 					gap: ${theme.euiTheme.size.s};
+
+					@container (width >= 700px) {
+						flex-direction: row;
+					}
 				`}
 			>
-				<div
-					css={css`
-						flex-basis: fit-content;
-						flex-shrink: 1;
-					`}
-				>
+				<div>
 					<TitleContentForItem
 						id={wire.id}
 						headline={headline}
@@ -475,10 +479,8 @@ export const WireDetail = ({
 					hasShadow={false}
 					grow={false}
 					css={css`
-						height: fit-content;
-						flex-basis: 50%;
-						max-width: fit-content;
 						flex-shrink: 1;
+						align-self: flex-end;
 					`}
 				>
 					<ToolsConnection
@@ -608,6 +610,6 @@ export const WireDetail = ({
 					</EuiDescriptionList>
 				</div>
 			)}
-		</>
+		</div>
 	);
 };

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -446,8 +446,14 @@ export const WireDetail = ({
 
 	return (
 		<>
-			<EuiFlexGroup direction="row" justifyContent="spaceBetween">
-				<EuiFlexItem
+			<div
+				css={css`
+					display: flex;
+					justify-content: space-between;
+					gap: ${theme.euiTheme.size.s};
+				`}
+			>
+				<div
 					css={css`
 						flex-basis: fit-content;
 						flex-shrink: 1;
@@ -462,7 +468,7 @@ export const WireDetail = ({
 						supplier={wire.supplier}
 						wordCount={wordCount}
 					/>
-				</EuiFlexItem>
+				</div>
 
 				<EuiPanel
 					hasBorder
@@ -481,7 +487,7 @@ export const WireDetail = ({
 						addToolLink={addToolLink}
 					/>
 				</EuiPanel>
-			</EuiFlexGroup>
+			</div>
 			<EuiSpacer size="s" />
 			{isShowingJson ? (
 				<EuiCodeBlock language="json">


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images


|Before|After|
|-|-|
|<img width="474" height="410" alt="image" src="https://github.com/user-attachments/assets/3e2ceaa2-ea91-42b4-93fe-050e138378a5" />|<img width="483" height="416" alt="image" src="https://github.com/user-attachments/assets/405615b1-45b4-47c3-a520-8422f1a7b822" />|

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
