### PR TITLE
Fix #788: Remove unnecessary usage of Zod from type-definitions

### DIFF
--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -143,8 +143,8 @@ const Summary = ({
 		(end === DEFAULT_DATE_RANGE.end || end === undefined);
 
 	const durationLabel = usePrettyDuration({
-		timeFrom: start ?? DEFAULT_DATE_RANGE.start,
-		timeTo: end ?? DEFAULT_DATE_RANGE.end,
+		timeFrom: start ?? (DEFAULT_DATE_RANGE.start as string),
+		timeTo: end ?? (DEFAULT_DATE_RANGE.end as string),
 		dateFormat: 'MMM D • HH:mm',
 	});
 

--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -143,8 +143,8 @@ const Summary = ({
 		(end === DEFAULT_DATE_RANGE.end || end === undefined);
 
 	const durationLabel = usePrettyDuration({
-		timeFrom: start ?? (DEFAULT_DATE_RANGE.start as string),
-		timeTo: end ?? (DEFAULT_DATE_RANGE.end as string),
+		timeFrom: start ?? DEFAULT_DATE_RANGE.start,
+		timeTo: end ?? DEFAULT_DATE_RANGE.end,
 		dateFormat: 'MMM D • HH:mm',
 	});
 

--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -143,8 +143,8 @@ const Summary = ({
 		(end === DEFAULT_DATE_RANGE.end || end === undefined);
 
 	const durationLabel = usePrettyDuration({
-		timeFrom: (start ?? DEFAULT_DATE_RANGE.start) as string,
-		timeTo: (end ?? DEFAULT_DATE_RANGE.end) as string,
+		timeFrom: start ?? DEFAULT_DATE_RANGE.start,
+		timeTo: end ?? DEFAULT_DATE_RANGE.end,
 		dateFormat: 'MMM D • HH:mm',
 	});
 

--- a/newswires/client/src/SideNav/SideNav.tsx
+++ b/newswires/client/src/SideNav/SideNav.tsx
@@ -317,8 +317,8 @@ function SearchHistoryBadge({
 	resultsCount: number;
 }) {
 	const dateRangeLabel = usePrettyDuration({
-		timeFrom: query.start ?? DEFAULT_DATE_RANGE.start,
-		timeTo: query.end ?? DEFAULT_DATE_RANGE.end,
+		timeFrom: (query.start ?? DEFAULT_DATE_RANGE.start) as string,
+		timeTo: (query.end ?? DEFAULT_DATE_RANGE.end) as string,
 		dateFormat: 'MMM D • HH:mm',
 	});
 

--- a/newswires/client/src/SideNav/SideNav.tsx
+++ b/newswires/client/src/SideNav/SideNav.tsx
@@ -317,8 +317,8 @@ function SearchHistoryBadge({
 	resultsCount: number;
 }) {
 	const dateRangeLabel = usePrettyDuration({
-		timeFrom: (query.start ?? DEFAULT_DATE_RANGE.start) as string,
-		timeTo: (query.end ?? DEFAULT_DATE_RANGE.end) as string,
+		timeFrom: query.start ?? DEFAULT_DATE_RANGE.start,
+		timeTo: query.end ?? DEFAULT_DATE_RANGE.end,
 		dateFormat: 'MMM D • HH:mm',
 	});
 

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -12,11 +12,6 @@ import {
 } from 'react';
 import { z } from 'zod/v4';
 import type { Config, Query, SortBy, WiresQueryData } from '../sharedTypes.ts';
-import {
-	ConfigSchema,
-	QuerySchema,
-	WiresQueryDataSchema,
-} from '../sharedTypes.ts';
 import { recognisedSuppliers } from '../suppliers.ts';
 import { configToUrl, defaultConfig, urlToConfig } from '../urlState.ts';
 import { takeWhile } from '../utils/takeWhile.ts';
@@ -79,31 +74,82 @@ export type State =
 	| OfflineState;
 
 // Action Schema
-const _ActionSchema = z.discriminatedUnion('type', [
-	z.object({ type: z.literal('ENTER_QUERY'), query: QuerySchema }),
-	z.object({ type: z.literal('LOADING_MORE') }),
-	z.object({
-		type: z.literal('FETCH_SUCCESS'),
-		query: QuerySchema,
-		data: WiresQueryDataSchema,
-	}),
-	z.object({
-		type: z.literal('APPEND_RESULTS'),
-		data: WiresQueryDataSchema,
-	}),
-	z.object({ type: z.literal('FETCH_ERROR'), error: z.string() }),
-	z.object({ type: z.literal('RETRY') }),
-	z.object({ type: z.literal('SELECT_ITEM'), item: z.string().optional() }),
-	z.object({
-		type: z.literal('UPDATE_RESULTS'),
-		query: QuerySchema,
-		data: WiresQueryDataSchema,
-	}),
-	z.object({ type: z.literal('TOGGLE_AUTO_UPDATE') }),
-]);
+// const _ActionSchema = z.discriminatedUnion('type', [
+// 	z.object({ type: z.literal('ENTER_QUERY'), query: QuerySchema }),
+// 	z.object({ type: z.literal('LOADING_MORE') }),
+// 	z.object({
+// 		type: z.literal('FETCH_SUCCESS'),
+// 		query: QuerySchema,
+// 		data: WiresQueryDataSchema,
+// 	}),
+// 	z.object({
+// 		type: z.literal('APPEND_RESULTS'),
+// 		data: WiresQueryDataSchema,
+// 	}),
+// 	z.object({ type: z.literal('FETCH_ERROR'), error: z.string() }),
+// 	z.object({ type: z.literal('RETRY') }),
+// 	z.object({ type: z.literal('SELECT_ITEM'), item: z.string().optional() }),
+// 	z.object({
+// 		type: z.literal('UPDATE_RESULTS'),
+// 		query: QuerySchema,
+// 		data: WiresQueryDataSchema,
+// 	}),
+// 	z.object({ type: z.literal('TOGGLE_AUTO_UPDATE') }),
+// ]);
 
+type Enter = {
+	type: 'ENTER_QUERY';
+	query: Query;
+};
+
+type LoadingMore = {
+	type: 'LOADING_MORE';
+};
+
+type FetchSuccess = {
+	type: 'FETCH_SUCCESS';
+	query: Query;
+	data: WiresQueryData;
+};
+
+type AppendResults = {
+	type: 'APPEND_RESULTS';
+	data: WiresQueryData;
+};
+
+type FetchError = {
+	type: 'FETCH_ERROR';
+	error: string;
+};
+
+type Retry = {
+	type: 'RETRY';
+};
+
+type SelectItem = {
+	type: 'SELECT_ITEM';
+};
+
+type UpdateResults = {
+	type: 'UPDATE_RESULTS';
+	query: Query;
+	data: WiresQueryData;
+};
+
+type ToggleAutoUpdate = {
+	type: 'TOGGLE_AUTO_UPDATE';
+};
 // Infer Action Type
-export type Action = z.infer<typeof _ActionSchema>;
+export type Action =
+	| Enter
+	| LoadingMore
+	| FetchSuccess
+	| AppendResults
+	| FetchError
+	| Retry
+	| SelectItem
+	| UpdateResults
+	| ToggleAutoUpdate;
 
 export type SearchContextShape = {
 	config: Config;
@@ -206,7 +252,8 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 
 	const popConfigStateCallback = useCallback(
 		(e: PopStateEvent) => {
-			const configParseResult = ConfigSchema.safeParse(e.state);
+			// TODO -> need a way to transform the state into a Config object
+			const configParseResult: Config = ConfigSchema.safeParse(e.state);
 			let config = defaultConfig;
 			if (configParseResult.success) {
 				config = configParseResult.data;

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -11,11 +11,10 @@ import {
 	useState,
 } from 'react';
 import { z } from 'zod/v4';
-import type { Config, Query } from '../sharedTypes.ts';
+import type { Config, Query, SortBy, WiresQueryData } from '../sharedTypes.ts';
 import {
 	ConfigSchema,
 	QuerySchema,
-	SortBySchema,
 	WiresQueryDataSchema,
 } from '../sharedTypes.ts';
 import { recognisedSuppliers } from '../suppliers.ts';
@@ -33,71 +32,51 @@ import {
 	getLatestTimeStamp,
 } from './timestamp-compare.ts';
 
-const SearchHistorySchema = z.array(
-	z.object({
-		query: QuerySchema,
-		resultsCount: z.number(),
-	}),
-);
-
-export type SearchHistory = z.infer<typeof SearchHistorySchema>;
+export type SearchHistory = {
+	query: Query;
+	resultsCount: number;
+};
 
 // State Schema
-const _StateSchema = z.discriminatedUnion('status', [
-	z.object({
-		status: z.literal('initialised'),
-		error: z.string().optional(),
-		queryData: WiresQueryDataSchema.optional(),
-		successfulQueryHistory: SearchHistorySchema,
-		autoUpdate: z.boolean().default(true),
-		lastUpdate: z.string().optional(),
-		loadingMore: z.boolean().default(false),
-		sortBy: SortBySchema,
-	}),
-	z.object({
-		status: z.literal('loading'),
-		error: z.string().optional(),
-		queryData: WiresQueryDataSchema.optional(),
-		successfulQueryHistory: SearchHistorySchema,
-		autoUpdate: z.boolean().default(true),
-		lastUpdate: z.string().optional(),
-		loadingMore: z.boolean().default(false),
-		sortBy: SortBySchema,
-	}),
-	z.object({
-		status: z.literal('success'),
-		error: z.string().optional(),
-		queryData: WiresQueryDataSchema,
-		successfulQueryHistory: SearchHistorySchema,
-		autoUpdate: z.boolean().default(true),
-		lastUpdate: z.string().optional(),
-		loadingMore: z.boolean().default(false),
-		sortBy: SortBySchema,
-	}),
-	z.object({
-		status: z.literal('error'),
-		error: z.string(),
-		queryData: WiresQueryDataSchema.optional(),
-		successfulQueryHistory: SearchHistorySchema,
-		autoUpdate: z.boolean().default(true),
-		lastUpdate: z.string().optional(),
-		loadingMore: z.boolean().default(false),
-		sortBy: SortBySchema,
-	}),
-	z.object({
-		status: z.literal('offline'),
-		error: z.string(),
-		queryData: WiresQueryDataSchema,
-		successfulQueryHistory: SearchHistorySchema,
-		autoUpdate: z.boolean().default(true),
-		lastUpdate: z.string().optional(),
-		loadingMore: z.boolean().default(false),
-		sortBy: SortBySchema,
-	}),
-]);
+type BaseState = {
+	error?: string;
+	successfulQueryHistory: SearchHistory[];
+	queryData?: WiresQueryData;
+	autoUpdate: boolean;
+	lastUpdate?: string;
+	loadingMore: boolean;
+	sortBy: SortBy;
+};
 
-// Infer State Type
-export type State = z.infer<typeof _StateSchema>;
+type InitialisedState = BaseState & {
+	status: 'initialised';
+};
+
+type LoadingState = BaseState & {
+	status: 'loading';
+};
+
+type SuccessState = BaseState & {
+	status: 'success';
+	queryData: WiresQueryData;
+};
+
+type ErrorState = BaseState & {
+	status: 'error';
+	error: string;
+};
+
+type OfflineState = BaseState & {
+	status: 'offline';
+	queryData: WiresQueryData;
+};
+
+export type State =
+	| InitialisedState
+	| LoadingState
+	| SuccessState
+	| ErrorState
+	| OfflineState;
 
 // Action Schema
 const _ActionSchema = z.discriminatedUnion('type', [

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -11,7 +11,13 @@ import {
 	useState,
 } from 'react';
 import { z } from 'zod/v4';
-import type { Config, Query, SortBy, WiresQueryData } from '../sharedTypes.ts';
+import {
+	type Config,
+	ConfigSchema,
+	type Query,
+	type SortBy,
+	type WiresQueryData,
+} from '../sharedTypes.ts';
 import { recognisedSuppliers } from '../suppliers.ts';
 import { configToUrl, defaultConfig, urlToConfig } from '../urlState.ts';
 import { takeWhile } from '../utils/takeWhile.ts';
@@ -252,8 +258,7 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 
 	const popConfigStateCallback = useCallback(
 		(e: PopStateEvent) => {
-			// TODO -> need a way to transform the state into a Config object
-			const configParseResult: Config = ConfigSchema.safeParse(e.state);
+			const configParseResult = ConfigSchema.safeParse(e.state);
 			let config = defaultConfig;
 			if (configParseResult.success) {
 				config = configParseResult.data;

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -79,30 +79,6 @@ export type State =
 	| ErrorState
 	| OfflineState;
 
-// Action Schema
-// const _ActionSchema = z.discriminatedUnion('type', [
-// 	z.object({ type: z.literal('ENTER_QUERY'), query: QuerySchema }),
-// 	z.object({ type: z.literal('LOADING_MORE') }),
-// 	z.object({
-// 		type: z.literal('FETCH_SUCCESS'),
-// 		query: QuerySchema,
-// 		data: WiresQueryDataSchema,
-// 	}),
-// 	z.object({
-// 		type: z.literal('APPEND_RESULTS'),
-// 		data: WiresQueryDataSchema,
-// 	}),
-// 	z.object({ type: z.literal('FETCH_ERROR'), error: z.string() }),
-// 	z.object({ type: z.literal('RETRY') }),
-// 	z.object({ type: z.literal('SELECT_ITEM'), item: z.string().optional() }),
-// 	z.object({
-// 		type: z.literal('UPDATE_RESULTS'),
-// 		query: QuerySchema,
-// 		data: WiresQueryDataSchema,
-// 	}),
-// 	z.object({ type: z.literal('TOGGLE_AUTO_UPDATE') }),
-// ]);
-
 type Enter = {
 	type: 'ENTER_QUERY';
 	query: Query;

--- a/newswires/client/src/context/SearchReducer.ts
+++ b/newswires/client/src/context/SearchReducer.ts
@@ -91,10 +91,10 @@ function appendQueryData(
 }
 
 function getUpdatedHistory(
-	previousHistory: SearchHistory,
+	previousHistory: SearchHistory[],
 	newQuery: Query,
 	newResultsCount: number,
-): SearchHistory {
+): SearchHistory[] {
 	if (deepIsEqual(newQuery, defaultQuery)) {
 		return previousHistory;
 	}

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -216,7 +216,7 @@ export const ConfigSchema = z.discriminatedUnion('view', [
 ]);
 export type Config = z.infer<typeof ConfigSchema>;
 
-const SortByIngestedAtSchema = z.object({ sortByKey: 'ingestedAt' });
+const SortByIngestedAtSchema = z.object({ sortByKey: z.literal('ingestedAt') });
 const SortByAddedToCollectionAtSchema = z.object({
 	sortByKey: z.literal('addedToCollectionAt'),
 	collectionId: z.number(),

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -130,7 +130,7 @@ export type SupplierInfo = {
 	colour: string;
 };
 
-export type WireData = WireDataFromAPI & {
+export type WireData = Omit<WireDataFromAPI, 'supplier'> & {
 	supplier: SupplierInfo;
 	localIngestedAt: Moment;
 	hasDataFormatting: boolean;
@@ -152,54 +152,69 @@ export const EuiDateStringSchema = z
 	.refine((val) => isValidDateValue(val));
 export type EuiDateString = z.infer<typeof EuiDateStringSchema>;
 
-// TODO - enforce mutual exclusive typing
-export type Query = {
-	q: string;
-	supplier?: string[];
-	supplierExcl?: string[];
-	keyword?: string[];
-	keywordExcl?: string[];
-	categoryCode?: string[];
-	categoryCodeExcl?: string[];
-	guSourceFeed?: string[];
-	guSourceFeedExcl?: string[];
-	preset?: string;
-	start?: string;
-	end?: string;
-	hasDataFormatting?: boolean;
-	previewPaApi?: boolean;
-	eventCode?: string;
-	collectionId?: number;
-};
+export const BaseQuerySchema = z.object({
+	q: z.string(),
+	supplier: z.array(z.string()).optional(),
+	supplierExcl: z.array(z.string()).optional(),
+	keyword: z.array(z.string()).optional(),
+	keywordExcl: z.array(z.string()).optional(),
+	categoryCode: z.array(z.string()).optional(),
+	categoryCodeExcl: z.array(z.string()).optional(),
+	guSourceFeed: z.array(z.string()).optional(),
+	guSourceFeedExcl: z.array(z.string()).optional(),
+	preset: z.string().optional(),
+	start: EuiDateStringSchema.optional(),
+	end: EuiDateStringSchema.optional(),
+	hasDataFormatting: z.boolean().optional(),
+	previewPaApi: z.boolean().optional(),
+	eventCode: z.string().optional(),
+});
+export type BaseQuery = z.infer<typeof BaseQuerySchema>;
 
-type FeedView = {
-	view: 'feed';
-	query: Query;
-	itemId: undefined;
-	ticker: boolean;
-};
+export const QuerySchema = z.union([
+	BaseQuerySchema.extend({
+		preset: z.undefined(),
+		collectionId: z.undefined(),
+	}),
+	BaseQuerySchema.extend({
+		preset: z.string(),
+		collectionId: z.undefined(),
+	}),
+	BaseQuerySchema.extend({
+		preset: z.undefined(),
+		collectionId: z.number(),
+	}),
+]);
 
-type ItemView = {
-	view: 'item';
-	query: Query;
-	itemId: string;
-	ticker: boolean;
-};
+export type Query = z.infer<typeof QuerySchema>;
 
-type DotCopyView = {
-	view: 'dotcopy';
-	query: Query;
-	itemId: string;
-	ticker: boolean;
-};
-
-type DotCopyItemView = {
-	view: 'dotcopy/item';
-	query: Query;
-	itemId: string;
-	ticker: boolean;
-};
-export type Config = FeedView | ItemView | DotCopyView | DotCopyItemView;
+export const ConfigSchema = z.discriminatedUnion('view', [
+	z.object({
+		view: z.literal('feed'),
+		query: QuerySchema,
+		itemId: z.undefined(),
+		ticker: z.boolean(),
+	}),
+	z.object({
+		view: z.literal('item'),
+		query: QuerySchema,
+		itemId: z.string(),
+		ticker: z.boolean(),
+	}),
+	z.object({
+		view: z.literal('dotcopy'),
+		query: QuerySchema,
+		itemId: z.undefined(),
+		ticker: z.boolean(),
+	}),
+	z.object({
+		view: z.literal('dotcopy/item'),
+		query: QuerySchema,
+		itemId: z.string(),
+		ticker: z.boolean(),
+	}),
+]);
+export type Config = z.infer<typeof ConfigSchema>;
 
 const SortByIngestedAtSchema = z.object({ sortByKey: 'ingestedAt' });
 const SortByAddedToCollectionAtSchema = z.object({

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -110,52 +110,38 @@ export type WireToolLinks = z.infer<typeof WiresToolLinksResponseSchema>;
 
 export type WiresQueryResponse = z.infer<typeof WiresQueryResponseSchema>;
 
-export const suppliers = [
-	'REUTERS',
-	'AP',
-	'AAP',
-	'AFP',
-	'PA',
-	'PAAPI',
-	'GUAP',
-	'GUREUTERS',
-	'MINOR_AGENCIES',
-	'UNAUTHED_EMAIL_FEED',
-	'UNKNOWN',
-] as const;
+export type SupplierName =
+	| 'REUTERS'
+	| 'AP'
+	| 'AAP'
+	| 'AFP'
+	| 'PA'
+	| 'PAAPI'
+	| 'GUAP'
+	| 'GUREUTERS'
+	| 'MINOR_AGENCIES'
+	| 'UNAUTHED_EMAIL_FEED'
+	| 'UNKNOWN';
 
-const SupplierNameSchema = z.enum(suppliers);
+export type SupplierInfo = {
+	name: SupplierName;
+	label: string;
+	shortLabel: string;
+	colour: string;
+};
 
-export type SupplierName = z.infer<typeof SupplierNameSchema>;
+export type WireData = WireDataFromAPI & {
+	supplier: SupplierInfo;
+	localIngestedAt: Moment;
+	hasDataFormatting: boolean;
+	isAlert: boolean;
+	isLead: boolean;
+};
 
-const SupplierInfoSchema = z.object({
-	name: SupplierNameSchema,
-	label: z.string(),
-	shortLabel: z.string(),
-	colour: z.string(),
-});
-
-export type SupplierInfo = z.infer<typeof SupplierInfoSchema>;
-
-const MomentSchema = z.custom<Moment>((val) => moment.isMoment(val));
-
-export const WireDataSchema = WireDataFromAPISchema.extend({
-	supplier: SupplierInfoSchema,
-	localIngestedAt: MomentSchema,
-	hasDataFormatting: z.boolean(),
-	isAlert: z.boolean(),
-	isLead: z.boolean(),
-});
-
-export type WireData = z.infer<typeof WireDataSchema>;
-
-export const WiresQueryDataSchema = z.object({
-	results: z.array(WireDataSchema),
-	totalCount: z.number(),
-	// keywordCounts: z.record(z.string(), z.number()),
-});
-
-export type WiresQueryData = z.infer<typeof WiresQueryDataSchema>;
+export type WiresQueryData = {
+	results: WireData[];
+	totalCount: number;
+};
 
 export const isValidDateValue = (value: string): value is EuiDateString =>
 	/^now(?:[+-]\d+[smhdwMy])*(?:\/\w+)?$/.test(value) || moment(value).isValid();
@@ -166,70 +152,54 @@ export const EuiDateStringSchema = z
 	.refine((val) => isValidDateValue(val));
 export type EuiDateString = z.infer<typeof EuiDateStringSchema>;
 
-export const BaseQuerySchema = z.object({
-	q: z.string(),
-	supplier: z.array(z.string()).optional(),
-	supplierExcl: z.array(z.string()).optional(),
-	keyword: z.array(z.string()).optional(),
-	keywordExcl: z.array(z.string()).optional(),
-	categoryCode: z.array(z.string()).optional(),
-	categoryCodeExcl: z.array(z.string()).optional(),
-	guSourceFeed: z.array(z.string()).optional(),
-	guSourceFeedExcl: z.array(z.string()).optional(),
-	preset: z.string().optional(),
-	start: EuiDateStringSchema.optional(),
-	end: EuiDateStringSchema.optional(),
-	hasDataFormatting: z.boolean().optional(),
-	previewPaApi: z.boolean().optional(),
-	eventCode: z.string().optional(),
-});
-export type BaseQuery = z.infer<typeof BaseQuerySchema>;
+// TODO - enforce mutual exclusive typing
+export type Query = {
+	q: string;
+	supplier?: string[];
+	supplierExcl?: string[];
+	keyword?: string[];
+	keywordExcl?: string[];
+	categoryCode?: string[];
+	categoryCodeExcl?: string[];
+	guSourceFeed?: string[];
+	guSourceFeedExcl?: string[];
+	preset?: string;
+	start?: string;
+	end?: string;
+	hasDataFormatting?: boolean;
+	previewPaApi?: boolean;
+	eventCode?: string;
+	collectionId?: number;
+};
 
-export const QuerySchema = z.union([
-	BaseQuerySchema.extend({
-		preset: z.undefined(),
-		collectionId: z.undefined(),
-	}),
-	BaseQuerySchema.extend({
-		preset: z.string(),
-		collectionId: z.undefined(),
-	}),
-	BaseQuerySchema.extend({
-		preset: z.undefined(),
-		collectionId: z.number(),
-	}),
-]);
+type FeedView = {
+	view: 'feed';
+	query: Query;
+	itemId: undefined;
+	ticker: boolean;
+};
 
-export type Query = z.infer<typeof QuerySchema>;
+type ItemView = {
+	view: 'item';
+	query: Query;
+	itemId: string;
+	ticker: boolean;
+};
 
-export const ConfigSchema = z.discriminatedUnion('view', [
-	z.object({
-		view: z.literal('feed'),
-		query: QuerySchema,
-		itemId: z.undefined(),
-		ticker: z.boolean(),
-	}),
-	z.object({
-		view: z.literal('item'),
-		query: QuerySchema,
-		itemId: z.string(),
-		ticker: z.boolean(),
-	}),
-	z.object({
-		view: z.literal('dotcopy'),
-		query: QuerySchema,
-		itemId: z.undefined(),
-		ticker: z.boolean(),
-	}),
-	z.object({
-		view: z.literal('dotcopy/item'),
-		query: QuerySchema,
-		itemId: z.string(),
-		ticker: z.boolean(),
-	}),
-]);
+type DotCopyView = {
+	view: 'dotcopy';
+	query: Query;
+	itemId: string;
+	ticker: boolean;
+};
 
-export type Config = z.infer<typeof ConfigSchema>;
+type DotCopyItemView = {
+	view: 'dotcopy/item';
+	query: Query;
+	itemId: string;
+	ticker: boolean;
+};
+export type Config = FeedView | ItemView | DotCopyView | DotCopyItemView;
 
 const SortByIngestedAtSchema = z.object({ sortByKey: 'ingestedAt' });
 const SortByAddedToCollectionAtSchema = z.object({


### PR DESCRIPTION
* https://github.com/guardian/newswires/issues/788

This PR uses typescript types instead of the `zod schema` definition in places where parsing is not needed