### PR TITLE
Split main feed/item layout into separate components

### DIFF
--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -169,6 +169,7 @@ export function App() {
 							synchronization will resume once connectivity is restored."
 							color="warning"
 							iconType="warning"
+							size="s"
 						/>
 					)}
 					{isRestricted(config.query.dateRange?.end) &&
@@ -179,6 +180,7 @@ export function App() {
 								filter to see the latest data."
 								color="warning"
 								iconType="warning"
+								size="s"
 							/>
 						)}
 					{!!config.ticker && (

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -1,15 +1,8 @@
 import {
 	EuiButton,
 	EuiButtonEmpty,
-	EuiButtonIcon,
 	EuiCallOut,
 	EuiEmptyPrompt,
-	EuiFlexGroup,
-	EuiHeader,
-	EuiHeaderSection,
-	EuiHeaderSectionItem,
-	EuiHeaderSectionItemButton,
-	EuiIcon,
 	EuiModal,
 	EuiModalBody,
 	EuiModalFooter,
@@ -17,18 +10,11 @@ import {
 	EuiModalHeaderTitle,
 	EuiPageTemplate,
 	EuiProvider,
-	EuiScreenReaderOnly,
-	EuiShowFor,
 	EuiText,
-	EuiTitle,
-	useEuiMaxBreakpoint,
-	useEuiMinBreakpoint,
 } from '@elastic/eui';
 import { css, Global } from '@emotion/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { z } from 'zod/v4';
-import { STAGE } from './app-configuration.ts';
-import { AppTitle } from './AppTitle.tsx';
 import { useKeyboardShortcuts } from './context/KeyboardShortcutsContext.tsx';
 import {
 	loadOrSetInLocalStorage,
@@ -36,41 +22,49 @@ import {
 } from './context/localStorage.tsx';
 import { useSearch } from './context/SearchContext.tsx';
 import { isRestricted } from './dateHelpers.ts';
-import { Feed } from './Feed';
+import { DefaultLayout } from './DefaultLayout.tsx';
 import { fontStyles } from './fontStyles.ts';
-import { ItemData } from './ItemData.tsx';
 import { presetLabel } from './presets.ts';
-import { ResizableContainer } from './ResizableContainer.tsx';
-import { SearchBox } from './SearchBox.tsx';
-import { SettingsMenu } from './SettingsMenu.tsx';
-import { SideNav } from './SideNav';
-import { TelemetryPixel } from './TelemetryPixel.tsx';
-import { Tooltip } from './Tooltip.tsx';
-import { defaultQuery } from './urlState';
+import { TickerLayout } from './TickerLayout.tsx';
+import { defaultQuery } from './urlState.ts';
+
+function ErrorPrompt({ errorMessage }: { errorMessage: string }) {
+	const { handleEnterQuery, handleRetry } = useSearch();
+	return (
+		<EuiEmptyPrompt
+			css={css`
+				background: white;
+			`}
+			actions={[
+				<EuiButton onClick={handleRetry} key="retry" iconType={'refresh'}>
+					Retry
+				</EuiButton>,
+				<EuiButton
+					onClick={() => handleEnterQuery(defaultQuery)}
+					key="clear"
+					iconType={'cross'}
+				>
+					Clear
+				</EuiButton>,
+			]}
+			body={<p>Sorry, failed to load because of {errorMessage}</p>}
+			hasBorder={true}
+		/>
+	);
+}
 
 export function App() {
-	const { config, state, handleEnterQuery, handleRetry, openTicker } =
-		useSearch();
+	const { config, state } = useSearch();
 
-	const [sideNavIsOpen, setSideNavIsOpen] = useState<boolean>(false);
-
-	const [sideNavIsDocked, setSideNavIsDocked] = useState<boolean>(true);
 	const [displayDisclaimer, setDisplayDisclaimer] = useState<boolean>(() =>
 		loadOrSetInLocalStorage<boolean>('displayDisclaimer', z.boolean(), true),
-	);
-	const handleTextQueryChange = useCallback(
-		(newQuery: string) => {
-			handleEnterQuery({ ...config.query, q: newQuery });
-		},
-		[config.query, handleEnterQuery],
 	);
 
 	const { handleShortcutKeyUp } = useKeyboardShortcuts();
 
-	const { view, itemId: selectedItemId, query } = config;
-	const { status } = state;
+	const isTickerView = config.ticker;
 
-	const isPoppedOut = config.ticker;
+	const { status } = state;
 
 	const dismissDisclaimer = (persist?: boolean) => {
 		setDisplayDisclaimer(false);
@@ -98,7 +92,7 @@ export function App() {
 		const displaySuppliers = !!supplier && supplier.length > 0;
 
 		if (displayPreset || displaySuppliers) {
-			const newswiresPrefix = !isPoppedOut ? 'Newswires -- ' : '';
+			const newswiresPrefix = !isTickerView ? 'Newswires -- ' : '';
 			const titlePrefix = supplier!.length == 1 ? `${supplier![0]} ` : '';
 			const titlePostfix =
 				supplier!.length > 1 ? ` ${supplier!.join(', ')}` : '';
@@ -107,10 +101,11 @@ export function App() {
 		} else {
 			document.title = 'Newswires';
 		}
-	}, [isPoppedOut, config.query]);
+	}, [isTickerView, config.query]);
 
-	const largeMinBreakpoint = useEuiMinBreakpoint('l');
-	const largeMaxBreakpoint = useEuiMaxBreakpoint('l');
+	const errorPromptComponent = useMemo(() => {
+		return <ErrorPrompt errorMessage={state.error ?? 'unknown error'} />;
+	}, [state.error]);
 
 	return (
 		<>
@@ -176,7 +171,7 @@ export function App() {
 							iconType="warning"
 						/>
 					)}
-					{isRestricted(query.dateRange?.end) &&
+					{isRestricted(config.query.dateRange?.end) &&
 						status !== 'offline' &&
 						status !== 'error' && (
 							<EuiCallOut
@@ -186,203 +181,12 @@ export function App() {
 								iconType="warning"
 							/>
 						)}
-					<div
-						css={css`
-							height: 100%;
-							max-height: 100vh;
-							${(status === 'loading' || status === 'error') &&
-							'display: flex; align-items: center;'}
-							${status === 'loading' && 'background: white;'}
-						`}
-					>
-						{isPoppedOut && (
-							<SideNav
-								navIsDocked={false}
-								sideNavIsOpen={sideNavIsOpen}
-								setSideNavIsOpen={setSideNavIsOpen}
-							/>
-						)}
-						{!isPoppedOut && (
-							<EuiHeader position="fixed">
-								<EuiHeaderSection side={'left'}>
-									<TelemetryPixel stage={STAGE} />
-									<EuiHeaderSectionItem>
-										<EuiHeaderSectionItemButton
-											aria-label="Toggle main navigation"
-											onClick={() =>
-												setSideNavIsDocked((isDocked) => !isDocked)
-											}
-											css={css`
-												${largeMaxBreakpoint} {
-													display: none;
-												}
-											`}
-										>
-											<EuiIcon type={'menu'} size="m" aria-hidden="true" />
-										</EuiHeaderSectionItemButton>
-										<SideNav
-											navIsDocked={sideNavIsDocked}
-											sideNavIsOpen={sideNavIsOpen}
-											setSideNavIsOpen={setSideNavIsOpen}
-										/>
-									</EuiHeaderSectionItem>
-									<EuiShowFor sizes={['xs']}>
-										{!sideNavIsOpen && (
-											<EuiScreenReaderOnly>
-												<h1>
-													<AppTitle />
-												</h1>
-											</EuiScreenReaderOnly>
-										)}
-									</EuiShowFor>
-									<EuiShowFor sizes={['s', 'm', 'l', 'xl']}>
-										<EuiHeaderSectionItem>
-											<EuiTitle
-												size={'s'}
-												css={css`
-													padding-bottom: 3px;
-
-													${largeMaxBreakpoint} {
-														margin-right: 8px;
-													}
-
-													${largeMinBreakpoint} {
-														width: 258px;
-													}
-												`}
-											>
-												<h1>
-													<AppTitle />
-												</h1>
-											</EuiTitle>
-										</EuiHeaderSectionItem>
-									</EuiShowFor>
-								</EuiHeaderSection>
-
-								<EuiHeaderSection grow={true}>
-									<EuiHeaderSectionItem
-										css={css`
-											flex: 1 1 100%;
-											max-width: 580px;
-										`}
-									>
-										<SearchBox
-											currentTextQuery={config.query.q}
-											handleTextQueryChange={handleTextQueryChange}
-										/>
-									</EuiHeaderSectionItem>
-								</EuiHeaderSection>
-
-								<EuiHeaderSection side={'right'}>
-									<EuiHeaderSectionItem>
-										<EuiFlexGroup
-											gutterSize="xs"
-											css={css`
-												margin-left: 8px;
-											`}
-										>
-											<EuiShowFor sizes={['xs', 's']}>
-												<Tooltip
-													tooltipContent={'Open new ticker'}
-													position="left"
-												>
-													<EuiButtonIcon
-														aria-label="New ticker"
-														display="base"
-														size="s"
-														iconType={'popout'}
-														onClick={() => openTicker(config.query)}
-													/>
-												</Tooltip>
-											</EuiShowFor>
-											<EuiShowFor sizes={['m', 'l', 'xl']}>
-												<EuiButton
-													size="s"
-													iconType={'popout'}
-													onClick={() => openTicker(config.query)}
-												>
-													New ticker
-												</EuiButton>
-											</EuiShowFor>
-											<SettingsMenu />
-										</EuiFlexGroup>
-									</EuiHeaderSectionItem>
-								</EuiHeaderSection>
-							</EuiHeader>
-						)}
-						{isPoppedOut && (
-							<h1
-								css={css`
-									display: none;
-								`}
-								className="sr-only"
-							>
-								Newswires
-							</h1>
-						)}
-						{status !== 'error' && (
-							<>
-								<EuiShowFor sizes={['xs', 's']}>
-									{isPoppedOut && (
-										<ResizableContainer
-											Feed={Feed}
-											Item={
-												selectedItemId ? (
-													<ItemData id={selectedItemId} />
-												) : undefined
-											}
-											directionOverride={'vertical'}
-											setSideNavIsOpen={setSideNavIsOpen}
-										/>
-									)}
-
-									{view === 'item' && !isPoppedOut && (
-										<ItemData id={selectedItemId} />
-									)}
-
-									{view !== 'item' && !isPoppedOut && (
-										<Feed setSideNavIsOpen={setSideNavIsOpen} />
-									)}
-								</EuiShowFor>
-								<EuiShowFor sizes={['m', 'l', 'xl']}>
-									<ResizableContainer
-										Feed={Feed}
-										Item={
-											selectedItemId ? (
-												<ItemData id={selectedItemId} />
-											) : undefined
-										}
-										setSideNavIsOpen={setSideNavIsOpen}
-									/>
-								</EuiShowFor>
-							</>
-						)}
-						{status == 'error' && (
-							<EuiEmptyPrompt
-								css={css`
-									background: white;
-								`}
-								actions={[
-									<EuiButton
-										onClick={handleRetry}
-										key="retry"
-										iconType={'refresh'}
-									>
-										Retry
-									</EuiButton>,
-									<EuiButton
-										onClick={() => handleEnterQuery(defaultQuery)}
-										key="clear"
-										iconType={'cross'}
-									>
-										Clear
-									</EuiButton>,
-								]}
-								body={<p>Sorry, failed to load because of {state.error}</p>}
-								hasBorder={true}
-							/>
-						)}
-					</div>
+					{!!config.ticker && (
+						<TickerLayout errorPromptComponent={errorPromptComponent} />
+					)}
+					{!config.ticker && (
+						<DefaultLayout errorPromptComponent={errorPromptComponent} />
+					)}
 				</EuiPageTemplate>
 			</EuiProvider>
 		</>

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -15,6 +15,7 @@ import {
 import { css, Global } from '@emotion/react';
 import { useEffect, useMemo, useState } from 'react';
 import { z } from 'zod/v4';
+import { STAGE } from './app-configuration.ts';
 import { useKeyboardShortcuts } from './context/KeyboardShortcutsContext.tsx';
 import {
 	loadOrSetInLocalStorage,
@@ -25,6 +26,7 @@ import { isRestricted } from './dateHelpers.ts';
 import { DefaultLayout } from './DefaultLayout.tsx';
 import { fontStyles } from './fontStyles.ts';
 import { presetLabel } from './presets.ts';
+import { TelemetryPixel } from './TelemetryPixel.tsx';
 import { TickerLayout } from './TickerLayout.tsx';
 import { defaultQuery } from './urlState.ts';
 
@@ -110,7 +112,9 @@ export function App() {
 	return (
 		<>
 			<Global styles={fontStyles} />
-
+			<div style={{ position: 'absolute' }}>
+				<TelemetryPixel stage={STAGE} />
+			</div>
 			<EuiProvider colorMode="light">
 				<EuiPageTemplate
 					css={css`

--- a/newswires/client/src/DefaultLayout.tsx
+++ b/newswires/client/src/DefaultLayout.tsx
@@ -57,9 +57,7 @@ export function DefaultLayout({
 				css={css`
 					height: 100%;
 					max-height: 100vh;
-					${(status === 'loading' || status === 'error') &&
-					'display: flex; align-items: center;'}
-					${status === 'loading' && 'background: white;'}
+					background: white;
 				`}
 			>
 				<EuiHeader position="fixed">

--- a/newswires/client/src/DefaultLayout.tsx
+++ b/newswires/client/src/DefaultLayout.tsx
@@ -15,7 +15,6 @@ import {
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useCallback, useState } from 'react';
-import { STAGE } from './app-configuration.ts';
 import { AppTitle } from './AppTitle.tsx';
 import { useSearch } from './context/SearchContext.tsx';
 import { Feed } from './Feed';
@@ -24,7 +23,6 @@ import { ResizableContainer } from './ResizableContainer.tsx';
 import { SearchBox } from './SearchBox.tsx';
 import { SettingsMenu } from './SettingsMenu.tsx';
 import { SideNav } from './SideNav';
-import { TelemetryPixel } from './TelemetryPixel.tsx';
 import { Tooltip } from './Tooltip.tsx';
 
 export function DefaultLayout({
@@ -62,7 +60,6 @@ export function DefaultLayout({
 			>
 				<EuiHeader position="fixed">
 					<EuiHeaderSection side={'left'}>
-						<TelemetryPixel stage={STAGE} />
 						<EuiHeaderSectionItem>
 							<EuiHeaderSectionItemButton
 								aria-label="Toggle main navigation"

--- a/newswires/client/src/DefaultLayout.tsx
+++ b/newswires/client/src/DefaultLayout.tsx
@@ -1,0 +1,188 @@
+import {
+	EuiButton,
+	EuiButtonIcon,
+	EuiFlexGroup,
+	EuiHeader,
+	EuiHeaderSection,
+	EuiHeaderSectionItem,
+	EuiHeaderSectionItemButton,
+	EuiIcon,
+	EuiScreenReaderOnly,
+	EuiShowFor,
+	EuiTitle,
+	useEuiMaxBreakpoint,
+	useEuiMinBreakpoint,
+} from '@elastic/eui';
+import { css } from '@emotion/react';
+import { useCallback, useState } from 'react';
+import { STAGE } from './app-configuration.ts';
+import { AppTitle } from './AppTitle.tsx';
+import { useSearch } from './context/SearchContext.tsx';
+import { Feed } from './Feed';
+import { ItemData } from './ItemData.tsx';
+import { ResizableContainer } from './ResizableContainer.tsx';
+import { SearchBox } from './SearchBox.tsx';
+import { SettingsMenu } from './SettingsMenu.tsx';
+import { SideNav } from './SideNav';
+import { TelemetryPixel } from './TelemetryPixel.tsx';
+import { Tooltip } from './Tooltip.tsx';
+
+export function DefaultLayout({
+	errorPromptComponent,
+}: {
+	errorPromptComponent?: React.ReactNode;
+}) {
+	const { config, state, handleEnterQuery, openTicker } = useSearch();
+
+	const [sideNavIsOpen, setSideNavIsOpen] = useState<boolean>(false);
+
+	const [sideNavIsDocked, setSideNavIsDocked] = useState<boolean>(true);
+
+	const handleTextQueryChange = useCallback(
+		(newQuery: string) => {
+			handleEnterQuery({ ...config.query, q: newQuery });
+		},
+		[config.query, handleEnterQuery],
+	);
+
+	const { view, itemId: selectedItemId } = config;
+	const { status } = state;
+
+	const largeMinBreakpoint = useEuiMinBreakpoint('l');
+	const largeMaxBreakpoint = useEuiMaxBreakpoint('l');
+
+	return (
+		<>
+			<div
+				css={css`
+					height: 100%;
+					max-height: 100vh;
+					${(status === 'loading' || status === 'error') &&
+					'display: flex; align-items: center;'}
+					${status === 'loading' && 'background: white;'}
+				`}
+			>
+				<EuiHeader position="fixed">
+					<EuiHeaderSection side={'left'}>
+						<TelemetryPixel stage={STAGE} />
+						<EuiHeaderSectionItem>
+							<EuiHeaderSectionItemButton
+								aria-label="Toggle main navigation"
+								onClick={() => setSideNavIsDocked((isDocked) => !isDocked)}
+								css={css`
+									${largeMaxBreakpoint} {
+										display: none;
+									}
+								`}
+							>
+								<EuiIcon type={'menu'} size="m" aria-hidden="true" />
+							</EuiHeaderSectionItemButton>
+							<SideNav
+								navIsDocked={sideNavIsDocked}
+								sideNavIsOpen={sideNavIsOpen}
+								setSideNavIsOpen={setSideNavIsOpen}
+							/>
+						</EuiHeaderSectionItem>
+						<EuiShowFor sizes={['xs']}>
+							{!sideNavIsOpen && (
+								<EuiScreenReaderOnly>
+									<h1>
+										<AppTitle />
+									</h1>
+								</EuiScreenReaderOnly>
+							)}
+						</EuiShowFor>
+						<EuiShowFor sizes={['s', 'm', 'l', 'xl']}>
+							<EuiHeaderSectionItem>
+								<EuiTitle
+									size={'s'}
+									css={css`
+										padding-bottom: 3px;
+
+										${largeMaxBreakpoint} {
+											margin-right: 8px;
+										}
+
+										${largeMinBreakpoint} {
+											width: 258px;
+										}
+									`}
+								>
+									<h1>
+										<AppTitle />
+									</h1>
+								</EuiTitle>
+							</EuiHeaderSectionItem>
+						</EuiShowFor>
+					</EuiHeaderSection>
+
+					<EuiHeaderSection grow={true}>
+						<EuiHeaderSectionItem
+							css={css`
+								flex: 1 1 100%;
+								max-width: 580px;
+							`}
+						>
+							<SearchBox
+								currentTextQuery={config.query.q}
+								handleTextQueryChange={handleTextQueryChange}
+							/>
+						</EuiHeaderSectionItem>
+					</EuiHeaderSection>
+
+					<EuiHeaderSection side={'right'}>
+						<EuiHeaderSectionItem>
+							<EuiFlexGroup
+								gutterSize="xs"
+								css={css`
+									margin-left: 8px;
+								`}
+							>
+								<EuiShowFor sizes={['xs', 's']}>
+									<Tooltip tooltipContent={'Open new ticker'} position="left">
+										<EuiButtonIcon
+											aria-label="New ticker"
+											display="base"
+											size="s"
+											iconType={'popout'}
+											onClick={() => openTicker(config.query)}
+										/>
+									</Tooltip>
+								</EuiShowFor>
+								<EuiShowFor sizes={['m', 'l', 'xl']}>
+									<EuiButton
+										size="s"
+										iconType={'popout'}
+										onClick={() => openTicker(config.query)}
+									>
+										New ticker
+									</EuiButton>
+								</EuiShowFor>
+								<SettingsMenu />
+							</EuiFlexGroup>
+						</EuiHeaderSectionItem>
+					</EuiHeaderSection>
+				</EuiHeader>
+				{status !== 'error' && (
+					<>
+						<EuiShowFor sizes={['xs', 's']}>
+							{view === 'item' && <ItemData id={selectedItemId} />}
+
+							{view !== 'item' && <Feed setSideNavIsOpen={setSideNavIsOpen} />}
+						</EuiShowFor>
+						<EuiShowFor sizes={['m', 'l', 'xl']}>
+							<ResizableContainer
+								Feed={Feed}
+								Item={
+									selectedItemId ? <ItemData id={selectedItemId} /> : undefined
+								}
+								setSideNavIsOpen={setSideNavIsOpen}
+							/>
+						</EuiShowFor>
+					</>
+				)}
+				{status == 'error' && errorPromptComponent}
+			</div>
+		</>
+	);
+}

--- a/newswires/client/src/TickerLayout.tsx
+++ b/newswires/client/src/TickerLayout.tsx
@@ -25,9 +25,7 @@ export const TickerLayout = ({
 				css={css`
 					height: 100%;
 					max-height: 100vh;
-					${(status === 'loading' || status === 'error') &&
-					'display: flex; align-items: center;'}
-					${status === 'loading' && 'background: white;'}
+					background: white;
 				`}
 			>
 				<SideNav

--- a/newswires/client/src/TickerLayout.tsx
+++ b/newswires/client/src/TickerLayout.tsx
@@ -1,0 +1,73 @@
+import { EuiShowFor } from '@elastic/eui';
+import { css } from '@emotion/react';
+import { useState } from 'react';
+import { useSearch } from './context/SearchContext.tsx';
+import { Feed } from './Feed';
+import { ItemData } from './ItemData.tsx';
+import { ResizableContainer } from './ResizableContainer.tsx';
+import { SideNav } from './SideNav';
+
+export const TickerLayout = ({
+	errorPromptComponent,
+}: {
+	errorPromptComponent?: React.ReactNode;
+}) => {
+	const { config, state } = useSearch();
+
+	const [sideNavIsOpen, setSideNavIsOpen] = useState<boolean>(false);
+
+	const { itemId: selectedItemId } = config;
+	const { status } = state;
+
+	return (
+		<>
+			<div
+				css={css`
+					height: 100%;
+					max-height: 100vh;
+					${(status === 'loading' || status === 'error') &&
+					'display: flex; align-items: center;'}
+					${status === 'loading' && 'background: white;'}
+				`}
+			>
+				<SideNav
+					navIsDocked={false}
+					sideNavIsOpen={sideNavIsOpen}
+					setSideNavIsOpen={setSideNavIsOpen}
+				/>
+				<h1
+					css={css`
+						display: none;
+					`}
+					className="sr-only"
+				>
+					Newswires
+				</h1>
+				{status !== 'error' && (
+					<>
+						<EuiShowFor sizes={['xs', 's']}>
+							<ResizableContainer
+								Feed={Feed}
+								Item={
+									selectedItemId ? <ItemData id={selectedItemId} /> : undefined
+								}
+								directionOverride={'vertical'}
+								setSideNavIsOpen={setSideNavIsOpen}
+							/>
+						</EuiShowFor>
+						<EuiShowFor sizes={['m', 'l', 'xl']}>
+							<ResizableContainer
+								Feed={Feed}
+								Item={
+									selectedItemId ? <ItemData id={selectedItemId} /> : undefined
+								}
+								setSideNavIsOpen={setSideNavIsOpen}
+							/>
+						</EuiShowFor>
+					</>
+				)}
+				{status == 'error' && errorPromptComponent}
+			</div>
+		</>
+	);
+};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

There's quite a lot of nested/interleaved logic to handle the differences in layout between the default view and the ticker view. This PR creates two separate 'layout' components which aim to encapsulate the distinct layouts of each view, so that we can just have a single decision point about which view to render in the App component.

Functionality and appearance should all be the same as before, except that I've made sure the telemetry pixel is added to both views by including it in the shared App parent.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

<!-- Database migrations need to be applied manually before releasing. The docs can be found in db/README.md -->