### PR TITLE
Deduplicate slug in feed for items with data formatting

### DIFF
--- a/newswires/client/src/Item.stories.tsx
+++ b/newswires/client/src/Item.stories.tsx
@@ -37,6 +37,7 @@ const sampleItemData: WireData = {
 	ingestedAt: '2025-02-26T09:58:22.000Z',
 	categoryCodes: ['C:US', 'C:CA'],
 	isFromRefresh: false,
+	hasDataFormatting: false,
 };
 
 const meta = {

--- a/newswires/client/src/Item.stories.tsx
+++ b/newswires/client/src/Item.stories.tsx
@@ -2,6 +2,7 @@ import { EuiProvider } from '@elastic/eui';
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { SearchContextProvider } from './context/SearchContext';
 import { TelemetryContextProvider } from './context/TelemetryContext';
+import { UserSettingsContextProvider } from './context/UserSettingsContext';
 import { setUpIcons } from './icons';
 import { Item } from './Item';
 import type { WireData } from './sharedTypes';
@@ -51,11 +52,13 @@ const meta = {
 		(Story) => (
 			<EuiProvider colorMode="light">
 				<TelemetryContextProvider sendTelemetryEvent={console.log}>
-					<SearchContextProvider>
-						<div style={{ maxWidth: '800px', margin: '0 auto' }}>
-							<Story />
-						</div>
-					</SearchContextProvider>
+					<UserSettingsContextProvider>
+						<SearchContextProvider>
+							<div style={{ maxWidth: '800px', margin: '0 auto' }}>
+								<Story />
+							</div>
+						</SearchContextProvider>
+					</UserSettingsContextProvider>
 				</TelemetryContextProvider>
 			</EuiProvider>
 		),

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -40,13 +40,22 @@ export const WireItemList = ({
 		<>
 			<ul>
 				{wires.map(
-					({ id, content, supplier, highlight, isFromRefresh, ingestedAt }) => (
+					({
+						id,
+						content,
+						supplier,
+						highlight,
+						isFromRefresh,
+						ingestedAt,
+						hasDataFormatting,
+					}) => (
 						<li key={id}>
 							<WirePreviewCard
 								id={id}
 								ingestedAt={ingestedAt}
 								supplier={supplier}
 								content={content}
+								hasDataFormatting={hasDataFormatting}
 								isFromRefresh={isFromRefresh}
 								highlight={highlight}
 								selected={selectedWireId == id.toString()}
@@ -75,17 +84,26 @@ export const WireItemList = ({
 function decideMainHeadingContent(
 	supplier: string,
 	{ headline, slug }: WireData['content'],
+	hasDataFormatting: boolean,
 ): string {
-	const prefix =
-		(supplier === 'AAP' || supplier === 'PA') && slug && slug.length > 0
-			? `${slug} - `
-			: '';
+	const hasNonEmptySlug = slug && slug.length > 0;
 
 	if (headline && headline.length > 0) {
+		/**
+		 * AAP and PA stories have useful slugs. But stories with 'data formatting' have
+		 * their slugs added to their headlines when we get them, so we don't need to add them again.
+		 */
+		const prefix =
+			(supplier === 'AAP' || supplier === 'PA') &&
+			!hasDataFormatting &&
+			hasNonEmptySlug
+				? `${slug} - `
+				: '';
+
 		return `${prefix}${headline}`;
 	}
 
-	if (slug && slug.length > 0) {
+	if (hasNonEmptySlug) {
 		return slug;
 	}
 
@@ -165,6 +183,7 @@ const WirePreviewCard = ({
 	supplier,
 	ingestedAt,
 	content,
+	hasDataFormatting,
 	highlight,
 	selected,
 	view,
@@ -174,6 +193,7 @@ const WirePreviewCard = ({
 	supplier: SupplierInfo;
 	ingestedAt: string;
 	content: WireData['content'];
+	hasDataFormatting: boolean;
 	highlight: string | undefined;
 	selected: boolean;
 	isFromRefresh: boolean;
@@ -214,7 +234,11 @@ const WirePreviewCard = ({
 		method: 'transparent',
 	});
 
-	const mainHeadingContent = decideMainHeadingContent(supplier.name, content);
+	const mainHeadingContent = decideMainHeadingContent(
+		supplier.name,
+		content,
+		hasDataFormatting,
+	);
 
 	const hasBeenViewed = viewedItemIds.includes(id.toString());
 

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -93,12 +93,9 @@ function decideMainHeadingContent(
 		 * AAP and PA stories have useful slugs. But stories with 'data formatting' have
 		 * their slugs added to their headlines when we get them, so we don't need to add them again.
 		 */
-		const prefix =
-			(supplier === 'AAP' || supplier === 'PA') &&
-			!hasDataFormatting &&
-			hasNonEmptySlug
-				? `${slug} - `
-				: '';
+		const shouldShowPrefix =
+			(supplier === 'AAP' || supplier === 'PA') && !hasDataFormatting;
+		const prefix = shouldShowPrefix && hasNonEmptySlug ? `${slug} - ` : '';
 
 		return `${prefix}${headline}`;
 	}

--- a/newswires/client/src/context/transformQueryResponse.test.ts
+++ b/newswires/client/src/context/transformQueryResponse.test.ts
@@ -18,6 +18,7 @@ describe('transformWireItemQueryResult', () => {
 			...input,
 			supplier: supplierData.find((supplier) => supplier.name === 'REUTERS')!,
 			ingestedAt: '2025-01-01T00:00:00+00:00',
+			hasDataFormatting: true,
 		};
 
 		expect(transformWireItemQueryResult(input)).toEqual(expectedOutput);
@@ -37,6 +38,26 @@ describe('transformWireItemQueryResult', () => {
 			...input,
 			supplier: UNKNOWN_SUPPLIER,
 			ingestedAt: '2025-01-02T00:00:00+00:00',
+			hasDataFormatting: true,
+		};
+		expect(transformWireItemQueryResult(input)).toEqual(expectedOutput);
+	});
+
+	it('should set hasDataFormatting to false if content.composerCompatible is false', () => {
+		const input: WireDataFromAPI = {
+			id: 3,
+			supplier: 'AP',
+			externalId: 'external-789',
+			ingestedAt: '2025-01-03T00:00:00Z',
+			categoryCodes: ['category4'],
+			content: { ...sampleFingerpostContent, composerCompatible: false },
+			isFromRefresh: false,
+		};
+		const expectedOutput: WireData = {
+			...input,
+			supplier: supplierData.find((supplier) => supplier.name === 'AP')!,
+			ingestedAt: '2025-01-03T00:00:00+00:00',
+			hasDataFormatting: false,
 		};
 		expect(transformWireItemQueryResult(input)).toEqual(expectedOutput);
 	});

--- a/newswires/client/src/context/transformQueryResponse.test.ts
+++ b/newswires/client/src/context/transformQueryResponse.test.ts
@@ -18,7 +18,7 @@ describe('transformWireItemQueryResult', () => {
 			...input,
 			supplier: supplierData.find((supplier) => supplier.name === 'REUTERS')!,
 			ingestedAt: '2025-01-01T00:00:00+00:00',
-			hasDataFormatting: true,
+			hasDataFormatting: false,
 		};
 
 		expect(transformWireItemQueryResult(input)).toEqual(expectedOutput);
@@ -38,12 +38,12 @@ describe('transformWireItemQueryResult', () => {
 			...input,
 			supplier: UNKNOWN_SUPPLIER,
 			ingestedAt: '2025-01-02T00:00:00+00:00',
-			hasDataFormatting: true,
+			hasDataFormatting: false,
 		};
 		expect(transformWireItemQueryResult(input)).toEqual(expectedOutput);
 	});
 
-	it('should set hasDataFormatting to false if content.composerCompatible is false', () => {
+	it('should set hasDataFormatting to true if content.composerCompatible is false', () => {
 		const input: WireDataFromAPI = {
 			id: 3,
 			supplier: 'AP',
@@ -57,8 +57,48 @@ describe('transformWireItemQueryResult', () => {
 			...input,
 			supplier: supplierData.find((supplier) => supplier.name === 'AP')!,
 			ingestedAt: '2025-01-03T00:00:00+00:00',
-			hasDataFormatting: false,
+			hasDataFormatting: true,
 		};
 		expect(transformWireItemQueryResult(input)).toEqual(expectedOutput);
+	});
+
+	it('should set hasDataFormatting to false if content.composerCompatible is true or missing', () => {
+		const inputWithTrue: WireDataFromAPI = {
+			id: 4,
+			supplier: 'AAP',
+			externalId: 'external-101',
+			ingestedAt: '2025-01-04T00:00:00Z',
+			categoryCodes: ['category5'],
+			content: { ...sampleFingerpostContent, composerCompatible: true },
+			isFromRefresh: false,
+		};
+		const expectedOutputWithTrue: WireData = {
+			...inputWithTrue,
+			supplier: supplierData.find((supplier) => supplier.name === 'AAP')!,
+			ingestedAt: '2025-01-04T00:00:00+00:00',
+			hasDataFormatting: false,
+		};
+		expect(transformWireItemQueryResult(inputWithTrue)).toEqual(
+			expectedOutputWithTrue,
+		);
+
+		const inputWithoutComposerCompatible: WireDataFromAPI = {
+			id: 5,
+			supplier: 'AFP',
+			externalId: 'external-102',
+			ingestedAt: '2025-01-05T00:00:00Z',
+			categoryCodes: ['category6'],
+			content: { ...sampleFingerpostContent }, // composerCompatible is missing
+			isFromRefresh: false,
+		};
+		const expectedOutputWithoutComposerCompatible: WireData = {
+			...inputWithoutComposerCompatible,
+			supplier: supplierData.find((supplier) => supplier.name === 'AFP')!,
+			ingestedAt: '2025-01-05T00:00:00+00:00',
+			hasDataFormatting: false,
+		};
+		expect(
+			transformWireItemQueryResult(inputWithoutComposerCompatible),
+		).toEqual(expectedOutputWithoutComposerCompatible);
 	});
 });

--- a/newswires/client/src/context/transformQueryResponse.ts
+++ b/newswires/client/src/context/transformQueryResponse.ts
@@ -11,5 +11,6 @@ export function transformWireItemQueryResult(data: WireDataFromAPI): WireData {
 		...data,
 		ingestedAt: convertToLocalDateString(data.ingestedAt),
 		supplier: enhanceSupplier(data.supplier),
+		hasDataFormatting: data.content.composerCompatible === false ? true : false, // if composerCompatible is missing or true, we assume true
 	};
 }

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -32,7 +32,7 @@ const FingerpostContentSchema = z
 		destinations: z.object({
 			code: z.array(z.string()),
 		}),
-		composerCompatible: z.boolean().default(true), // the only value we receive from the API is 'false'. If it's not present, we should assume true.
+		composerCompatible: z.boolean().optional(), // the only value we receive from the API is 'false'. If it's not present, we should assume true.
 	})
 	.partial();
 

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -32,6 +32,7 @@ const FingerpostContentSchema = z
 		destinations: z.object({
 			code: z.array(z.string()),
 		}),
+		composerCompatible: z.boolean().default(true), // the only value we receive from the API is 'false'. If it's not present, we should assume true.
 	})
 	.partial();
 
@@ -97,6 +98,7 @@ export type SupplierInfo = z.infer<typeof SupplierInfoSchema>;
 
 export const WireDataSchema = WireDataFromAPISchema.extend({
 	supplier: SupplierInfoSchema,
+	hasDataFormatting: z.boolean(),
 });
 
 export type WireData = z.infer<typeof WireDataSchema>;

--- a/newswires/client/src/tests/fixtures/wireData.ts
+++ b/newswires/client/src/tests/fixtures/wireData.ts
@@ -44,4 +44,5 @@ export const sampleWireData: WireData = {
 		colour: '#000000',
 	},
 	ingestedAt: '2025-01-01T00:00:00+00:00',
+	hasDataFormatting: false,
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We've started getting the headlines through from Fip for items with data formatting, but the headline includes the slug. So we shouldn't add the slug to the headline in the feed view, for items with data formatting.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

### Before

<img width="692" height="42" alt="image" src="https://github.com/user-attachments/assets/3bf3d5d4-debf-417f-b5e9-fdea31edcd35" />

### After

<img width="558" height="40" alt="image" src="https://github.com/user-attachments/assets/3dbbb7af-b578-4d06-8ccf-c35c36774953" />


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
