### PR TITLE
Tweaks for displaying dataformatted items in feed list

### DIFF
--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -1,5 +1,6 @@
 import {
 	EuiButton,
+	EuiIcon,
 	EuiScreenReaderOnly,
 	EuiText,
 	EuiTextBlockTruncate,
@@ -146,7 +147,7 @@ function MaybeSecondaryCardContent({
 		return <p>{subhead}</p>;
 	}
 	const maybeBodyTextPreview = bodyText
-		? sanitizeHtml(bodyText.replace(/(<br \/>|<\/p>)/g, '&nbsp;'), {
+		? sanitizeHtml(bodyText.replace(/(<br \/>|<\/p>|<\/td>)/g, ' '), {
 				allowedTags: [],
 				allowedAttributes: {},
 			}).slice(0, 300)
@@ -246,15 +247,15 @@ const WirePreviewCard = ({
 		display: grid;
 
 		align-items: baseline;
-		grid-template-areas: 'title time' 'title supplier' 'content supplier' 'content supplier';
-		grid-template-columns: 1fr min-content;
+		grid-template-areas: 'title time time' 'title badges supplier' 'content badges supplier' 'content badges supplier';
+		grid-template-columns: 1fr min-content min-content;
 		grid-template-rows: auto auto auto auto;
 	`;
 
 	const compactCardGrid = css`
 		display: grid;
 		gap: 0.3rem;
-		grid-template-areas: 'title supplier time';
+		grid-template-areas: 'title badges supplier time';
 		grid-template-columns: 1fr min-content min-content;
 		align-items: baseline;
 	`;
@@ -338,6 +339,16 @@ const WirePreviewCard = ({
 								{part}
 							</EuiText>
 						))}
+				</div>
+				<div
+					css={css`
+						grid-area: badges;
+						justify-self: end;
+					`}
+				>
+					{hasDataFormatting && (
+						<EuiIcon type="visTable" size="m" title="Has data formatting" />
+					)}
 				</div>
 				<div
 					css={css`

--- a/newswires/client/src/icons.ts
+++ b/newswires/client/src/icons.ts
@@ -38,6 +38,7 @@ import { icon as returnKey } from '@elastic/eui/es/components/icon/assets/return
 import { icon as search } from '@elastic/eui/es/components/icon/assets/search';
 import { icon as sortLeft } from '@elastic/eui/es/components/icon/assets/sortLeft';
 import { icon as sortRight } from '@elastic/eui/es/components/icon/assets/sortRight';
+import { icon as visTable } from '@elastic/eui/es/components/icon/assets/vis_table';
 import { icon as warning } from '@elastic/eui/es/components/icon/assets/warning';
 import { appendIconComponentCache } from '@elastic/eui/es/components/icon/icon';
 
@@ -80,6 +81,7 @@ const icons = {
 	error,
 	gear,
 	flask,
+	visTable,
 };
 
 // One or more icons are passed in as an object of iconKey (string): IconComponent


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

- Add a 'table' icon to the feed item for stories with data formatting
- Fix the text wrapping and truncation for subheadings. 
  - Before we were replacing certain html tags with non-breaking spaces, but this mean that the truncation didn't work and text was overflowing its container sometimes.
  - I've looked to see if there are any unintended consequences of this change for rendering other items but I haven't been able to spot any yet

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images (Before / After)

### Regular items are unchanged 

<img width="1915" height="222" alt="image" src="https://github.com/user-attachments/assets/574af98e-fcf8-4a78-a6f4-f099d9e7eccc" />

### Items with data formatting have a new icon

<img width="1912" height="200" alt="image" src="https://github.com/user-attachments/assets/ff7a6d81-f70d-47dd-a8a0-dc75af72b04b" />

### Text truncation on subheadings is fixed

(See the third item down on both -- on the left the text is breaking out of the list)

<img width="1914" height="435" alt="image" src="https://github.com/user-attachments/assets/09896c7c-338e-4317-b00c-160771d95093" />



<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
