### PR TITLE
Refactor alert UI: use EuiCallOut instead of EuiToast

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -2,6 +2,7 @@ import {
 	EuiButton,
 	EuiButtonEmpty,
 	EuiButtonIcon,
+	EuiCallOut,
 	EuiEmptyPrompt,
 	EuiFlexGroup,
 	EuiHeader,
@@ -20,10 +21,8 @@ import {
 	EuiShowFor,
 	EuiText,
 	EuiTitle,
-	EuiToast,
 	useEuiMaxBreakpoint,
 	useEuiMinBreakpoint,
-	useIsWithinMinBreakpoint,
 } from '@elastic/eui';
 import { css, Global } from '@emotion/react';
 import { useCallback, useEffect, useState } from 'react';
@@ -48,45 +47,6 @@ import { SideNav } from './SideNav';
 import { TelemetryPixel } from './TelemetryPixel.tsx';
 import { Tooltip } from './Tooltip.tsx';
 import { defaultQuery } from './urlState';
-
-const Alert = ({
-	title,
-	icon = 'warning',
-}: {
-	title: string;
-	icon?: string;
-}) => {
-	const isOnLargerScreen = useIsWithinMinBreakpoint('l');
-
-	return (
-		<div
-			css={css`
-				.euiToast.header-only span {
-					font-weight: 500;
-					font-size: 1rem;
-				}
-
-				.euiToast.header-only svg {
-					top: 2px;
-				}
-			`}
-		>
-			<EuiToast
-				title={title}
-				iconType={icon}
-				className={'header-only'}
-				css={css`
-					padding: 8px;
-					border-radius: 0;
-					background: #fdf6d8;
-					position: fixed;
-					z-index: 1000;
-					${isOnLargerScreen && 'width: calc(100% - 300px)'}
-				`}
-			></EuiToast>
-		</div>
-	);
-};
 
 export function App() {
 	const { config, state, handleEnterQuery, handleRetry, openTicker } =
@@ -151,7 +111,6 @@ export function App() {
 
 	const largeMinBreakpoint = useEuiMinBreakpoint('l');
 	const largeMaxBreakpoint = useEuiMaxBreakpoint('l');
-	const smallMinBreakpoint = useEuiMinBreakpoint('s');
 
 	return (
 		<>
@@ -210,27 +169,25 @@ export function App() {
 						</EuiModal>
 					)}
 					{status === 'offline' && (
-						<Alert
+						<EuiCallOut
 							title="The application is no longer retrieving updates. Data
 							synchronization will resume once connectivity is restored."
+							color="warning"
+							iconType="warning"
 						/>
 					)}
 					{isRestricted(query.dateRange?.end) &&
 						status !== 'offline' &&
 						status !== 'error' && (
-							<Alert
+							<EuiCallOut
 								title="Your current filter settings exclude recent updates. Adjust the
 								filter to see the latest data."
+								color="warning"
+								iconType="warning"
 							/>
 						)}
 					<div
 						css={css`
-							${(status === 'offline' || isRestricted(query.dateRange?.end)) &&
-							`padding-top: 40px;
-							  ${smallMinBreakpoint} {
-								padding-top: 72px;
-							  }
-							`}
 							height: 100%;
 							max-height: 100vh;
 							${(status === 'loading' || status === 'error') &&


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<EuiCallOut> is "to display important messages directly related to content on the page", [according to the docs](https://eui.elastic.co/v106.6.0/docs/components/display/callout/#warning). Elastic UI also handles the offset required for it to stick to the top of the container, without us having to add our own custom logic to try and add the offset. (This custom logic was broken, which is what prompted me to look at this component in the first place.)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

### Before

(note the extra empty vertical space between the alert message and the search summary)

<img width="938" height="487" alt="image" src="https://github.com/user-attachments/assets/8d626b5e-d8df-4002-9911-5da74fcbcf2b" />


### After

<img width="934" height="334" alt="image" src="https://github.com/user-attachments/assets/164f2859-54e3-4c3a-9965-25b5cdb837d8" />


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

<!-- Database migrations need to be applied manually before releasing. The docs can be found in db/README.md -->