### PR TITLE
override aws sdk v2 versions to latest to get updated netty dep

### DIFF
--- a/newswires/build.sbt
+++ b/newswires/build.sbt
@@ -56,6 +56,8 @@ dependencyOverrides ++= Seq(
   "com.fasterxml.jackson.module" %% "jackson-module-scala"
 ).map(_ % jacksonVersion)
 
+dependencyOverrides ++= Seq("autoscaling", "ec2", "ssm", "rds").map("software.amazon.awssdk" % _ % "2.32.28")
+
 // needed to parse conditional statements in `logback.xml`
 // i.e. to only log to disk in DEV
 // see: https://logback.qos.ch/setup.html#janino


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Overrides sdk versions to get an updated netty codec which does not contain the high vulnerability

- [x] Tested on CODE