### PR TITLE
Further overhaul of Sport presets

### DIFF
--- a/newswires/app/conf/Categories.scala
+++ b/newswires/app/conf/Categories.scala
@@ -82,8 +82,8 @@ private[conf] object CategoryCodes {
   }
 
   object Cricket {
-    val REUTERS: List[String] = List("N2:CRIC")
-    val PA: List[String] = List("paCat:SCR")
+    val REUTERS: List[String] = List("N2:CRIC", "subj:15017000")
+    val PA: List[String] = List("paCat:SCR", "subj:15017000")
     val AAP: List[String] = List("subj:15017000")
   }
 
@@ -101,37 +101,37 @@ private[conf] object CategoryCodes {
   }
 
   object RugbyUnion {
-    val REUTERS: List[String] = List("N2:RUGU")
+    val REUTERS: List[String] = List("N2:RUGU", "subj:15049000")
     val AAP: List[String] = List("subj:15049000")
   }
 
   object Tennis {
-    val REUTERS: List[String] = List("N2:TENN")
+    val REUTERS: List[String] = List("N2:TENN", "subj:15065000")
     val AAP: List[String] = List("subj:15065000")
   }
 
   object Cycling {
-    val REUTERS: List[String] = List("N2:CYCL")
+    val REUTERS: List[String] = List("N2:CYCL", "subj:15019000")
     val AAP: List[String] = List("subj:15019000")
   }
 
-  object F1 {
-    val REUTERS: List[String] = List("N2:FO1")
-    val AAP: List[String] = List("subj:15046001")
+  object MotorRacing {
+    val REUTERS: List[String] = List("N2:MORA", "subj:15039000")
+    val AAP: List[String] = List("subj:15039000")
   }
 
   object Golf {
-    val REUTERS: List[String] = List("N2:GOLF")
+    val REUTERS: List[String] = List("N2:GOLF", "subj:15027000")
     val AAP: List[String] = List("subj:15027000")
   }
 
   object Boxing {
-    val REUTERS: List[String] = List("N2:BOXI")
+    val REUTERS: List[String] = List("N2:BOXI", "subj:15014000")
     val AAP: List[String] = List("subj:15014000")
   }
 
   object RugbyLeague {
-    val REUTERS: List[String] = List("N2:RUGL")
+    val REUTERS: List[String] = List("N2:RUGL", "subj:15048000")
     val AAP: List[String] = List("subj:15048000")
   }
 
@@ -151,17 +151,18 @@ private[conf] object CategoryCodes {
     )
   }
   object HorseRacing {
-    val REUTERS: List[String] = List("N2:HORS")
+    val REUTERS: List[String] = List("N2:HORS", "subj:15030000")
     val PA: List[String] = List("paCat:SRR")
     val AAP: List[String] = List("subj:15030000")
   }
 
   object Athletics {
-    val REUTERS: List[String] = List("N2:ATHL")
+    val REUTERS: List[String] = List("N2:ATHL", "subj:15005000")
     val AAP: List[String] = List("subj:15005000")
   }
 
   object Olympics {
+    val REUTERS: List[String] = List("N2:OLY", "subj:15073001", "subj:15073002")
     val AAP: List[String] = List("subj:15073001", "subj:15073002")
   }
 
@@ -1330,7 +1331,7 @@ object Categories {
     "subj:15044001",
     "subj:15045000",
     "subj:15046000",
-    "subj:15046001",
+    "subj:15046001", // this is not cars, this is F1 Powerboat thing
     "subj:15046002",
     "subj:15047000",
     "subj:15047001",

--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -90,7 +90,8 @@ object SearchPresets {
     case "tennis"               => Some(Tennis)
     case "tennis-results"       => Some(TennisResults)
     case "cycling"              => Some(Cycling)
-    case "f1"                   => Some(F1)
+    case "cycling-results"      => Some(CyclingResults)
+    case "motor-racing"         => Some(MotorRacing)
     case "golf"                 => Some(Golf)
     case "golf-results"         => Some(GolfResults)
     case "boxing"               => Some(Boxing)
@@ -225,14 +226,16 @@ object SearchPresets {
   )
 
   private val Soccer = List(
-    SearchPreset.fromSearchTerm(REUTERS, searchTerm = SearchTerm.Simple("-soc-", Slug), CategoryCodes.Soccer.REUTERS),
+    SearchPreset.fromSearchTerm(REUTERS, searchTerm = SearchTerm.Simple("-(OPTA)", SearchField.BodyText), CategoryCodes.Soccer.REUTERS),
     SearchPreset(PA, CategoryCodes.Soccer.PA, hasDataFormatting = Some(false)),
-    SearchPreset.fromText(AFP, SimpleSearchQueries.SOCCER, CategoryCodes.Sport.AFP),
-    SearchPreset.fromSearchTerm(AAP, searchTerm = SearchTerm.Simple("Soccer", Slug), CategoryCodes.Soccer.AAP),
-    SearchPreset(AP, CategoryCodes.Sport.AP, keyword = Some(SimpleSearchQueries.SOCCER))
+    SearchPreset.fromSearchTerm(AFP, searchTerm = SearchTerm.Simple("fbl", Slug), CategoryCodes.Sport.AFP),
+    SearchPreset(AAP, CategoryCodes.Soccer.AAP),
+    //   SearchPreset.fromSearchTerm(AP, searchTerm = SearchTerm.Simple("AP-SOC--", Slug), CategoryCodes.Sport.AP),
+    SearchPreset(AP, CategoryCodes.Sport.AP, keyword = Some("Soccer"))
   )
 
   private val SoccerScores = List(
+    SearchPreset.fromSearchTerm(REUTERS, searchTerm = SearchTerm.Simple("(OPTA)", SearchField.BodyText), CategoryCodes.Soccer.REUTERS),
     SearchPreset.fromSearchTerm(
       PA,
       searchTerm = SearchTerm.Simple("SOCCER", Slug),
@@ -259,13 +262,16 @@ object SearchPresets {
       categoryCodes = CategoryCodes.Sport.PA.filterNot(CategoryCodes.Soccer.PA.contains),
       categoryCodesExcl = CategoryCodes.Soccer.PA
     ),
-    SearchPreset.fromText(AFP, SimpleSearchQueries.NOSOCCER, CategoryCodes.Sport.AFP),
+    SearchPreset.fromSearchTerm(
+      AFP,
+      searchTerm = SearchTerm.Simple("-fbl", Slug),
+      categoryCodes = CategoryCodes.Sport.AFP),
     SearchPreset(
       AAP,
       categoryCodes = CategoryCodes.Sport.AAP.filterNot(CategoryCodes.Soccer.AAP.contains),
       categoryCodesExcl = CategoryCodes.Soccer.AAP
     ),
-    SearchPreset(AP, CategoryCodes.Sport.AP, keyword = Some(SimpleSearchQueries.NOSOCCER))
+    SearchPreset(AP, CategoryCodes.Sport.AP, keywordExcl = List("Soccer"))
   )
 
   private val Cricket = List(
@@ -273,7 +279,8 @@ object SearchPresets {
     SearchPreset(PA, CategoryCodes.Cricket.PA),
     SearchPreset.fromText(AFP, text = SimpleSearchQueries.CRICKET, CategoryCodes.Sport.AFP),
     SearchPreset(AAP, CategoryCodes.Cricket.AAP),
-    SearchPreset(AP, CategoryCodes.Sport.AP, keyword = Some(SimpleSearchQueries.CRICKET))
+    SearchPreset(AP, CategoryCodes.Sport.AP, keyword = Some("Cricket"))
+
   )
 
   private val CricketResults = List(
@@ -281,53 +288,57 @@ object SearchPresets {
   )
 
   private val RugbyLeague = List(
-    SearchPreset
-      .fromSearchTerm(REUTERS, searchTerm = SearchTerm.Simple("RUGBYL", Slug), CategoryCodes.RugbyLeague.REUTERS),
-    SearchPreset.fromText(PA, text = SimpleSearchQueries.RUGBY_LEAGUE, categoryCodes = List("paCat:SRS", "paCat:SSS")),
-    SearchPreset.fromText(AFP, text = SimpleSearchQueries.RUGBY_LEAGUE, CategoryCodes.Sport.AFP),
+    SearchPreset.fromSearchTerm(REUTERS, searchTerm = SearchTerm.Simple("-(OPTA)", SearchField.BodyText), CategoryCodes.RugbyLeague.REUTERS),
+    SearchPreset.fromSearchTerm(PA, searchTerm = SearchTerm.Simple("RUGBYL", Slug), CategoryCodes.Sport.PA), // make excluding "sourceFeed": "PA PA SPORT DATA"
+    SearchPreset.fromSearchTerm(AFP, searchTerm = SearchTerm.Simple("RugbyL", Slug), CategoryCodes.Sport.AFP),
     SearchPreset(AAP, CategoryCodes.RugbyLeague.AAP),
-    SearchPreset.fromText(AP, text = SimpleSearchQueries.RUGBY_LEAGUE, CategoryCodes.Sport.AP, keyword = Some("Rugby"))
+    SearchPreset.fromSearchTerm(AP, searchTerm = SearchTerm.Simple("RGL", Slug), CategoryCodes.Sport.AP, keyword = Some("Rugby"))
   )
 
   private val RugbyUnion = List(
     SearchPreset
-      .fromSearchTerm(REUTERS, searchTerm = SearchTerm.Simple("RUGBYU", Slug), CategoryCodes.RugbyUnion.REUTERS),
-    SearchPreset.fromText(PA, text = SimpleSearchQueries.RUGBY_UNION, categoryCodes = List("paCat:SRS", "paCat:SSS")),
-    SearchPreset.fromText(AFP, text = SimpleSearchQueries.RUGBY_UNION, CategoryCodes.Sport.AFP),
+      .fromSearchTerm(REUTERS, searchTerm = SearchTerm.Simple("-(OPTA)", SearchField.BodyText), CategoryCodes.RugbyUnion.REUTERS),
+    SearchPreset.fromSearchTerm(PA, searchTerm = SearchTerm.Simple("RUGBYU", Slug), CategoryCodes.Sport.PA), // make excluding "sourceFeed": "PA PA SPORT DATA"
+    SearchPreset.fromSearchTerm(AFP, searchTerm = SearchTerm.Simple("RugbyU", Slug), CategoryCodes.Sport.AFP),
     SearchPreset(AAP, CategoryCodes.RugbyUnion.AAP),
-    SearchPreset.fromText(AP, text = SimpleSearchQueries.RUGBY_UNION, CategoryCodes.Sport.AP, keyword = Some("Rugby"))
+    SearchPreset.fromSearchTerm(AP, searchTerm = SearchTerm.Simple("RGU", Slug), CategoryCodes.Sport.AP, keyword = Some("Rugby"))
   )
 
   private val RugbyResults = List(
-    SearchPreset(PA, categoryCodes = CategoryCodes.RugbyResults.PA)
+    SearchPreset(PA, categoryCodes = CategoryCodes.RugbyResults.PA),
+    SearchPreset.fromSearchTerm(REUTERS, searchTerm = SearchTerm.Simple("(OPTA)", SearchField.BodyText), CategoryCodes.RugbyLeague.REUTERS),
   )
 
   private val Tennis = List(
-    SearchPreset.fromSearchTerm(REUTERS, searchTerm = SearchTerm.Simple("TENNIS", Slug), CategoryCodes.Tennis.REUTERS),
-    SearchPreset.fromText(PA, text = SimpleSearchQueries.TENNIS, categoryCodes = List("paCat:SRS", "paCat:SSS")),
-    SearchPreset.fromText(AFP, text = SimpleSearchQueries.TENNIS, CategoryCodes.Sport.AFP),
+    SearchPreset.fromSearchTerm(REUTERS, searchTerm = SearchTerm.Simple("-(OPTA)", SearchField.BodyText), CategoryCodes.Tennis.REUTERS),
+    SearchPreset.fromSearchTerm(PA, searchTerm = SearchTerm.Simple("TENNIS", Slug), CategoryCodes.Sport.PA),
+    SearchPreset.fromSearchTerm(AFP, searchTerm = SearchTerm.Simple("Tennis", Slug), CategoryCodes.Sport.AFP),
     SearchPreset(AAP, CategoryCodes.Tennis.AAP),
-    SearchPreset(AP, CategoryCodes.Sport.AP, keyword = Some("Tennis"))
+    SearchPreset.fromSearchTerm(AP, searchTerm = SearchTerm.Simple("AP TEN", Slug), CategoryCodes.Sport.AP, keyword = Some("Tennis"))
   )
 
   private val TennisResults = List(
+    SearchPreset.fromSearchTerm(REUTERS, searchTerm = SearchTerm.Simple("(OPTA)", SearchField.BodyText), CategoryCodes.Tennis.REUTERS),
     SearchPreset.fromSearchTerm(PA, searchTerm = SearchTerm.Simple("TENNIS", Slug), hasDataFormatting = Some(true))
   )
 
   private val Cycling = List(
-    SearchPreset(REUTERS, CategoryCodes.Cycling.REUTERS),
-    SearchPreset.fromText(PA, text = SimpleSearchQueries.CYCLING, categoryCodes = List("paCat:SRS", "paCat:SSS")),
-    SearchPreset.fromText(AFP, text = SimpleSearchQueries.CYCLING, CategoryCodes.Sport.AFP),
+    SearchPreset.fromSearchTerm(REUTERS, searchTerm = SearchTerm.Simple("-Gracenote", SearchField.BodyText), CategoryCodes.Cycling.REUTERS),
+    SearchPreset.fromSearchTerm(PA, searchTerm = SearchTerm.Simple("CYCLING", Slug), CategoryCodes.Sport.PA),
+    SearchPreset.fromSearchTerm(AFP, searchTerm = SearchTerm.Simple("cycling", Slug), CategoryCodes.Sport.AFP),
     SearchPreset(AAP, CategoryCodes.Cycling.AAP),
-    SearchPreset(AP, CategoryCodes.Sport.AP, keyword = Some("Cycling"))
+    SearchPreset.fromSearchTerm(AP, searchTerm = SearchTerm.Simple("CYC", Slug), CategoryCodes.Sport.AP, keyword = Some("Cycling"))
   )
 
-  private val F1 = List(
-    SearchPreset.fromSearchTerm(REUTERS, searchTerm = SearchTerm.Simple("MOTOR RACING"), CategoryCodes.F1.REUTERS),
-    SearchPreset.fromText(PA, text = SimpleSearchQueries.F1, categoryCodes = List("paCat:SRS", "paCat:SSS")),
-    SearchPreset.fromText(AFP, text = SimpleSearchQueries.F1, CategoryCodes.Sport.AFP),
-    SearchPreset(AAP, CategoryCodes.F1.AAP),
-    SearchPreset(AP, CategoryCodes.Sport.AP, keyword = Some("Formula One racing"))
+  private val CyclingResults = List(
+    SearchPreset.fromSearchTerm(REUTERS, searchTerm = SearchTerm.Simple("Gracenote", SearchField.BodyText), CategoryCodes.Cycling.REUTERS),
+  )
+  private val MotorRacing = List(
+    SearchPreset(REUTERS, CategoryCodes.MotorRacing.REUTERS),
+    SearchPreset.fromSearchTerm(PA, searchTerm = SearchTerm.Simple("auto", Slug), CategoryCodes.Sport.PA),
+    SearchPreset.fromSearchTerm(AFP, searchTerm = SearchTerm.Simple("auto", Slug), CategoryCodes.Sport.AFP),
+    SearchPreset(AAP, CategoryCodes.MotorRacing.AAP),
+    SearchPreset(AP, CategoryCodes.Sport.AP, keyword = Some("Automobile racing"))
   )
 
   private val Golf = List(
@@ -336,25 +347,26 @@ object SearchPresets {
       .fromSearchTerm(PA, searchTerm = SearchTerm.Simple("GOLF", Slug), categoryCodesExcl = List("paCat:RSR")),
     SearchPreset.fromText(AFP, text = SimpleSearchQueries.GOLF, CategoryCodes.Sport.AFP),
     SearchPreset(AAP, CategoryCodes.Golf.AAP),
-    SearchPreset(AP, CategoryCodes.Sport.AP, keyword = Some("Golf"))
+    SearchPreset.fromSearchTerm(AP, searchTerm = SearchTerm.Simple("GLF -Scores", Slug), CategoryCodes.Sport.AP, keyword = Some("Golf"))
   )
 
   private val GolfResults = List(
-    SearchPreset.fromSearchTerm(PA, searchTerm = SearchTerm.Simple("GOLF", Slug), categoryCodes = List("paCat:RSR"))
+    SearchPreset.fromSearchTerm(PA, searchTerm = SearchTerm.Simple("GOLF", Slug), categoryCodes = List("paCat:RSR")),
+    SearchPreset.fromSearchTerm(AP, searchTerm = SearchTerm.Simple("GLF Scores", Slug), CategoryCodes.Sport.AP, keyword = Some("Golf"))
   )
 
   private val Boxing = List(
     SearchPreset(REUTERS, CategoryCodes.Boxing.REUTERS),
-    SearchPreset.fromText(PA, text = SimpleSearchQueries.BOXING, categoryCodes = List("paCat:SRS", "paCat:SSS")),
-    SearchPreset.fromText(AFP, text = SimpleSearchQueries.BOXING, CategoryCodes.Sport.AFP),
+    SearchPreset.fromSearchTerm(PA, searchTerm = SearchTerm.Simple("BOXING", Slug), categoryCodes = List("paCat:SRS", "paCat:SSS")),
+    SearchPreset.fromSearchTerm(AFP, searchTerm = SearchTerm.Simple("Box", Slug), CategoryCodes.Sport.AFP),
     SearchPreset(AAP, CategoryCodes.Boxing.AAP),
-    SearchPreset(AP, CategoryCodes.Sport.AP, keyword = Some("Boxing"))
+    SearchPreset.fromSearchTerm(AP, searchTerm = SearchTerm.Simple("BOX", Slug), keyword = Some("Boxing"))
   )
 
   private val HorseRacing = List(
     SearchPreset(REUTERS, CategoryCodes.HorseRacing.REUTERS),
     SearchPreset(PA, CategoryCodes.HorseRacing.PA),
-    SearchPreset.fromText(AFP, text = SimpleSearchQueries.HORSE_RACING, CategoryCodes.Sport.AFP),
+    SearchPreset.fromSearchTerm(AFP, searchTerm = SearchTerm.Simple("racing", Slug), CategoryCodes.Sport.AFP),
     SearchPreset(AAP, CategoryCodes.HorseRacing.AAP),
     SearchPreset(AP, CategoryCodes.Sport.AP, keyword = Some("Horse racing"))
   )
@@ -368,15 +380,15 @@ object SearchPresets {
     ),
     SearchPreset.fromSearchTerm(AFP, searchTerm = SearchTerm.Simple("ATHLETICS", Slug), CategoryCodes.Sport.AFP),
     SearchPreset(AAP, CategoryCodes.Athletics.AAP),
-    SearchPreset(AP, CategoryCodes.Sport.AP, keyword = Some("Track and field"))
+    SearchPreset.fromSearchTerm(AP, searchTerm = SearchTerm.Simple("ATH", Slug), CategoryCodes.Sport.AP, keyword = Some("Track and field"))
   )
 
   private val Olympics = List(
-    SearchPreset.fromText(REUTERS, text = SimpleSearchQueries.OLYMPICS, categoryCodes = List("subj:15073000")),
-    SearchPreset.fromText(PA, text = SimpleSearchQueries.OLYMPICS, categoryCodes = List("paCat:SRS", "paCat:SSS")),
-    SearchPreset.fromText(AFP, text = SimpleSearchQueries.OLYMPICS, CategoryCodes.Sport.AFP),
+    SearchPreset(REUTERS, CategoryCodes.Olympics.REUTERS),
+    SearchPreset.fromText(PA, text = SimpleSearchQueries.OLYMPICS, categoryCodes = List("paCat:SRS", "paCat:SSS")), //too broad, to recheck when stories arrive
+    SearchPreset.fromSearchTerm(AFP, searchTerm = SearchTerm.Simple("Oly", Slug), CategoryCodes.Sport.AFP),
     SearchPreset(AAP, CategoryCodes.Olympics.AAP),
-    SearchPreset.fromText(AP, text = SimpleSearchQueries.OLYMPICS, CategoryCodes.Sport.AP)
+    SearchPreset(AP, CategoryCodes.Sport.AP, keyword = Some("Olympic games"))
   )
 
   private val AllDataFormats = List(

--- a/newswires/client/src/presets.ts
+++ b/newswires/client/src/presets.ts
@@ -33,8 +33,16 @@ export const sportPresets: Preset[] = [
 		id: 'cricket-results',
 	},
 	{
+		name: 'Rugby League',
+		id: 'rugby-league',
+	},
+	{
 		name: 'Rugby Union',
 		id: 'rugby-union',
+	},
+	{
+		name: 'Rugby Results',
+		id: 'rugby-results',
 	},
 	{
 		name: 'Tennis',
@@ -49,8 +57,12 @@ export const sportPresets: Preset[] = [
 		id: 'cycling',
 	},
 	{
-		name: 'Formula One',
-		id: 'f1',
+		name: 'Cycling Results',
+		id: 'cycling-results',
+	},
+	{
+		name: 'Motor Racing',
+		id: 'motor-racing',
 	},
 	{
 		name: 'Golf',
@@ -63,14 +75,6 @@ export const sportPresets: Preset[] = [
 	{
 		name: 'Boxing',
 		id: 'boxing',
-	},
-	{
-		name: 'Rugby League',
-		id: 'rugby-league',
-	},
-	{
-		name: 'Rugby Results',
-		id: 'rugby-results',
 	},
 	{
 		name: 'Horse racing',


### PR DESCRIPTION
This builds on @lindseydew’s work in `ld/add-sports-presets` (which, among other things, allows for slug searches, yay!)
  
## What does this change?

- Fixes sort order of Rugby presets in the dropdown
- Renames F1 to Motor Racing (and broadens its scope to all car racing), but without motorbikes, so maybe should be called Car Racing? Or include motorbikes?
- Adds Cycling Results presets to declutter cycling stories
- I went through all Sport presets, tightened them and separated results as best I could
- To improve it, we need two things I can’t see us having currently:
   - ability to specify a preset by searching in multiple fields at once (eg. AP Soccer should be Slug: `fbl` and Headline: `-table -results`)
   - ability to exclude subsuppliers (`sourceFeed` field) (eg. some PA Rugby Results arrive as `pa:SSS`, but should be excluded by`sourceFeed:-"PA PA SPORT DATA"`)
- We should probably rename `All Data Formats` to `All Sport Tables` (but there is a broaden question of making TYPES of stories more evident/accessible)

## How to test

Best to compare with naked `ld/add-sports-presets`, I suppose. I would give details of what this PR does, but unsure if current CODE contains naked `ld/add-sports-presets`.

## How can we measure success?

This seems ready(ish) for human consumption. 

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
