### PR TITLE
Remove sideNav state from SearchContext; pass as prop from App instead

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -89,14 +89,10 @@ const Alert = ({
 };
 
 export function App() {
-	const {
-		config,
-		state,
-		handleEnterQuery,
-		handleRetry,
-		openTicker,
-		sideNavIsOpen,
-	} = useSearch();
+	const { config, state, handleEnterQuery, handleRetry, openTicker } =
+		useSearch();
+
+	const [sideNavIsOpen, setSideNavIsOpen] = useState<boolean>(false);
 
 	const [sideNavIsDocked, setSideNavIsDocked] = useState<boolean>(true);
 	const [displayDisclaimer, setDisplayDisclaimer] = useState<boolean>(() =>
@@ -242,7 +238,13 @@ export function App() {
 							${status === 'loading' && 'background: white;'}
 						`}
 					>
-						{isPoppedOut && <SideNav navIsDocked={false} />}
+						{isPoppedOut && (
+							<SideNav
+								navIsDocked={false}
+								sideNavIsOpen={sideNavIsOpen}
+								setSideNavIsOpen={setSideNavIsOpen}
+							/>
+						)}
 						{!isPoppedOut && (
 							<EuiHeader position="fixed">
 								<EuiHeaderSection side={'left'}>
@@ -261,7 +263,11 @@ export function App() {
 										>
 											<EuiIcon type={'menu'} size="m" aria-hidden="true" />
 										</EuiHeaderSectionItemButton>
-										<SideNav navIsDocked={sideNavIsDocked} />
+										<SideNav
+											navIsDocked={sideNavIsDocked}
+											sideNavIsOpen={sideNavIsOpen}
+											setSideNavIsOpen={setSideNavIsOpen}
+										/>
 									</EuiHeaderSectionItem>
 									<EuiShowFor sizes={['xs']}>
 										{!sideNavIsOpen && (
@@ -369,6 +375,7 @@ export function App() {
 												) : undefined
 											}
 											directionOverride={'vertical'}
+											setSideNavIsOpen={setSideNavIsOpen}
 										/>
 									)}
 
@@ -376,7 +383,9 @@ export function App() {
 										<ItemData id={selectedItemId} />
 									)}
 
-									{view !== 'item' && !isPoppedOut && <Feed />}
+									{view !== 'item' && !isPoppedOut && (
+										<Feed setSideNavIsOpen={setSideNavIsOpen} />
+									)}
 								</EuiShowFor>
 								<EuiShowFor sizes={['m', 'l', 'xl']}>
 									<ResizableContainer
@@ -386,6 +395,7 @@ export function App() {
 												<ItemData id={selectedItemId} />
 											) : undefined
 										}
+										setSideNavIsOpen={setSideNavIsOpen}
 									/>
 								</EuiShowFor>
 							</>

--- a/newswires/client/src/Feed.tsx
+++ b/newswires/client/src/Feed.tsx
@@ -16,6 +16,7 @@ import { WireItemList } from './WireItemList.tsx';
 export interface FeedProps {
 	containerRef?: React.RefObject<HTMLDivElement>;
 	direction?: string;
+	setSideNavIsOpen: (isOpen: boolean) => void;
 }
 
 const baseStyles = css`
@@ -26,7 +27,11 @@ const columnStyles = css`
 	flex-direction: column;
 `;
 
-export const Feed = ({ containerRef, direction }: FeedProps) => {
+export const Feed = ({
+	containerRef,
+	direction,
+	setSideNavIsOpen,
+}: FeedProps) => {
 	const { state, config } = useSearch();
 	const { status, queryData } = state;
 
@@ -73,7 +78,7 @@ export const Feed = ({ containerRef, direction }: FeedProps) => {
 						<EuiEmptyPrompt
 							body={
 								<>
-									<SearchSummary />
+									<SearchSummary setSideNavIsOpen={setSideNavIsOpen} />
 									<p>Try another search or reset filters.</p>
 								</>
 							}
@@ -90,7 +95,7 @@ export const Feed = ({ containerRef, direction }: FeedProps) => {
 						<div>
 							<EuiFlexGroup css={[baseStyles, isColumn && columnStyles]}>
 								<EuiFlexItem style={{ flex: 1 }}>
-									<SearchSummary />
+									<SearchSummary setSideNavIsOpen={setSideNavIsOpen} />
 								</EuiFlexItem>
 								{!isPoppedOut && (
 									<EuiFlexItem grow={false}>

--- a/newswires/client/src/ResizableContainer.tsx
+++ b/newswires/client/src/ResizableContainer.tsx
@@ -41,10 +41,12 @@ export const ResizableContainer = ({
 	Feed,
 	Item,
 	directionOverride,
+	setSideNavIsOpen,
 }: {
 	Feed: React.ComponentType<FeedProps>;
 	Item?: React.ReactNode;
 	directionOverride?: PanelDirections;
+	setSideNavIsOpen: (isOpen: boolean) => void;
 }) => {
 	const leftPanelRef = useRef<HTMLDivElement>(null);
 
@@ -82,7 +84,11 @@ export const ResizableContainer = ({
 						style={{ padding: 0 }}
 						panelRef={leftPanelRef}
 					>
-						<Feed containerRef={leftPanelRef} direction={direction} />
+						<Feed
+							containerRef={leftPanelRef}
+							direction={direction}
+							setSideNavIsOpen={setSideNavIsOpen}
+						/>
 					</EuiResizablePanel>
 					<EuiResizableButton
 						accountForScrollbars={'both'}

--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -291,12 +291,15 @@ const Summary = ({
 	);
 };
 
-export const SearchSummary = () => {
+export const SearchSummary = ({
+	setSideNavIsOpen,
+}: {
+	setSideNavIsOpen: (isOpen: boolean) => void;
+}) => {
 	const {
 		state: { queryData, status, lastUpdate },
 		config,
 		openTicker,
-		setSideNavIsOpen,
 	} = useSearch();
 	const isPoppedOut = config.ticker;
 

--- a/newswires/client/src/SideNav.tsx
+++ b/newswires/client/src/SideNav.tsx
@@ -49,7 +49,15 @@ function presetName(presetId: string): string | undefined {
 	return presets.find((preset) => preset.id === presetId)?.name;
 }
 
-export const SideNav = ({ navIsDocked }: { navIsDocked: boolean }) => {
+export const SideNav = ({
+	navIsDocked,
+	sideNavIsOpen,
+	setSideNavIsOpen,
+}: {
+	navIsDocked: boolean;
+	sideNavIsOpen: boolean;
+	setSideNavIsOpen: (isOpen: boolean) => void;
+}) => {
 	const largeMinBreakpoint = useEuiMinBreakpoint('l');
 	const isLargeScreen = useIsWithinBreakpoints(['l']);
 	const isExtraSmallScreen = useIsWithinBreakpoints(['xs']);
@@ -62,8 +70,6 @@ export const SideNav = ({ navIsDocked }: { navIsDocked: boolean }) => {
 		activeSuppliers,
 		toggleSupplier,
 		openTicker,
-		sideNavIsOpen: navIsOpen,
-		setSideNavIsOpen: setNavIsOpen,
 	} = useSearch();
 
 	const isPoppedOut = config.ticker;
@@ -190,21 +196,21 @@ export const SideNav = ({ navIsDocked }: { navIsDocked: boolean }) => {
 
 	useEffect(() => {
 		if (isLargeScreen) {
-			setNavIsOpen(false);
+			setSideNavIsOpen(false);
 		}
-	}, [isLargeScreen, setNavIsOpen]);
+	}, [isLargeScreen, setSideNavIsOpen]);
 
 	return (
 		<>
 			<EuiCollapsibleNav
-				isOpen={navIsOpen}
+				isOpen={sideNavIsOpen}
 				isDocked={navIsDocked}
 				size={300}
 				button={
 					!isPoppedOut ? (
 						<EuiHeaderSectionItemButton
 							aria-label="Toggle main navigation"
-							onClick={() => setNavIsOpen((isOpen) => !isOpen)}
+							onClick={() => setSideNavIsOpen(!sideNavIsOpen)}
 							css={css`
 								${largeMinBreakpoint} {
 									display: none;
@@ -215,7 +221,7 @@ export const SideNav = ({ navIsDocked }: { navIsDocked: boolean }) => {
 						</EuiHeaderSectionItemButton>
 					) : undefined
 				}
-				onClose={() => setNavIsOpen(false)}
+				onClose={() => setSideNavIsOpen(false)}
 				css={css`
 					.hover-only-icon {
 						opacity: 0;

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -130,8 +130,6 @@ export type SearchContextShape = {
 	loadMoreResults: (beforeId: string) => Promise<void>;
 	activeSuppliers: string[];
 	toggleSupplier: (supplier: string) => void;
-	sideNavIsOpen: boolean;
-	setSideNavIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };
 export const SearchContext: Context<SearchContextShape | null> =
 	createContext<SearchContextShape | null>(null);
@@ -142,8 +140,6 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 	const [previousItemId, setPreviousItemId] = useState<string | undefined>(
 		undefined,
 	);
-
-	const [sideNavIsOpen, setSideNavIsOpen] = useState<boolean>(false);
 
 	const [currentConfig, setConfig] = useState<Config>(() =>
 		urlToConfig(window.location),
@@ -499,8 +495,6 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 				activeSuppliers,
 				toggleSupplier,
 				openTicker,
-				sideNavIsOpen,
-				setSideNavIsOpen,
 			}}
 		>
 			{children}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This is a preparatory step towards refactoring SearchContext. Side nav state isn't connected directly to any of the search state management, so it's good to manage it separately. I thought about creating a new context provider for it, but prop-drilling works fine at the moment, and it'd be easy to switch to a new context later if we want.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

<!-- Database migrations need to be applied manually before releasing. The docs can be found in db/README.md -->