### PR TITLE
Allow sport and finance in US news if it also has US domestic codes

### DIFF
--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -194,8 +194,7 @@ object SearchPresets {
   private val AllUs = List(
     SearchPreset(
       AP,
-      categoryCodes = CategoryCodes.US.AP,
-      categoryCodesExcl = CategoryCodes.Sport.AP ++ CategoryCodes.Business.AP
+      categoryCodes = CategoryCodes.US.AP
     ),
     SearchPreset(
       REUTERS,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Remove the exclusion of finance (`apCat:f`) and sport (`apCat:s`) from the US news preset for AP. There aren't an overwhelming number of extra stories that have these codes in addition to the US domestic codes that we're including. And many of the extra stories are quite relevant to US editors, according to conversations we've had.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Run locally against the CODE db, and compare with actual CODE. Are the extra stories broadly relevant?

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD