### PR TITLE
Upgrade PROD db to XLarge

### DIFF
--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -104,7 +104,7 @@ export class Newswires extends GuStack {
 		const databaseName = 'newswires';
 
 		const instanceSize =
-			this.stage === 'PROD' ? InstanceSize.LARGE : InstanceSize.SMALL;
+			this.stage === 'PROD' ? InstanceSize.XLARGE : InstanceSize.SMALL;
 
 		// multiAz on if this is PROD
 		const multiAz = this.stage === 'PROD';


### PR DESCRIPTION
We upgraded to Large in #790 before realising that Medium->Large doesn't increase CPU, which seemed to be the main bottleneck before. We'll see whether the extra memory from the previous upgrade helps, but if not we should probably go to XL.