### PR TITLE
Add dotcopy view to UI

### DIFF
--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -395,6 +395,22 @@ function CopyButton({
 	);
 }
 
+function decideEdNote({
+	ednote,
+	supplier,
+}: {
+	ednote?: string;
+	supplier: SupplierInfo;
+}): string | undefined {
+	if (ednote) {
+		return ednote;
+	}
+	if (supplier.name === 'UNAUTHED_EMAIL_FEED') {
+		return "NOTE: This item has been ingested via email, and hasn't been authenticated. Please check carefully before use, and treat it as you would a regular email.";
+	}
+	return undefined;
+}
+
 export const WireDetail = ({
 	wire,
 	isShowingJson,
@@ -443,6 +459,8 @@ export const WireDetail = ({
 					.filter((word) => word.length > 0).length
 			: 0;
 	}, [wire]);
+
+	const ednoteToRender = decideEdNote({ ednote, supplier: wire.supplier });
 
 	return (
 		<div
@@ -507,9 +525,9 @@ export const WireDetail = ({
 					`}
 				>
 					<EuiSpacer size="xs" />
-					{ednote && (
+					{ednoteToRender && (
 						<>
-							<EuiCallOut size="s" title={ednote} color="success" />
+							<EuiCallOut size="s" title={ednoteToRender} color="success" />
 							<EuiSpacer size="m" />
 						</>
 					)}

--- a/newswires/client/src/app-configuration.ts
+++ b/newswires/client/src/app-configuration.ts
@@ -22,8 +22,8 @@ const configLookup: AppConfiguration = isJest
 const showGuSuppliers = configLookup.switches.ShowGuSuppliers;
 
 export const SUPPLIERS_TO_EXCLUDE = showGuSuppliers
-	? []
-	: ['GUAP', 'GUREUTERS'];
+	? ['UNAUTHED_EMAIL_FEED']
+	: ['UNAUTHED_EMAIL_FEED', 'GUAP', 'GUREUTERS'];
 
 export const STAGE = configLookup.stage;
 

--- a/newswires/client/src/app-configuration.ts
+++ b/newswires/client/src/app-configuration.ts
@@ -21,6 +21,10 @@ const configLookup: AppConfiguration = isJest
 
 const showGuSuppliers = configLookup.switches.ShowGuSuppliers;
 
+/**
+ * The list of suppliers to exclude from the list of 'recognised suppliers' that
+ * we use to populate the options in the sidebar
+ */
 export const SUPPLIERS_TO_EXCLUDE = showGuSuppliers
 	? ['UNAUTHED_EMAIL_FEED']
 	: ['UNAUTHED_EMAIL_FEED', 'GUAP', 'GUREUTERS'];

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -218,7 +218,7 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 
 		if (state.status === 'loading') {
 			const start = performance.now();
-			fetchResults(currentConfig.query, {}, abortController)
+			fetchResults(currentConfig.query, {}, abortController, currentConfig.view)
 				.then((data) => {
 					sendTelemetryEvent('NEWSWIRES_FETCHED_RESULTS', {
 						...Object.fromEntries(
@@ -246,7 +246,12 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 									...state.queryData.results.map((wire) => wire.id),
 								).toString()
 							: undefined;
-					fetchResults(currentConfig.query, { sinceId }, abortController)
+					fetchResults(
+						currentConfig.query,
+						{ sinceId },
+						abortController,
+						currentConfig.view,
+					)
 						.then((data) => {
 							if (!abortController.signal.aborted) {
 								dispatch({
@@ -273,6 +278,7 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 		currentConfig.query,
 		state.queryData?.results,
 		sendTelemetryEvent,
+		currentConfig.view,
 	]);
 
 	const handleEnterQuery = useCallback(
@@ -316,7 +322,7 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 		});
 
 		pushConfigState({
-			view: 'item',
+			view: currentConfig.view.includes('dotcopy') ? 'dotcopy/item' : 'item',
 			itemId: item,
 			query: currentConfig.query,
 			ticker: currentConfig.ticker,
@@ -325,7 +331,7 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 
 	const handleDeselectItem = () => {
 		pushConfigState({
-			view: 'feed',
+			view: currentConfig.view.includes('dotcopy') ? 'dotcopy' : 'feed',
 			query: currentConfig.query,
 			ticker: currentConfig.ticker,
 			itemId: undefined,
@@ -406,7 +412,12 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 			beforeId,
 		});
 
-		return fetchResults(currentConfig.query, { beforeId })
+		return fetchResults(
+			currentConfig.query,
+			{ beforeId },
+			undefined,
+			currentConfig.view,
+		)
 			.then((data) => {
 				dispatch({ type: 'APPEND_RESULTS', data });
 

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -218,7 +218,7 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 
 		if (state.status === 'loading') {
 			const start = performance.now();
-			fetchResults(currentConfig.query, {}, abortController, currentConfig.view)
+			fetchResults({ query: currentConfig.query, view: currentConfig.view })
 				.then((data) => {
 					sendTelemetryEvent('NEWSWIRES_FETCHED_RESULTS', {
 						...Object.fromEntries(
@@ -246,12 +246,12 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 									...state.queryData.results.map((wire) => wire.id),
 								).toString()
 							: undefined;
-					fetchResults(
-						currentConfig.query,
-						{ sinceId },
+					fetchResults({
+						query: currentConfig.query,
+						sinceId,
 						abortController,
-						currentConfig.view,
-					)
+						view: currentConfig.view,
+					})
 						.then((data) => {
 							if (!abortController.signal.aborted) {
 								dispatch({
@@ -412,12 +412,11 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 			beforeId,
 		});
 
-		return fetchResults(
-			currentConfig.query,
-			{ beforeId },
-			undefined,
-			currentConfig.view,
-		)
+		return fetchResults({
+			query: currentConfig.query,
+			beforeId,
+			view: currentConfig.view,
+		})
 			.then((data) => {
 				dispatch({ type: 'APPEND_RESULTS', data });
 

--- a/newswires/client/src/context/fetchResults.test.ts
+++ b/newswires/client/src/context/fetchResults.test.ts
@@ -26,9 +26,12 @@ describe('fetchResults', () => {
 
 	it('should call pandaFetch with correct URL and headers', async () => {
 		const mockQuery = { q: 'value' };
-		await fetchResults(mockQuery);
+		await fetchResults({ query: mockQuery, view: 'feed' });
 
-		expect(paramsToQuerystring).toHaveBeenCalledWith(mockQuery, true, {});
+		expect(paramsToQuerystring).toHaveBeenCalledWith({
+			query: mockQuery,
+			useAbsoluteDateTimeValues: true,
+		});
 		expect(pandaFetch).toHaveBeenCalledWith('/api/search?queryString', {
 			headers: { Accept: 'application/json' },
 		});
@@ -42,9 +45,9 @@ describe('fetchResults', () => {
 			ok: false,
 		});
 
-		await expect(fetchResults({ q: 'value' })).rejects.toThrow(
-			'Error occurred',
-		);
+		await expect(
+			fetchResults({ query: { q: 'value' }, view: 'feed' }),
+		).rejects.toThrow('Error occurred');
 	});
 
 	it('should throw an error if response data is invalid', async () => {
@@ -53,9 +56,9 @@ describe('fetchResults', () => {
 			ok: true,
 		});
 
-		await expect(fetchResults({ q: 'value' })).rejects.toThrow(
-			'Received invalid data from server',
-		);
+		await expect(
+			fetchResults({ query: { q: 'value' }, view: 'feed' }),
+		).rejects.toThrow('Received invalid data from server');
 	});
 
 	it('should return parsed data if response is valid', async () => {
@@ -69,39 +72,39 @@ describe('fetchResults', () => {
 			ok: true,
 		});
 
-		const result = await fetchResults({ q: 'value' });
+		const result = await fetchResults({ query: { q: 'value' }, view: 'feed' });
 		expect(result).toEqual(mockResponseData);
 	});
 
 	it('should append sinceId to the query if provided', async () => {
 		const mockQuery = { q: 'value' };
-		await fetchResults(mockQuery, { sinceId: '123' });
+		await fetchResults({ query: mockQuery, view: 'feed', sinceId: '123' });
 
-		expect(paramsToQuerystring).toHaveBeenCalledWith(
-			{
-				...mockQuery,
-			},
-			true,
-			{ sinceId: '123' },
-		);
+		expect(paramsToQuerystring).toHaveBeenCalledWith({
+			query: mockQuery,
+			useAbsoluteDateTimeValues: true,
+			sinceId: '123',
+		});
 	});
 
 	it('should append beforeId to the query if provided', async () => {
 		const mockQuery = { q: 'value' };
-		await fetchResults(mockQuery, { beforeId: '123' });
+		await fetchResults({
+			query: mockQuery,
+			view: 'feed',
+			beforeId: '123',
+		});
 
-		expect(paramsToQuerystring).toHaveBeenCalledWith(
-			{
-				...mockQuery,
-			},
-			true,
-			{ beforeId: '123' },
-		);
+		expect(paramsToQuerystring).toHaveBeenCalledWith({
+			query: mockQuery,
+			useAbsoluteDateTimeValues: true,
+			beforeId: '123',
+		});
 	});
 
 	it('should transform the results using transformWireItemQueryResult', async () => {
 		const mockQuery = { q: 'value' };
-		const results = await fetchResults(mockQuery);
+		const results = await fetchResults({ query: mockQuery, view: 'feed' });
 		expect(results.results).toHaveLength(1);
 		expect(results.results[0]).toEqual(
 			transformWireItemQueryResult(sampleWireResponse),

--- a/newswires/client/src/context/fetchResults.ts
+++ b/newswires/client/src/context/fetchResults.ts
@@ -4,17 +4,26 @@ import { WiresQueryResponseSchema } from '../sharedTypes.ts';
 import { paramsToQuerystring } from '../urlState.ts';
 import { transformWireItemQueryResult } from './transformQueryResponse.ts';
 
-export const fetchResults = async (
-	query: Query,
-	additionalParams: {
-		sinceId?: string;
-		beforeId?: string;
-	} = {},
-	abortController?: AbortController,
-	view: Config['view'] = 'feed',
-): Promise<WiresQueryData> => {
+export const fetchResults = async ({
+	query,
+	view,
+	sinceId,
+	beforeId,
+	abortController,
+}: {
+	query: Query;
+	view: Config['view'];
+	sinceId?: string;
+	beforeId?: string;
+	abortController?: AbortController;
+}): Promise<WiresQueryData> => {
 	const endpoint = view.includes('dotcopy') ? '/api/dotcopy' : '/api/search';
-	const queryString = paramsToQuerystring(query, true, additionalParams);
+	const queryString = paramsToQuerystring({
+		query,
+		useAbsoluteDateTimeValues: true,
+		beforeId,
+		sinceId,
+	});
 	const response = await pandaFetch(`${endpoint}${queryString}`, {
 		headers: {
 			Accept: 'application/json',

--- a/newswires/client/src/context/fetchResults.ts
+++ b/newswires/client/src/context/fetchResults.ts
@@ -1,5 +1,5 @@
 import { pandaFetch } from '../panda-session.ts';
-import type { Query, WiresQueryData } from '../sharedTypes.ts';
+import type { Config, Query, WiresQueryData } from '../sharedTypes.ts';
 import { WiresQueryResponseSchema } from '../sharedTypes.ts';
 import { paramsToQuerystring } from '../urlState.ts';
 import { transformWireItemQueryResult } from './transformQueryResponse.ts';
@@ -11,9 +11,11 @@ export const fetchResults = async (
 		beforeId?: string;
 	} = {},
 	abortController?: AbortController,
+	view: Config['view'] = 'feed',
 ): Promise<WiresQueryData> => {
+	const endpoint = view.includes('dotcopy') ? '/api/dotcopy' : '/api/search';
 	const queryString = paramsToQuerystring(query, true, additionalParams);
-	const response = await pandaFetch(`/api/search${queryString}`, {
+	const response = await pandaFetch(`${endpoint}${queryString}`, {
 		headers: {
 			Accept: 'application/json',
 		},

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -79,6 +79,7 @@ export const suppliers = [
 	'GUAP',
 	'GUREUTERS',
 	'MINOR_AGENCIES',
+	'UNAUTHED_EMAIL_FEED',
 	'UNKNOWN',
 ] as const;
 
@@ -138,6 +139,18 @@ export const ConfigSchema = z.discriminatedUnion('view', [
 	}),
 	z.object({
 		view: z.literal('item'),
+		query: QuerySchema,
+		itemId: z.string(),
+		ticker: z.boolean(),
+	}),
+	z.object({
+		view: z.literal('dotcopy'),
+		query: QuerySchema,
+		itemId: z.undefined(),
+		ticker: z.boolean(),
+	}),
+	z.object({
+		view: z.literal('dotcopy/item'),
 		query: QuerySchema,
 		itemId: z.string(),
 		ticker: z.boolean(),

--- a/newswires/client/src/suppliers.ts
+++ b/newswires/client/src/suppliers.ts
@@ -34,6 +34,12 @@ export const supplierData: SupplierInfo[] = [
 		shortLabel: 'Min.',
 		colour: '#39756a',
 	},
+	{
+		name: 'UNAUTHED_EMAIL_FEED',
+		label: 'Dotcopy',
+		shortLabel: 'Unauthed',
+		colour: '#808080',
+	},
 ] as const;
 
 export const UNKNOWN_SUPPLIER: SupplierInfo = {

--- a/newswires/client/src/suppliers.ts
+++ b/newswires/client/src/suppliers.ts
@@ -37,7 +37,7 @@ export const supplierData: SupplierInfo[] = [
 	{
 		name: 'UNAUTHED_EMAIL_FEED',
 		label: 'Dotcopy',
-		shortLabel: 'Unauthed',
+		shortLabel: 'Dotcopy',
 		colour: '#808080',
 	},
 ] as const;

--- a/newswires/client/src/urlState.test.ts
+++ b/newswires/client/src/urlState.test.ts
@@ -442,7 +442,10 @@ describe('paramsToQuerystring', () => {
 			q: 'abc',
 		};
 
-		const url = paramsToQuerystring(query);
+		const url = paramsToQuerystring({
+			query,
+			useAbsoluteDateTimeValues: false,
+		});
 		expect(url).toBe('?q=abc');
 	});
 
@@ -460,7 +463,10 @@ describe('paramsToQuerystring', () => {
 			},
 		};
 
-		const url = paramsToQuerystring(query);
+		const url = paramsToQuerystring({
+			query,
+			useAbsoluteDateTimeValues: false,
+		});
 		expect(url).toBe('?q=abc&start=now-3d&end=now');
 	});
 
@@ -478,7 +484,7 @@ describe('paramsToQuerystring', () => {
 			},
 		};
 
-		const url = paramsToQuerystring(query, true);
+		const url = paramsToQuerystring({ query, useAbsoluteDateTimeValues: true });
 		expect(url).toBe(
 			'?q=abc&start=2025-02-21T00%3A00%3A00.000Z&end=2025-02-21T23%3A59%3A59.000Z',
 		);
@@ -497,7 +503,7 @@ describe('paramsToQuerystring', () => {
 			},
 		};
 
-		const url = paramsToQuerystring(query, true);
+		const url = paramsToQuerystring({ query, useAbsoluteDateTimeValues: true });
 		expect(url).toBe('?q=abc&start=2025-02-21T00%3A00%3A00.000Z');
 	});
 });

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -1,3 +1,4 @@
+import { getErrorMessage } from '../../../shared/getErrorMessage.ts';
 import { DEFAULT_DATE_RANGE, START_OF_TODAY } from './dateConstants.ts';
 import {
 	isValidDateValue,
@@ -108,14 +109,22 @@ export function urlToConfig(location: {
 	const ticker = firstSegment === 'ticker';
 	const viewSegments = ticker ? restSegments : segments;
 
-	if (viewSegments[0] === 'item' && viewSegments.length === 2) {
-		return { ticker, view: 'item', itemId: viewSegments[1], query };
-	} else if (viewSegments[0] === 'dotcopy' && viewSegments.length === 1) {
-		return { ticker, view: 'dotcopy', itemId: undefined, query };
-	} else if (viewSegments[0] === 'dotcopy') {
-		return { ticker, view: 'dotcopy/item', itemId: viewSegments[2], query };
-	} else {
-		return { ticker, view: 'feed', itemId: undefined, query };
+	try {
+		if (viewSegments[0] === 'item' && viewSegments.length === 2) {
+			return { ticker, view: 'item', itemId: viewSegments[1], query };
+		} else if (viewSegments[0] === 'dotcopy' && viewSegments.length === 1) {
+			return { ticker, view: 'dotcopy', itemId: undefined, query };
+		} else if (viewSegments[0] === 'dotcopy') {
+			return { ticker, view: 'dotcopy/item', itemId: viewSegments[2], query };
+		} else {
+			return { ticker, view: 'feed', itemId: undefined, query };
+		}
+	} catch (e) {
+		const errorMessage = getErrorMessage(e);
+		console.error(
+			`Error parsing URL to config: ${errorMessage}. Pathname: ${location.pathname}. Search: ${location.search}. Returning default config.`,
+		);
+		return defaultConfig;
 	}
 }
 

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -133,46 +133,43 @@ export const configToUrl = (config: Config): string => {
 	}
 };
 
-const processDateRange = (
-	config: Query,
-	useAbsoluteDateTimeValues: boolean,
-) => {
+const processDateRange = (query: Query, useAbsoluteDateTimeValues: boolean) => {
 	if (useAbsoluteDateTimeValues) {
 		// Convert relative dates to ISO-formatted absolute UTC dates, as required by the backend API.
-		if (config.dateRange) {
+		if (query.dateRange) {
 			const [maybeStartMoment, maybeEndMoment] =
 				relativeDateRangeToAbsoluteDateRange({
-					start: config.dateRange.start,
-					end: config.dateRange.end,
+					start: query.dateRange.start,
+					end: query.dateRange.end,
 				});
 
 			return {
-				...config,
+				...query,
 				start: maybeStartMoment?.toISOString(),
 				end: maybeEndMoment?.toISOString(),
 			};
 		} else {
-			return { ...config, start: START_OF_TODAY.toISOString() };
+			return { ...query, start: START_OF_TODAY.toISOString() };
 		}
 	} else {
 		return {
-			...config,
+			...query,
 			start:
-				config.dateRange?.start &&
-				config.dateRange.start !== DEFAULT_DATE_RANGE.start
-					? config.dateRange.start
+				query.dateRange?.start &&
+				query.dateRange.start !== DEFAULT_DATE_RANGE.start
+					? query.dateRange.start
 					: undefined,
 			end:
-				config.dateRange?.end && config.dateRange.end !== DEFAULT_DATE_RANGE.end
-					? config.dateRange.end
+				query.dateRange?.end && query.dateRange.end !== DEFAULT_DATE_RANGE.end
+					? query.dateRange.end
 					: undefined,
 		};
 	}
 };
 
 export const paramsToQuerystring = (
-	config: Query,
-	useDateTimeValue: boolean = false,
+	query: Query,
+	useAbsoluteDateTimeValues: boolean = false,
 	{
 		sinceId,
 		beforeId,
@@ -181,7 +178,7 @@ export const paramsToQuerystring = (
 		beforeId?: string;
 	} = {},
 ): string => {
-	const flattenedQuery = processDateRange(config, useDateTimeValue);
+	const flattenedQuery = processDateRange(query, useAbsoluteDateTimeValues);
 
 	const params = Object.entries(flattenedQuery).reduce<Array<[string, string]>>(
 		(acc, [k, v]) => {

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -110,6 +110,10 @@ export function urlToConfig(location: {
 
 	if (viewSegments[0] === 'item' && viewSegments.length === 2) {
 		return { ticker, view: 'item', itemId: viewSegments[1], query };
+	} else if (viewSegments[0] === 'dotcopy' && viewSegments.length === 1) {
+		return { ticker, view: 'dotcopy', itemId: undefined, query };
+	} else if (viewSegments[0] === 'dotcopy') {
+		return { ticker, view: 'dotcopy/item', itemId: viewSegments[2], query };
 	} else {
 		return { ticker, view: 'feed', itemId: undefined, query };
 	}
@@ -122,6 +126,10 @@ export const configToUrl = (config: Config): string => {
 			return `${config.ticker ? '/ticker' : ''}/feed${paramsToQuerystring(query)}`;
 		case 'item':
 			return `${config.ticker ? '/ticker' : ''}/item/${itemId}${paramsToQuerystring(query)}`;
+		case 'dotcopy':
+			return `${config.ticker ? '/ticker' : ''}/dotcopy${paramsToQuerystring(query)}`;
+		case 'dotcopy/item':
+			return `${config.ticker ? '/ticker' : ''}/dotcopy/item/${itemId}${paramsToQuerystring(query)}`;
 	}
 };
 

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -123,13 +123,13 @@ export const configToUrl = (config: Config): string => {
 	const { view, query, itemId } = config;
 	switch (view) {
 		case 'feed':
-			return `${config.ticker ? '/ticker' : ''}/feed${paramsToQuerystring(query)}`;
+			return `${config.ticker ? '/ticker' : ''}/feed${paramsToQuerystring({ query, useAbsoluteDateTimeValues: false })}`;
 		case 'item':
-			return `${config.ticker ? '/ticker' : ''}/item/${itemId}${paramsToQuerystring(query)}`;
+			return `${config.ticker ? '/ticker' : ''}/item/${itemId}${paramsToQuerystring({ query, useAbsoluteDateTimeValues: false })}`;
 		case 'dotcopy':
-			return `${config.ticker ? '/ticker' : ''}/dotcopy${paramsToQuerystring(query)}`;
+			return `${config.ticker ? '/ticker' : ''}/dotcopy${paramsToQuerystring({ query, useAbsoluteDateTimeValues: false })}`;
 		case 'dotcopy/item':
-			return `${config.ticker ? '/ticker' : ''}/dotcopy/item/${itemId}${paramsToQuerystring(query)}`;
+			return `${config.ticker ? '/ticker' : ''}/dotcopy/item/${itemId}${paramsToQuerystring({ query, useAbsoluteDateTimeValues: false })}`;
 	}
 };
 
@@ -167,17 +167,17 @@ const processDateRange = (query: Query, useAbsoluteDateTimeValues: boolean) => {
 	}
 };
 
-export const paramsToQuerystring = (
-	query: Query,
-	useAbsoluteDateTimeValues: boolean = false,
-	{
-		sinceId,
-		beforeId,
-	}: {
-		sinceId?: string;
-		beforeId?: string;
-	} = {},
-): string => {
+export const paramsToQuerystring = ({
+	query,
+	sinceId,
+	beforeId,
+	useAbsoluteDateTimeValues,
+}: {
+	query: Query;
+	sinceId?: string;
+	beforeId?: string;
+	useAbsoluteDateTimeValues: boolean;
+}): string => {
 	const flattenedQuery = processDateRange(query, useAbsoluteDateTimeValues);
 
 	const params = Object.entries(flattenedQuery).reduce<Array<[string, string]>>(

--- a/newswires/conf/routes
+++ b/newswires/conf/routes
@@ -6,7 +6,9 @@
 # An example controller showing a sample home page
 GET     /                           controllers.ViteController.index()
 GET     /feed                       controllers.ViteController.index()
+GET     /dotcopy                    controllers.ViteController.index()
 GET     /item/*id                   controllers.ViteController.item(id: String)
+GET     /dotcopy/item/*id           controllers.ViteController.item(id: String)
 GET     /ticker/feed                controllers.ViteController.index()
 GET     /ticker/item/*id            controllers.ViteController.item(id: String)
 GET     /api/search                 controllers.QueryController.query(q: Option[String], keyword: List[String], supplier: List[String], categoryCode: List[String], categoryCodeExcl: List[String], start: Option[String], end: Option[String], beforeId: Option[Int], sinceId: Option[Int], hasDataFormatting: Option[Boolean])


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add `/dotcopy` and `/dotcopy/item/:id` routes to the app, to serve versions of the feed and item views that just pull in dotcopy items.

This branch isn't trying to integrate the dotcopy view with the regular feed view in any kind of user-friendly way. Rather, it's just getting the rendering and routing logic in place. UX for navigation etc. will come later.

I'm also hoping to do some more refactors to the client-side routing in general, but I didn't want to block this change behind that, and I don't think that the additional routing logic introduced here will make the future refactor significantly more difficult.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] deploy locally or to CODE
- [x] go to `/dotcopy` and search for items in the last week; there should be something
- [x] open and close the item, refresh the page, check that state is persisted as you'd expect from the URL

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
