### PR TITLE
Upgrade app to Java 21

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-java corretto-17.0.13
+java corretto-21.0.9.10.1

--- a/cdk/lib/__snapshots__/riffraff.test.ts.snap
+++ b/cdk/lib/__snapshots__/riffraff.test.ts.snap
@@ -144,7 +144,7 @@ deployments:
         AMINewswires:
           BuiltBy: amigo
           AmigoStage: PROD
-          Recipe: editorial-tools-jammy-java17
+          Recipe: editorial-tools-jammy-java21
           Encrypted: 'true'
     dependencies:
       - lambda-upload-eu-west-1-editorial-feeds-fingerpost-queueing-lambda

--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -506,7 +506,7 @@ export class Newswires extends GuStack {
 			},
 			scaling,
 			applicationLogging: { enabled: true, systemdUnitName: appName },
-			imageRecipe: 'editorial-tools-jammy-java17',
+			imageRecipe: 'editorial-tools-jammy-java21',
 			roleConfiguration: {
 				additionalPolicies: [
 					new GuGetS3ObjectsPolicy(this, 'PandaAuthPolicy', {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Upgrade newswires app to run on Java 21

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD