### PR TITLE
Upgrade PROD db to Large

### DIFF
--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -104,7 +104,7 @@ export class Newswires extends GuStack {
 		const databaseName = 'newswires';
 
 		const instanceSize =
-			this.stage === 'PROD' ? InstanceSize.MEDIUM : InstanceSize.SMALL;
+			this.stage === 'PROD' ? InstanceSize.LARGE : InstanceSize.SMALL;
 
 		// multiAz on if this is PROD
 		const multiAz = this.stage === 'PROD';


### PR DESCRIPTION
We've hit 100% CPU on the existing db instance, which has taken the site down. It looks like the CPU usage has been consistently high since we did the PA switch-over, presumably because the site is getting more usage. So it seems sensible to upsize it.