### PR TITLE
Refactor where clause builder, fixing beforeId/sinceId handling

### DIFF
--- a/newswires/test/db/FingerpostWireEntrySpec.scala
+++ b/newswires/test/db/FingerpostWireEntrySpec.scala
@@ -7,8 +7,8 @@ import helpers.models
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import io.circe.syntax.EncoderOps
-import _root_.models.{MostRecent, NextPage, QueryParams, SearchParams}
-import scalikejdbc.{scalikejdbcSQLInterpolationImplicitDef, sqls}
+import models.{MostRecent, NextPage, QueryParams, SearchParams}
+import scalikejdbc.scalikejdbcSQLInterpolationImplicitDef
 
 class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
 
@@ -80,7 +80,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
       )
 
     whereClause should matchSqlSnippet(
-      expectedClause = "",
+      expectedClause = "true",
       expectedParams = Nil
     )
   }
@@ -106,7 +106,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
       )
 
     whereClauseBeforeId should matchSqlSnippet(
-      expectedClause = "WHERE fm.id < ?",
+      expectedClause = "fm.id < ?",
       expectedParams = List(10)
     )
 
@@ -119,7 +119,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
       )
 
     whereClauseSinceId should matchSqlSnippet(
-      expectedClause = "WHERE fm.id > ?",
+      expectedClause = "fm.id > ?",
       expectedParams = List(20)
     )
   }
@@ -139,7 +139,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
       )
 
     whereClause should matchSqlSnippet(
-      "WHERE websearch_to_tsquery('english', ?) @@ fm.combined_textsearch",
+      "websearch_to_tsquery('english', ?) @@ fm.combined_textsearch",
       expectedParams = List("text1")
     )
   }
@@ -161,7 +161,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
       )
 
     whereClause should matchSqlSnippet(
-      "WHERE ((fm.content -> 'keywords') ??| ? and fm.category_codes && ?)",
+      "((fm.content -> 'keywords') ??| ? and fm.category_codes && ?)",
       List(
         List("keyword1", "keyword2"),
         List("category1", "category2")
@@ -195,7 +195,6 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
         None,
         None
       )
-      .replaceFirst("WHERE ", "")
 
     val dateRangeWhereClause = FingerpostWireEntry
       .buildWhereClause(
@@ -208,7 +207,6 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
         None,
         None
       )
-      .replaceFirst("WHERE ", "")
 
     val keywordsExclWhereClause = FingerpostWireEntry
       .buildWhereClause(
@@ -220,7 +218,6 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
         None,
         None
       )
-      .replaceFirst("WHERE ", "")
 
     val suppliersExclWhereClause = FingerpostWireEntry
       .buildWhereClause(
@@ -232,7 +229,6 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
         None,
         None
       )
-      .replaceFirst("WHERE ", "")
 
     val categoryCodesExclWhereClause = FingerpostWireEntry
       .buildWhereClause(
@@ -244,10 +240,9 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
         None,
         None
       )
-      .replaceFirst("WHERE ", "")
 
     whereClause should matchSqlSnippet(
-      s"""WHERE fm.id < ? and $dateRangeWhereClause
+      sqls"""fm.id < ? and $dateRangeWhereClause
          | and $keywordsExclWhereClause
          | and $textSearchWhereClause
          | and $suppliersExclWhereClause
@@ -280,7 +275,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
       )
 
     whereClause should matchSqlSnippet(
-      "WHERE fm.ingested_at >= CAST(? AS timestamptz)",
+      "fm.ingested_at >= CAST(? AS timestamptz)",
       List("2025-03-10T00:00:00.000Z")
     )
   }
@@ -300,7 +295,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
       )
 
     whereClause should matchSqlSnippet(
-      "WHERE fm.ingested_at <= CAST(? AS timestamptz)",
+      "fm.ingested_at <= CAST(? AS timestamptz)",
       List("2025-03-10T23:59:59.999Z")
     )
   }
@@ -334,7 +329,6 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
         None,
         None
       )
-      .replaceFirst("WHERE ", "")
 
     val preset1Clause = FingerpostWireEntry
       .buildWhereClause(
@@ -343,7 +337,6 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
         None,
         None
       )
-      .replaceFirst("WHERE ", "")
 
     val preset2Clause = FingerpostWireEntry
       .buildWhereClause(
@@ -352,7 +345,6 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
         None,
         None
       )
-      .replaceFirst("WHERE ", "")
 
     val whereClause =
       FingerpostWireEntry.buildWhereClause(
@@ -363,7 +355,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
       )
 
     whereClause should matchSqlSnippet(
-      s"WHERE $customParamsClause and (($preset1Clause or $preset2Clause))",
+      sqls"$customParamsClause and (($preset1Clause or $preset2Clause))",
       List(
         "supplier1",
         List("N2:GB"),
@@ -392,7 +384,6 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
         None,
         None
       )
-      .replaceFirst("WHERE ", "")
 
     val dateRangeWhereClause = FingerpostWireEntry
       .buildWhereClause(
@@ -401,7 +392,6 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
         None,
         None
       )
-      .replaceFirst("WHERE ", "")
 
     val whereClause =
       FingerpostWireEntry.buildWhereClause(
@@ -412,7 +402,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
       )
 
     whereClause should matchSqlSnippet(
-      s"WHERE $dateRangeWhereClause and $textSearchWhereClause",
+      sqls"$dateRangeWhereClause and $textSearchWhereClause",
       List(
         "2025-03-10T00:00:00.000Z",
         "2025-03-10T23:59:59.999Z",

--- a/newswires/test/db/FingerpostWireEntrySpec.scala
+++ b/newswires/test/db/FingerpostWireEntrySpec.scala
@@ -7,8 +7,8 @@ import helpers.models
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import io.circe.syntax.EncoderOps
-import models.{MostRecent, NextPage, QueryParams, SearchParams}
-import scalikejdbc.scalikejdbcSQLInterpolationImplicitDef
+import _root_.models.{MostRecent, NextPage, QueryParams, SearchParams}
+import scalikejdbc.{scalikejdbcSQLInterpolationImplicitDef, sqls}
 
 class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
 
@@ -85,6 +85,45 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
     )
   }
 
+  it should "apply beforeId or sinceId even if no other custom search params are set" in {
+
+    val searchParams = SearchParams(
+      text = None,
+      start = None,
+      end = None,
+      keywordIncl = Nil,
+      keywordExcl = Nil,
+      suppliersIncl = Nil,
+      suppliersExcl = Nil
+    )
+
+    val whereClauseBeforeId =
+      FingerpostWireEntry.buildWhereClause(
+        searchParams,
+        List(),
+        maybeBeforeId = Some(10),
+        None
+      )
+
+    whereClauseBeforeId should matchSqlSnippet(
+      expectedClause = "WHERE fm.id < ?",
+      expectedParams = List(10)
+    )
+
+    val whereClauseSinceId =
+      FingerpostWireEntry.buildWhereClause(
+        searchParams,
+        List(),
+        None,
+        maybeSinceId = Some(20)
+      )
+
+    whereClauseSinceId should matchSqlSnippet(
+      expectedClause = "WHERE fm.id > ?",
+      expectedParams = List(20)
+    )
+  }
+
   it should "generate a where clause for a single field" in {
     val searchParams =
       SearchParams(
@@ -122,7 +161,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
       )
 
     whereClause should matchSqlSnippet(
-      "WHERE (fm.content -> 'keywords') ??| ? and fm.category_codes && ?",
+      "WHERE ((fm.content -> 'keywords') ??| ? and fm.category_codes && ?)",
       List(
         List("keyword1", "keyword2"),
         List("category1", "category2")
@@ -149,28 +188,78 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
         None
       )
 
+    val textSearchWhereClause = FingerpostWireEntry
+      .buildWhereClause(
+        SearchParams(Some(SearchTerm.English("text1"))),
+        List(),
+        None,
+        None
+      )
+      .replaceFirst("WHERE ", "")
+
+    val dateRangeWhereClause = FingerpostWireEntry
+      .buildWhereClause(
+        SearchParams(
+          text = None,
+          start = Some("2025-03-10T00:00:00.000Z"),
+          end = Some("2025-03-10T23:59:59.999Z")
+        ),
+        List(),
+        None,
+        None
+      )
+      .replaceFirst("WHERE ", "")
+
+    val keywordsExclWhereClause = FingerpostWireEntry
+      .buildWhereClause(
+        SearchParams(
+          text = None,
+          keywordExcl = List("keyword1")
+        ),
+        List(),
+        None,
+        None
+      )
+      .replaceFirst("WHERE ", "")
+
+    val suppliersExclWhereClause = FingerpostWireEntry
+      .buildWhereClause(
+        SearchParams(
+          text = None,
+          suppliersExcl = List("supplier1", "supplier2")
+        ),
+        List(),
+        None,
+        None
+      )
+      .replaceFirst("WHERE ", "")
+
+    val categoryCodesExclWhereClause = FingerpostWireEntry
+      .buildWhereClause(
+        SearchParams(
+          text = None,
+          categoryCodesExcl = List("category1", "category2")
+        ),
+        List(),
+        None,
+        None
+      )
+      .replaceFirst("WHERE ", "")
+
     whereClause should matchSqlSnippet(
-      """WHERE fm.id < ? and NOT EXISTS (
-        |  SELECT FROM fingerpost_wire_entry keywordsExcl
-        |  WHERE fm.id = keywordsExcl.id
-        |    AND (keywordsExcl.content->'keywords') ??| ?
-        |) and websearch_to_tsquery('english', ?) @@ fm.combined_textsearch and NOT EXISTS (
-        |  SELECT FROM fingerpost_wire_entry sourceFeedsExcl
-        |  WHERE fm.id = sourceFeedsExcl.id
-        |    AND  upper(sourceFeedsExcl.supplier) in (upper(?), upper(?))
-        |) and (fm.ingested_at BETWEEN CAST(? AS timestamptz) AND CAST(? AS timestamptz)) and NOT EXISTS (
-        |  SELECT FROM fingerpost_wire_entry categoryCodesExcl
-        |  WHERE fm.id = categoryCodesExcl.id
-        |    AND categoryCodesExcl.category_codes && ?
-        |)""".stripMargin,
+      s"""WHERE fm.id < ? and $dateRangeWhereClause
+         | and $keywordsExclWhereClause
+         | and $textSearchWhereClause
+         | and $suppliersExclWhereClause
+         | and $categoryCodesExclWhereClause""".stripMargin,
       List(
         1,
+        "2025-03-10T00:00:00.000Z",
+        "2025-03-10T23:59:59.999Z",
         List("keyword1"),
         "text1",
         "supplier1",
         "supplier2",
-        "2025-03-10T00:00:00.000Z",
-        "2025-03-10T23:59:59.999Z",
         List("category1", "category2")
       )
     )
@@ -217,63 +306,117 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
   }
 
   it should "should join complex search presets using 'or'" in {
-    val searchParams =
-      SearchParams(
-        text = None,
-        start = Some("2025-03-10T00:00:00.000Z"),
-        suppliersExcl = List("supplier1")
-      )
 
-    val savedSearchParamList = List(
+    val customParams = SearchParams(
+      text = None,
+      suppliersExcl = List("supplier1")
+    )
+
+    val presetSearchParams1 =
       SearchParams(
         text = Some(SearchTerm.Simple("News Summary", SearchField.Headline)),
         suppliersIncl = List("REUTERS"),
         categoryCodesIncl = List(
-          "MCC:OEC"
-        ),
-        categoryCodesExcl = List(
-          "N2:GB",
-          "N2:COM",
-          "N2:ECI"
+          "N2:GB"
         )
-      ),
+      )
+    val presetSearchParams2 =
       SearchParams(
         text = Some(SearchTerm.Simple("soccer")),
         suppliersIncl = List("AFP"),
         categoryCodesIncl = List("afpCat:SPO")
       )
-    )
+
+    val customParamsClause = FingerpostWireEntry
+      .buildWhereClause(
+        customParams,
+        List(),
+        None,
+        None
+      )
+      .replaceFirst("WHERE ", "")
+
+    val preset1Clause = FingerpostWireEntry
+      .buildWhereClause(
+        presetSearchParams1,
+        List(),
+        None,
+        None
+      )
+      .replaceFirst("WHERE ", "")
+
+    val preset2Clause = FingerpostWireEntry
+      .buildWhereClause(
+        presetSearchParams2,
+        List(),
+        None,
+        None
+      )
+      .replaceFirst("WHERE ", "")
 
     val whereClause =
       FingerpostWireEntry.buildWhereClause(
-        searchParams,
-        savedSearchParamList,
+        customParams,
+        List(presetSearchParams1, presetSearchParams2),
         None,
         None
       )
 
     whereClause should matchSqlSnippet(
-      """WHERE (NOT EXISTS (
-        |  SELECT FROM fingerpost_wire_entry sourceFeedsExcl
-        |  WHERE fm.id = sourceFeedsExcl.id
-        |    AND  upper(sourceFeedsExcl.supplier) in (upper(?))
-        |) and fm.ingested_at >= CAST(? AS timestamptz)) and ((fm.category_codes && ? and ? @@ websearch_to_tsquery('simple', lower(?)) and  upper(fm.supplier) in (upper(?)) and NOT EXISTS (
-        |  SELECT FROM fingerpost_wire_entry categoryCodesExcl
-        |  WHERE fm.id = categoryCodesExcl.id
-        |    AND categoryCodesExcl.category_codes && ?
-        |)) or ((fm.category_codes && ? and ? @@ websearch_to_tsquery('simple', lower(?)) and upper(fm.supplier) in (upper(?)))))""".stripMargin,
+      s"WHERE $customParamsClause and (($preset1Clause or $preset2Clause))",
       List(
         "supplier1",
-        "2025-03-10T00:00:00.000Z",
-        List("MCC:OEC"),
+        List("N2:GB"),
         "headline_tsv_simple",
         "News Summary",
         "REUTERS",
-        List("N2:GB", "N2:COM", "N2:ECI"),
         List("afpCat:SPO"),
         "body_text_tsv_simple",
         "soccer",
         "AFP"
+      )
+    )
+  }
+
+  it should "apply date ranges using 'AND' at the top level of the query" in {
+    val customParams = SearchParams(
+      text = Some(SearchTerm.English("text1")),
+      start = Some("2025-03-10T00:00:00.000Z"),
+      end = Some("2025-03-10T23:59:59.999Z")
+    )
+
+    val textSearchWhereClause = FingerpostWireEntry
+      .buildWhereClause(
+        customParams.copy(start = None, end = None),
+        List(),
+        None,
+        None
+      )
+      .replaceFirst("WHERE ", "")
+
+    val dateRangeWhereClause = FingerpostWireEntry
+      .buildWhereClause(
+        customParams.copy(text = None),
+        List(),
+        None,
+        None
+      )
+      .replaceFirst("WHERE ", "")
+
+    val whereClause =
+      FingerpostWireEntry.buildWhereClause(
+        customParams,
+        List.empty,
+        None,
+        None
+      )
+
+    whereClause should matchSqlSnippet(
+      s"WHERE $dateRangeWhereClause and $textSearchWhereClause",
+      List(
+        "2025-03-10T00:00:00.000Z",
+        "2025-03-10T23:59:59.999Z",
+        "text1"
       )
     )
   }
@@ -321,4 +464,5 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
 
     query.statement should include("ORDER BY fm.ingested_at ASC")
   }
+
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Refactors the building of where clauses:
  - `sqls.joinWithOr()` works fine with no arguments (returns an empty sqls clause) or just one argument (it returns it unmodified) so we don't need to do so many checks to see whether we have 0, 1 or >1 clauses before passing to this method.
  - Always add a 'where' clause, with 'true' as the fallback/default if there are no other clauses in play. (So we can add the 'where' part just once, when we're constructing the final query.)
- Add the `beforeId`/`sinceId` clauses in at the top level of the where clause:
  - Previously, they were being added to each of the sub-clauses, i.e. the custom search clause and the saved search/presets clause.
  - But because these sub-clauses are being joined with 'AND', we can just add the before/since clauses at the top level using 'AND', too. This is a bit simpler.
  - More importantly, it fixes a bug: previously if there were no other search clauses, then the 'data-only where clauses' would get dropped.

```
// Before:
WHERE 
    (customSearchClauses 
        AND beforeID < 10
    ) 
    AND ((savedSearchClause1 OR savedSearchClause2) 
        AND beforeID < 10
    )

// After:
WHERE 
    beforeId < 10
    AND (customSearchClauses)
    AND (savedSearchClause1 OR savedSearchClause2)
```



<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
