### PR TITLE
Rename MediaTopic `football` to `soccer`

### DIFF
--- a/newswires/client/src/category-code-lookup-tables.ts
+++ b/newswires/client/src/category-code-lookup-tables.ts
@@ -2480,7 +2480,7 @@ export const lookupTables: Array<{
 			'medtop:20001062': 'sky diving',
 			'medtop:20001063': 'snooker',
 			'medtop:20001064': 'snowboarding',
-			'medtop:20001065': 'football',
+			'medtop:20001065': 'soccer',
 			'medtop:20001066': 'softball',
 			'medtop:20001067': 'speed skating',
 			'medtop:20001068': 'squash',


### PR DESCRIPTION
We use `Soccer` everywhere, including UI, to avoid confusion, and also this is a legal `en-US` [name for this MediaTopic](https://cv.iptc.org/newscodes/mediatopic/20001065).