### PR TITLE
All/Some combinator for category codes

### DIFF
--- a/newswires/app/conf/CategoryCodesCondition.scala
+++ b/newswires/app/conf/CategoryCodesCondition.scala
@@ -1,0 +1,6 @@
+package conf
+
+case class CategoryCodesCondition(
+    categoryCodes: List[String],
+    combiner: Combination
+)

--- a/newswires/app/conf/CategoryCodesCondition.scala
+++ b/newswires/app/conf/CategoryCodesCondition.scala
@@ -1,6 +1,12 @@
 package conf
 
+sealed trait SetCombination
+
+case object SOME extends SetCombination
+case object ALL extends SetCombination
+case object NONE extends SetCombination
+
 case class CategoryCodesCondition(
     categoryCodes: List[String],
-    combiner: Combination
+    combiner: SetCombination
 )

--- a/newswires/app/conf/CategoryCodesCondition.scala
+++ b/newswires/app/conf/CategoryCodesCondition.scala
@@ -4,7 +4,6 @@ sealed trait SetCombination
 
 case object SOME extends SetCombination
 case object ALL extends SetCombination
-case object NONE extends SetCombination
 
 case class CategoryCodesCondition(
     categoryCodes: List[String],

--- a/newswires/app/conf/CategoryCodesCondition.scala
+++ b/newswires/app/conf/CategoryCodesCondition.scala
@@ -2,7 +2,18 @@ package conf
 
 sealed trait SetCombination
 
+/** SOME translates to "at least one of the categoryCodes list matches the
+  * category codes of the entry" It uses the PostgreSQL `&&` operator which
+  * checks if the two arrays have any elements in common.
+  * https://www.postgresql.org/docs/current/functions-array.html#FUNCTIONS-ARRAY
+  */
 case object SOME extends SetCombination
+
+/** ALL translates to "all of the categoryCodes list are included in the
+  * category codes of the entry" It uses the PostgreSQL `@>` operator which
+  * checks if the left-hand array contains all elements of the right-hand array.
+  * https://www.postgresql.org/docs/current/functions-array.html#FUNCTIONS-ARRAY
+  */
 case object ALL extends SetCombination
 
 case class CategoryCodesCondition(

--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -118,7 +118,7 @@ object SearchPresets {
     SearchPreset(
       AP,
       keywords = List("General news"),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.World.AP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.World.AP, SOME))
     )
   )
 
@@ -126,12 +126,12 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField(SimpleSearchQueries.REUTERS_NEWS_SCHEDULE, Headline))),
-      categoryCodes = Some(CategoryCodesCondition(List("MCC:DED"), OR))
+      categoryCodes = Some(CategoryCodesCondition(List("MCC:DED"), SOME))
     )
   )
 
   private val ReutersWorld = List(
-    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.World.REUTERS, OR))),
+    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.World.REUTERS, SOME))),
     SearchPreset(
       REUTERS,
       preComputedCategories = List("other-topic-codes"),
@@ -139,7 +139,8 @@ object SearchPresets {
     ),
     SearchPreset(
       REUTERS,
-      categoryCodes = Some(CategoryCodesCondition(List("MCC:OVR", "MCC:QFE", "MCCL:OVR", "MCCL:OSM", "MCC:DED", "N2:US"), OR)),
+      categoryCodes =
+        Some(CategoryCodesCondition(List("MCC:OVR", "MCC:QFE", "MCCL:OVR", "MCCL:OSM", "MCC:DED", "N2:US"), SOME)),
       categoryCodesExcl = List(
         "MCC:SPO",
         "MCC:OEC",
@@ -152,7 +153,7 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SearchTerm.SingleField("News Summary", Headline))),
-      categoryCodes = Some(CategoryCodesCondition(List("MCC:OEC"), OR)),
+      categoryCodes = Some(CategoryCodesCondition(List("MCC:OEC"), SOME)),
       categoryCodesExcl = List("N2:GB", "N2:COM", "N2:ECI")
     )
   )
@@ -170,7 +171,7 @@ object SearchPresets {
   )
 
   private val PaWorld = List(
-    SearchPreset(PA, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.World.PA, OR)))
+    SearchPreset(PA, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.World.PA, SOME)))
   )
 
   private val AllWorld =
@@ -183,9 +184,9 @@ object SearchPresets {
   private val AllUk = List(
     SearchPreset(
       PA,
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.UK.PA, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.UK.PA, SOME))
     ), // We aren't excluding CategoryCodes.World.PA because PA's still fairly UK-focused, and UK eds are used to seeing all non-sport, non-business PA content in the UK feed
-    SearchPreset(MINOR_AGENCIES, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.UK.MINOR_AGENCIES, OR)))
+    SearchPreset(MINOR_AGENCIES, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.UK.MINOR_AGENCIES, SOME)))
   )
 
   /*
@@ -194,11 +195,11 @@ object SearchPresets {
   private val AllUs = List(
     SearchPreset(
       AP,
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.US.AP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.US.AP, SOME))
     ),
     SearchPreset(
       REUTERS,
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.US.REUTERS, OR)),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.US.REUTERS, SOME)),
       preComputedCategoriesExcl = List(
         "sports-related-topic-codes",
         "sports-related-news-codes",
@@ -218,7 +219,7 @@ object SearchPresets {
    */
 
   private val AllBusiness = List(
-    SearchPreset(PA, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Business.PA, OR))),
+    SearchPreset(PA, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Business.PA, SOME))),
     SearchPreset(
       REUTERS,
       preComputedCategories = List("business-related-topic-codes"),
@@ -226,7 +227,7 @@ object SearchPresets {
     ),
     SearchPreset(
       AP,
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Business.AP, OR)),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Business.AP, SOME)),
       categoryCodesExcl = CategoryCodes.Sport.AP ::: CategoryCodes.Other.AP
     ),
     SearchPreset(AAP, preComputedCategories = List("business-related-news-codes"))
@@ -256,7 +257,7 @@ object SearchPresets {
           AND
         )
       ),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.REUTERS, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.REUTERS, SOME))
     ),
     SearchPreset(
       PA,
@@ -299,9 +300,9 @@ object SearchPresets {
     SearchPreset(
       AFP,
       searchTerms = Some(SingleTerm(SingleField("-result -results -scorers -table", Headline))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
     ),
-    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AAP, OR))),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AAP, SOME))),
     SearchPreset(
       AP,
       searchTerms = Some(
@@ -313,7 +314,7 @@ object SearchPresets {
           )
         )
       ),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME))
     )
   )
 
@@ -321,12 +322,12 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("-(OPTA)", BodyText))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Soccer.REUTERS, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Soccer.REUTERS, SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("-RUGBYU -RUGBY", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Soccer.PA, OR)),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Soccer.PA, SOME)),
       hasDataFormatting = Some(false)
     ),
     SearchPreset(
@@ -340,13 +341,13 @@ object SearchPresets {
           AND
         )
       ),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
     ),
-    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Soccer.AAP, OR))),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Soccer.AAP, SOME))),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("AP SOC -Glance", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME)),
       keyword = Some("Soccer")
     )
   )
@@ -355,24 +356,24 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("(OPTA)", BodyText))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Soccer.REUTERS, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Soccer.REUTERS, SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("-RUGBY -RUGBYU -RUGBYL", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.SoccerScores.PA, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.SoccerScores.PA, SOME))
     ),
     SearchPreset(PA, searchTerms = Some(SingleTerm(SingleField("\"SOCCER TABULATED RESULTS\"", Slug)))),
     SearchPreset(
       AFP,
       searchTerms =
         Some(ComboTerm(List(SingleField("fbl", Slug), SingleField("result OR results OR scorers", Headline)), AND)),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("\"BC-SOC\" OR SOC Glance", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME))
     )
   )
 
@@ -380,12 +381,12 @@ object SearchPresets {
     SearchPreset(
       AFP,
       searchTerms = Some(ComboTerm(List(SingleField("fbl", Slug), SingleField("table", Headline)), AND)),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = None,
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.SoccerTables.PA, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.SoccerTables.PA, SOME))
     )
   )
   // SoccerTablesDataFormats
@@ -404,7 +405,7 @@ object SearchPresets {
     SearchPreset(
       AFP,
       searchTerms = Some(SingleTerm(SingleField("-fbl", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
     ),
     SearchPreset(
       AAP,
@@ -422,7 +423,7 @@ object SearchPresets {
   private val AmericanFootball = List(
     SearchPreset(
       REUTERS,
-      categoryCodes = Some(CategoryCodesCondition(List("N2:AMER", "N2:NFL", "subj:15003000", "subj:15003001"), OR))
+      categoryCodes = Some(CategoryCodesCondition(List("N2:AMER", "N2:NFL", "subj:15003000", "subj:15003001"), SOME))
     ),
     SearchPreset(
       PA,
@@ -430,99 +431,99 @@ object SearchPresets {
     ),
     SearchPreset(
       AAP,
-      categoryCodes = Some(CategoryCodesCondition(List("subj:15003000", "subj:15003001"), OR))
+      categoryCodes = Some(CategoryCodesCondition(List("subj:15003000", "subj:15003001"), SOME))
     ),
     SearchPreset(
       AFP,
       searchTerms = Some(SingleTerm(SingleField("Amfoot", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("FBN -FBC", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("-FBC", Slug))),
       keywords = List("Football", "NFL football", "NFL Playoffs"),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME))
     )
   )
 
   private val AustralianRules = List(
     SearchPreset(
       REUTERS,
-      categoryCodes = Some(CategoryCodesCondition(List("N2:AUSR", "subj:15084000"), OR))
+      categoryCodes = Some(CategoryCodesCondition(List("N2:AUSR", "subj:15084000"), SOME))
     ),
     SearchPreset(
       AAP,
-      categoryCodes = Some(CategoryCodesCondition(List("subj:15084000"), OR))
+      categoryCodes = Some(CategoryCodesCondition(List("subj:15084000"), SOME))
     )
   )
 
   private val Baseball = List(
     SearchPreset(
       REUTERS,
-      categoryCodes = Some(CategoryCodesCondition(List("N2:BASE", "subj:15007000"), OR))
+      categoryCodes = Some(CategoryCodesCondition(List("N2:BASE", "subj:15007000"), SOME))
     ),
     SearchPreset(
       AFP,
       searchTerms = Some(SingleTerm(SingleField("baseball", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("BBO -BBC", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("-BBC", Slug))),
       keywords = List("Baseball", "MLB baseball"),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME))
     )
   )
 
   private val Basketball = List(
     SearchPreset(
       REUTERS,
-      categoryCodes = Some(CategoryCodesCondition(List("N2:BASK", "subj:15008000", "subj:15008001"), OR))
+      categoryCodes = Some(CategoryCodesCondition(List("N2:BASK", "subj:15008000", "subj:15008001"), SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("BASKETBALL", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:RSR"), OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:RSR"), SOME))
     ),
     SearchPreset(
       AAP,
-      categoryCodes = Some(CategoryCodesCondition(List("subj:15008000", "subj:15008001"), OR))
+      categoryCodes = Some(CategoryCodesCondition(List("subj:15008000", "subj:15008001"), SOME))
     ),
     SearchPreset(
       AFP,
       searchTerms = Some(SingleTerm(SingleField("Basket", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("-BKC -BKW BKN OR BKL", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME))
     )
   )
 
   private val CollegeSports = List(
     SearchPreset(
       REUTERS,
-      categoryCodes = Some(CategoryCodesCondition(List("N2:FBC", "N2:BKC", "N2:HKC"), OR))
+      categoryCodes = Some(CategoryCodesCondition(List("N2:FBC", "N2:BKC", "N2:HKC"), SOME))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("BKC OR BKW OR FBC OR HKC", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME))
     ),
     SearchPreset(
       AP,
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME)),
       keywords = List("College sports")
     )
   )
@@ -531,7 +532,7 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("-(OPTA)", BodyText))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Cricket.REUTERS, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Cricket.REUTERS, SOME))
     ),
     SearchPreset(
       PA,
@@ -544,18 +545,18 @@ object SearchPresets {
           AND
         )
       ),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Cricket.PA, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Cricket.PA, SOME))
     ),
     SearchPreset(
       AFP,
       searchTerms = Some(SingleTerm(SingleField("cricket", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
     ),
-    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Cricket.AAP, OR))),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Cricket.AAP, SOME))),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("\"AP-CRI\" -Glance -Figures -Runs", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME))
     )
   )
 
@@ -563,23 +564,23 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("(OPTA)", BodyText))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Cricket.REUTERS, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Cricket.REUTERS, SOME))
     ),
-    SearchPreset(PA, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.CricketScores.PA, OR))),
+    SearchPreset(PA, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.CricketScores.PA, SOME))),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("fixtures OR fixture", Headline))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:SCR"), OR))
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:SCR"), SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("Summaries", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:SCR"), OR))
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:SCR"), SOME))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("\"AP-CRI\" Glance OR Figures OR Runs", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME))
     )
   )
 
@@ -587,33 +588,33 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("-(OPTA)", BodyText))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyLeague.REUTERS, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyLeague.REUTERS, SOME))
     ),
     SearchPreset(
       REUTERS,
       searchTerms = Some((ComboTerm(List(SingleField("(OPTA)", BodyText), SingleField("/SUMMARIES", Slug)), AND))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyLeague.REUTERS, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyLeague.REUTERS, SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("RUGBYL -Scorer", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
     ),
     SearchPreset(
       AFP,
       searchTerms = Some(ComboTerm(List(SingleField("RugbyL", Slug), SingleField("-result -results", Headline)), AND)),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("RUGBYL -SOCCER Summaries", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME))
     ),
-    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyLeague.AAP, OR))),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyLeague.AAP, SOME))),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("RGL", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME)),
       keyword = Some("Rugby")
     )
   )
@@ -622,28 +623,28 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("-(OPTA)", BodyText))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyUnion.REUTERS, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyUnion.REUTERS, SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("\"RUGBY UNION\" OR RUGBYU -SOCCER Summaries", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("\"RUGBY UNION\" OR RUGBYU -Scorer", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:SFF"), OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:SFF"), SOME))
     ),
     SearchPreset(
       AFP,
       searchTerms = Some(ComboTerm(List(SingleField("RugbyU", Slug), SingleField("-result -results", Headline)), AND)),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
     ),
-    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyUnion.AAP, OR))),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyUnion.AAP, SOME))),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("RGU", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME)),
       keyword = Some("Rugby")
     )
   )
@@ -652,19 +653,19 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("-SOCCER -Summaries", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("RUGBY", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:RFC"), OR))
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RFC"), SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(
         SingleTerm(SingleField("RUGBYU Scorer OR RUGBYL Scorer", Slug))
       ),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
     ),
     SearchPreset(
       AFP,
@@ -677,12 +678,12 @@ object SearchPresets {
           AND
         )
       ),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
     ),
     SearchPreset(
       REUTERS,
       searchTerms = Some((ComboTerm(List(SingleField("(OPTA)", BodyText), SingleField("-/SUMMARIES", Slug)), AND))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyLeague.REUTERS, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyLeague.REUTERS, SOME))
     )
   )
 
@@ -690,19 +691,23 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("-(OPTA)", BodyText))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Tennis.REUTERS, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Tennis.REUTERS, SOME))
     ),
-    SearchPreset(PA, searchTerms = Some(SingleTerm(SingleField("TENNIS", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, OR))),
+    SearchPreset(
+      PA,
+      searchTerms = Some(SingleTerm(SingleField("TENNIS", Slug))),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
+    ),
     SearchPreset(
       AFP,
       searchTerms = Some(ComboTerm(List(SingleField("Tennis", Slug), SingleField("-result -results", Headline)), AND)),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
     ),
-    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Tennis.AAP, OR))),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Tennis.AAP, SOME))),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("AP TEN", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME)),
       keyword = Some("Tennis")
     )
   )
@@ -711,68 +716,92 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("(OPTA)", BodyText))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Tennis.REUTERS, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Tennis.REUTERS, SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("TENNIS", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), OR))
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME))
     ),
     SearchPreset(
       AFP,
       searchTerms = Some(ComboTerm(List(SingleField("Tennis", Slug), SingleField("result OR results", Headline)), AND)),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("\"BC-TEN\"", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME))
     )
   )
 
   private val Cycling = List(
-    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Cycling.REUTERS, OR))),
-    SearchPreset(PA, searchTerms = Some(SingleTerm(SingleField("CYCLING", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, OR))),
-    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("cycling", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))),
-    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Cycling.AAP, OR))),
+    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Cycling.REUTERS, SOME))),
+    SearchPreset(
+      PA,
+      searchTerms = Some(SingleTerm(SingleField("CYCLING", Slug))),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
+    ),
+    SearchPreset(
+      AFP,
+      searchTerms = Some(SingleTerm(SingleField("cycling", Slug))),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
+    ),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Cycling.AAP, SOME))),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("CYC", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME)),
       keyword = Some("Cycling")
     )
   )
 
   private val MotorSport = List(
-    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.MotorSport.REUTERS, OR))),
+    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.MotorSport.REUTERS, SOME))),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("auto OR MOTO", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:RSR"), OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:RSR"), SOME))
     ),
-    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("auto OR moto", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))),
-    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.MotorSport.AAP, OR))),
-    SearchPreset(AP, searchTerms = Some(SingleTerm(SingleField("CAR", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))),
-    SearchPreset(AP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)), keywords = List("Automobile racing", "Formula One racing"))
+    SearchPreset(
+      AFP,
+      searchTerms = Some(SingleTerm(SingleField("auto OR moto", Slug))),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
+    ),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.MotorSport.AAP, SOME))),
+    SearchPreset(
+      AP,
+      searchTerms = Some(SingleTerm(SingleField("CAR", Slug))),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME))
+    ),
+    SearchPreset(
+      AP,
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME)),
+      keywords = List("Automobile racing", "Formula One racing")
+    )
   )
 
   private val Golf = List(
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("-(OPTA)", BodyText))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Golf.REUTERS, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Golf.REUTERS, SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("GOLF", Slug))),
       categoryCodesExcl = List("paCat:RSR")
     ),
-    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("golf", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))),
-    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Golf.AAP, OR))),
+    SearchPreset(
+      AFP,
+      searchTerms = Some(SingleTerm(SingleField("golf", Slug))),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
+    ),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Golf.AAP, SOME))),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("GLF -Scores", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME)),
       keyword = Some("Golf")
     )
   )
@@ -781,12 +810,12 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("(OPTA)", BodyText))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Golf.REUTERS, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Golf.REUTERS, SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("GOLF", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), OR))
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME))
     ),
     SearchPreset(
       AP,
@@ -799,19 +828,23 @@ object SearchPresets {
           )
         )
       ),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME))
     )
   )
 
   private val Boxing = List(
-    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Boxing.REUTERS, OR))),
+    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Boxing.REUTERS, SOME))),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("BOXING", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:SRS", "paCat:SSS"), OR))
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:SRS", "paCat:SSS"), SOME))
     ),
-    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("Box", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))),
-    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Boxing.AAP, OR))),
+    SearchPreset(
+      AFP,
+      searchTerms = Some(SingleTerm(SingleField("Box", Slug))),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
+    ),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Boxing.AAP, SOME))),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("BOX", Slug))),
@@ -820,59 +853,71 @@ object SearchPresets {
   )
 
   private val HorseRacing = List(
-    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.HorseRacing.REUTERS, OR))),
-    SearchPreset(PA, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.HorseRacing.PA, OR))),
-    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("racing", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))),
-    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.HorseRacing.AAP, OR))),
-    SearchPreset(AP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)), keyword = Some("Horse racing"))
+    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.HorseRacing.REUTERS, SOME))),
+    SearchPreset(PA, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.HorseRacing.PA, SOME))),
+    SearchPreset(
+      AFP,
+      searchTerms = Some(SingleTerm(SingleField("racing", Slug))),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
+    ),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.HorseRacing.AAP, SOME))),
+    SearchPreset(
+      AP,
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME)),
+      keyword = Some("Horse racing")
+    )
   )
 
   private val IceHockey = List(
     SearchPreset(
       REUTERS,
-      categoryCodes = Some(CategoryCodesCondition(List("N2:ICEH", "N2:NHL", "subj:15031000"), OR))
+      categoryCodes = Some(CategoryCodesCondition(List("N2:ICEH", "N2:NHL", "subj:15031000"), SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("ICEHOCKEY", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:RSR"), OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:RSR"), SOME))
     ),
     SearchPreset(
       AFP,
       searchTerms = Some(SingleTerm(SingleField("IHockey", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("HKN OR HKW", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME))
     ),
     SearchPreset(
       AP,
       keywords = List("Hockey", "NHL hockey"),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME))
     )
   )
 
   private val Athletics = List(
-    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Athletics.REUTERS, OR))),
+    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Athletics.REUTERS, SOME))),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("ATHLETICS", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
     ),
-    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("ATHLETICS", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))),
-    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Athletics.AAP, OR))),
+    SearchPreset(
+      AFP,
+      searchTerms = Some(SingleTerm(SingleField("ATHLETICS", Slug))),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
+    ),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Athletics.AAP, SOME))),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("ATH", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME)),
       keyword = Some("Track and field")
     )
   )
 
   private val Olympics = List(
-    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Olympics.REUTERS, OR))),
+    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Olympics.REUTERS, SOME))),
     SearchPreset(
       PA,
       searchTerms = Some(
@@ -881,16 +926,24 @@ object SearchPresets {
           OR
         )
       ),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, OR))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
     ),
-    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("Oly", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))),
-    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Olympics.AAP, OR))),
+    SearchPreset(
+      AFP,
+      searchTerms = Some(SingleTerm(SingleField("Oly", Slug))),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, SOME))
+    ),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Olympics.AAP, SOME))),
     SearchPreset(
       AP,
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME)),
       keywords = List("Olympic games", "2026 Milan Cortina Olympic Games")
     ),
-    SearchPreset(AP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)), searchTerms = Some(SingleTerm(SingleField("OLY-", Slug))))
+    SearchPreset(
+      AP,
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME)),
+      searchTerms = Some(SingleTerm(SingleField("OLY-", Slug)))
+    )
   )
 
   private val AllDataFormats = List(

--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -27,7 +27,7 @@ object SearchPreset {
       suppliersExcl = Nil,
       keywordIncl = keyword.toList ::: keywords,
       keywordExcl = keywordExcl,
-      categoryCodes = categoryCodes,
+      categoryCodesIncl = categoryCodes,
       categoryCodesExcl = categoryCodesExcl,
       hasDataFormatting = hasDataFormatting,
       preComputedCategories = preComputedCategories,

--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -3,7 +3,7 @@ package conf
 import conf.SearchField.{BodyText, Headline, Slug}
 import conf.SearchTerm.SingleField
 import conf.Suppliers._
-import models.{FilterParams, SearchParams}
+import models.{FilterParams}
 
 // Increase max line length to improve readability of search presets
 // scalafmt: { maxColumn = 120 }
@@ -12,7 +12,7 @@ object SearchPreset {
   def apply(
       supplier: String,
       searchTerms: Option[SearchTerms] = None,
-      categoryCodes: List[String] = Nil,
+      categoryCodes: Option[CategoryCodesCondition] = None,
       categoryCodesExcl: List[String] = Nil,
       keyword: Option[String] = None,
       keywords: List[String] = Nil,
@@ -27,7 +27,7 @@ object SearchPreset {
       suppliersExcl = Nil,
       keywordIncl = keyword.toList ::: keywords,
       keywordExcl = keywordExcl,
-      categoryCodesIncl = categoryCodes,
+      categoryCodes = categoryCodes,
       categoryCodesExcl = categoryCodesExcl,
       hasDataFormatting = hasDataFormatting,
       preComputedCategories = preComputedCategories,
@@ -118,7 +118,7 @@ object SearchPresets {
     SearchPreset(
       AP,
       keywords = List("General news"),
-      categoryCodes = CategoryCodes.World.AP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.World.AP, OR))
     )
   )
 
@@ -126,12 +126,12 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField(SimpleSearchQueries.REUTERS_NEWS_SCHEDULE, Headline))),
-      categoryCodes = List("MCC:DED")
+      categoryCodes = Some(CategoryCodesCondition(List("MCC:DED"), OR))
     )
   )
 
   private val ReutersWorld = List(
-    SearchPreset(REUTERS, categoryCodes = CategoryCodes.World.REUTERS),
+    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.World.REUTERS, OR))),
     SearchPreset(
       REUTERS,
       preComputedCategories = List("other-topic-codes"),
@@ -139,7 +139,7 @@ object SearchPresets {
     ),
     SearchPreset(
       REUTERS,
-      categoryCodes = List("MCC:OVR", "MCC:QFE", "MCCL:OVR", "MCCL:OSM", "MCC:DED", "N2:US"),
+      categoryCodes = Some(CategoryCodesCondition(List("MCC:OVR", "MCC:QFE", "MCCL:OVR", "MCCL:OSM", "MCC:DED", "N2:US"), OR)),
       categoryCodesExcl = List(
         "MCC:SPO",
         "MCC:OEC",
@@ -152,7 +152,7 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SearchTerm.SingleField("News Summary", Headline))),
-      categoryCodes = List("MCC:OEC"),
+      categoryCodes = Some(CategoryCodesCondition(List("MCC:OEC"), OR)),
       categoryCodesExcl = List("N2:GB", "N2:COM", "N2:ECI")
     )
   )
@@ -170,7 +170,7 @@ object SearchPresets {
   )
 
   private val PaWorld = List(
-    SearchPreset(PA, categoryCodes = CategoryCodes.World.PA)
+    SearchPreset(PA, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.World.PA, OR)))
   )
 
   private val AllWorld =
@@ -183,9 +183,9 @@ object SearchPresets {
   private val AllUk = List(
     SearchPreset(
       PA,
-      categoryCodes = CategoryCodes.UK.PA
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.UK.PA, OR))
     ), // We aren't excluding CategoryCodes.World.PA because PA's still fairly UK-focused, and UK eds are used to seeing all non-sport, non-business PA content in the UK feed
-    SearchPreset(MINOR_AGENCIES, categoryCodes = CategoryCodes.UK.MINOR_AGENCIES)
+    SearchPreset(MINOR_AGENCIES, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.UK.MINOR_AGENCIES, OR)))
   )
 
   /*
@@ -194,11 +194,11 @@ object SearchPresets {
   private val AllUs = List(
     SearchPreset(
       AP,
-      categoryCodes = CategoryCodes.US.AP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.US.AP, OR))
     ),
     SearchPreset(
       REUTERS,
-      categoryCodes = CategoryCodes.US.REUTERS,
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.US.REUTERS, OR)),
       preComputedCategoriesExcl = List(
         "sports-related-topic-codes",
         "sports-related-news-codes",
@@ -218,7 +218,7 @@ object SearchPresets {
    */
 
   private val AllBusiness = List(
-    SearchPreset(PA, categoryCodes = CategoryCodes.Business.PA),
+    SearchPreset(PA, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Business.PA, OR))),
     SearchPreset(
       REUTERS,
       preComputedCategories = List("business-related-topic-codes"),
@@ -226,7 +226,7 @@ object SearchPresets {
     ),
     SearchPreset(
       AP,
-      categoryCodes = CategoryCodes.Business.AP,
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Business.AP, OR)),
       categoryCodesExcl = CategoryCodes.Sport.AP ::: CategoryCodes.Other.AP
     ),
     SearchPreset(AAP, preComputedCategories = List("business-related-news-codes"))
@@ -256,7 +256,7 @@ object SearchPresets {
           AND
         )
       ),
-      CategoryCodes.Sport.REUTERS
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.REUTERS, OR))
     ),
     SearchPreset(
       PA,
@@ -299,9 +299,9 @@ object SearchPresets {
     SearchPreset(
       AFP,
       searchTerms = Some(SingleTerm(SingleField("-result -results -scorers -table", Headline))),
-      CategoryCodes.Sport.AFP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
     ),
-    SearchPreset(AAP, categoryCodes = CategoryCodes.Sport.AAP),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AAP, OR))),
     SearchPreset(
       AP,
       searchTerms = Some(
@@ -313,7 +313,7 @@ object SearchPresets {
           )
         )
       ),
-      CategoryCodes.Sport.AP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
     )
   )
 
@@ -321,12 +321,12 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("-(OPTA)", BodyText))),
-      CategoryCodes.Soccer.REUTERS
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Soccer.REUTERS, OR))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("-RUGBYU -RUGBY", Slug))),
-      categoryCodes = CategoryCodes.Soccer.PA,
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Soccer.PA, OR)),
       hasDataFormatting = Some(false)
     ),
     SearchPreset(
@@ -340,13 +340,13 @@ object SearchPresets {
           AND
         )
       ),
-      CategoryCodes.Sport.AFP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
     ),
-    SearchPreset(AAP, categoryCodes = CategoryCodes.Soccer.AAP),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Soccer.AAP, OR))),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("AP SOC -Glance", Slug))),
-      CategoryCodes.Sport.AP,
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)),
       keyword = Some("Soccer")
     )
   )
@@ -355,24 +355,24 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("(OPTA)", BodyText))),
-      CategoryCodes.Soccer.REUTERS
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Soccer.REUTERS, OR))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("-RUGBY -RUGBYU -RUGBYL", Slug))),
-      CategoryCodes.SoccerScores.PA
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.SoccerScores.PA, OR))
     ),
     SearchPreset(PA, searchTerms = Some(SingleTerm(SingleField("\"SOCCER TABULATED RESULTS\"", Slug)))),
     SearchPreset(
       AFP,
       searchTerms =
         Some(ComboTerm(List(SingleField("fbl", Slug), SingleField("result OR results OR scorers", Headline)), AND)),
-      CategoryCodes.Sport.AFP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("\"BC-SOC\" OR SOC Glance", Slug))),
-      CategoryCodes.Sport.AP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
     )
   )
 
@@ -380,12 +380,12 @@ object SearchPresets {
     SearchPreset(
       AFP,
       searchTerms = Some(ComboTerm(List(SingleField("fbl", Slug), SingleField("table", Headline)), AND)),
-      CategoryCodes.Sport.AFP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
     ),
     SearchPreset(
       PA,
       searchTerms = None,
-      CategoryCodes.SoccerTables.PA
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.SoccerTables.PA, OR))
     )
   )
   // SoccerTablesDataFormats
@@ -404,7 +404,7 @@ object SearchPresets {
     SearchPreset(
       AFP,
       searchTerms = Some(SingleTerm(SingleField("-fbl", Slug))),
-      categoryCodes = CategoryCodes.Sport.AFP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
     ),
     SearchPreset(
       AAP,
@@ -422,7 +422,7 @@ object SearchPresets {
   private val AmericanFootball = List(
     SearchPreset(
       REUTERS,
-      categoryCodes = List("N2:AMER", "N2:NFL", "subj:15003000", "subj:15003001")
+      categoryCodes = Some(CategoryCodesCondition(List("N2:AMER", "N2:NFL", "subj:15003000", "subj:15003001"), OR))
     ),
     SearchPreset(
       PA,
@@ -430,99 +430,99 @@ object SearchPresets {
     ),
     SearchPreset(
       AAP,
-      categoryCodes = List("subj:15003000", "subj:15003001")
+      categoryCodes = Some(CategoryCodesCondition(List("subj:15003000", "subj:15003001"), OR))
     ),
     SearchPreset(
       AFP,
       searchTerms = Some(SingleTerm(SingleField("Amfoot", Slug))),
-      categoryCodes = CategoryCodes.Sport.AFP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("FBN -FBC", Slug))),
-      CategoryCodes.Sport.AP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("-FBC", Slug))),
       keywords = List("Football", "NFL football", "NFL Playoffs"),
-      categoryCodes = CategoryCodes.Sport.AP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
     )
   )
 
   private val AustralianRules = List(
     SearchPreset(
       REUTERS,
-      categoryCodes = List("N2:AUSR", "subj:15084000")
+      categoryCodes = Some(CategoryCodesCondition(List("N2:AUSR", "subj:15084000"), OR))
     ),
     SearchPreset(
       AAP,
-      categoryCodes = List("subj:15084000")
+      categoryCodes = Some(CategoryCodesCondition(List("subj:15084000"), OR))
     )
   )
 
   private val Baseball = List(
     SearchPreset(
       REUTERS,
-      categoryCodes = List("N2:BASE", "subj:15007000")
+      categoryCodes = Some(CategoryCodesCondition(List("N2:BASE", "subj:15007000"), OR))
     ),
     SearchPreset(
       AFP,
       searchTerms = Some(SingleTerm(SingleField("baseball", Slug))),
-      categoryCodes = CategoryCodes.Sport.AFP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("BBO -BBC", Slug))),
-      CategoryCodes.Sport.AP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("-BBC", Slug))),
       keywords = List("Baseball", "MLB baseball"),
-      categoryCodes = CategoryCodes.Sport.AP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
     )
   )
 
   private val Basketball = List(
     SearchPreset(
       REUTERS,
-      categoryCodes = List("N2:BASK", "subj:15008000", "subj:15008001")
+      categoryCodes = Some(CategoryCodesCondition(List("N2:BASK", "subj:15008000", "subj:15008001"), OR))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("BASKETBALL", Slug))),
-      CategoryCodes.Sport.PA ::: List("paCat:RSR")
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:RSR"), OR))
     ),
     SearchPreset(
       AAP,
-      categoryCodes = List("subj:15008000", "subj:15008001")
+      categoryCodes = Some(CategoryCodesCondition(List("subj:15008000", "subj:15008001"), OR))
     ),
     SearchPreset(
       AFP,
       searchTerms = Some(SingleTerm(SingleField("Basket", Slug))),
-      categoryCodes = CategoryCodes.Sport.AFP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("-BKC -BKW BKN OR BKL", Slug))),
-      categoryCodes = CategoryCodes.Sport.AP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
     )
   )
 
   private val CollegeSports = List(
     SearchPreset(
       REUTERS,
-      categoryCodes = List("N2:FBC", "N2:BKC", "N2:HKC")
+      categoryCodes = Some(CategoryCodesCondition(List("N2:FBC", "N2:BKC", "N2:HKC"), OR))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("BKC OR BKW OR FBC OR HKC", Slug))),
-      categoryCodes = CategoryCodes.Sport.AP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
     ),
     SearchPreset(
       AP,
-      categoryCodes = CategoryCodes.Sport.AP,
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)),
       keywords = List("College sports")
     )
   )
@@ -531,7 +531,7 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("-(OPTA)", BodyText))),
-      categoryCodes = CategoryCodes.Cricket.REUTERS
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Cricket.REUTERS, OR))
     ),
     SearchPreset(
       PA,
@@ -544,18 +544,18 @@ object SearchPresets {
           AND
         )
       ),
-      CategoryCodes.Cricket.PA
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Cricket.PA, OR))
     ),
     SearchPreset(
       AFP,
       searchTerms = Some(SingleTerm(SingleField("cricket", Slug))),
-      categoryCodes = CategoryCodes.Sport.AFP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
     ),
-    SearchPreset(AAP, categoryCodes = CategoryCodes.Cricket.AAP),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Cricket.AAP, OR))),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("\"AP-CRI\" -Glance -Figures -Runs", Slug))),
-      CategoryCodes.Sport.AP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
     )
   )
 
@@ -563,23 +563,23 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("(OPTA)", BodyText))),
-      categoryCodes = CategoryCodes.Cricket.REUTERS
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Cricket.REUTERS, OR))
     ),
-    SearchPreset(PA, categoryCodes = CategoryCodes.CricketScores.PA),
+    SearchPreset(PA, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.CricketScores.PA, OR))),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("fixtures OR fixture", Headline))),
-      categoryCodes = List("paCat:SCR")
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:SCR"), OR))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("Summaries", Slug))),
-      categoryCodes = List("paCat:SCR")
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:SCR"), OR))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("\"AP-CRI\" Glance OR Figures OR Runs", Slug))),
-      CategoryCodes.Sport.AP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
     )
   )
 
@@ -587,33 +587,33 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("-(OPTA)", BodyText))),
-      CategoryCodes.RugbyLeague.REUTERS
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyLeague.REUTERS, OR))
     ),
     SearchPreset(
       REUTERS,
       searchTerms = Some((ComboTerm(List(SingleField("(OPTA)", BodyText), SingleField("/SUMMARIES", Slug)), AND))),
-      CategoryCodes.RugbyLeague.REUTERS
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyLeague.REUTERS, OR))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("RUGBYL -Scorer", Slug))),
-      CategoryCodes.Sport.PA
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, OR))
     ),
     SearchPreset(
       AFP,
       searchTerms = Some(ComboTerm(List(SingleField("RugbyL", Slug), SingleField("-result -results", Headline)), AND)),
-      CategoryCodes.Sport.AFP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("RUGBYL -SOCCER Summaries", Slug))),
-      CategoryCodes.RugbyScores.PA
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, OR))
     ),
-    SearchPreset(AAP, categoryCodes = CategoryCodes.RugbyLeague.AAP),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyLeague.AAP, OR))),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("RGL", Slug))),
-      CategoryCodes.Sport.AP,
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)),
       keyword = Some("Rugby")
     )
   )
@@ -622,28 +622,28 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("-(OPTA)", BodyText))),
-      CategoryCodes.RugbyUnion.REUTERS
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyUnion.REUTERS, OR))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("\"RUGBY UNION\" OR RUGBYU -SOCCER Summaries", Slug))),
-      CategoryCodes.RugbyScores.PA
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, OR))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("\"RUGBY UNION\" OR RUGBYU -Scorer", Slug))),
-      CategoryCodes.Sport.PA ::: List("paCat:SFF")
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:SFF"), OR))
     ),
     SearchPreset(
       AFP,
       searchTerms = Some(ComboTerm(List(SingleField("RugbyU", Slug), SingleField("-result -results", Headline)), AND)),
-      CategoryCodes.Sport.AFP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
     ),
-    SearchPreset(AAP, categoryCodes = CategoryCodes.RugbyUnion.AAP),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyUnion.AAP, OR))),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("RGU", Slug))),
-      CategoryCodes.Sport.AP,
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)),
       keyword = Some("Rugby")
     )
   )
@@ -652,19 +652,19 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("-SOCCER -Summaries", Slug))),
-      CategoryCodes.RugbyScores.PA
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, OR))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("RUGBY", Slug))),
-      categoryCodes = List("paCat:RFC")
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RFC"), OR))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(
         SingleTerm(SingleField("RUGBYU Scorer OR RUGBYL Scorer", Slug))
       ),
-      CategoryCodes.Sport.PA
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, OR))
     ),
     SearchPreset(
       AFP,
@@ -677,12 +677,12 @@ object SearchPresets {
           AND
         )
       ),
-      CategoryCodes.Sport.AFP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
     ),
     SearchPreset(
       REUTERS,
       searchTerms = Some((ComboTerm(List(SingleField("(OPTA)", BodyText), SingleField("-/SUMMARIES", Slug)), AND))),
-      CategoryCodes.RugbyLeague.REUTERS
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyLeague.REUTERS, OR))
     )
   )
 
@@ -690,19 +690,19 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("-(OPTA)", BodyText))),
-      CategoryCodes.Tennis.REUTERS
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Tennis.REUTERS, OR))
     ),
-    SearchPreset(PA, searchTerms = Some(SingleTerm(SingleField("TENNIS", Slug))), CategoryCodes.Sport.PA),
+    SearchPreset(PA, searchTerms = Some(SingleTerm(SingleField("TENNIS", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, OR))),
     SearchPreset(
       AFP,
       searchTerms = Some(ComboTerm(List(SingleField("Tennis", Slug), SingleField("-result -results", Headline)), AND)),
-      CategoryCodes.Sport.AFP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
     ),
-    SearchPreset(AAP, categoryCodes = CategoryCodes.Tennis.AAP),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Tennis.AAP, OR))),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("AP TEN", Slug))),
-      CategoryCodes.Sport.AP,
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)),
       keyword = Some("Tennis")
     )
   )
@@ -711,68 +711,68 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("(OPTA)", BodyText))),
-      CategoryCodes.Tennis.REUTERS
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Tennis.REUTERS, OR))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("TENNIS", Slug))),
-      categoryCodes = List("paCat:RSR")
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), OR))
     ),
     SearchPreset(
       AFP,
       searchTerms = Some(ComboTerm(List(SingleField("Tennis", Slug), SingleField("result OR results", Headline)), AND)),
-      CategoryCodes.Sport.AFP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("\"BC-TEN\"", Slug))),
-      CategoryCodes.Sport.AP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
     )
   )
 
   private val Cycling = List(
-    SearchPreset(REUTERS, categoryCodes = CategoryCodes.Cycling.REUTERS),
-    SearchPreset(PA, searchTerms = Some(SingleTerm(SingleField("CYCLING", Slug))), CategoryCodes.Sport.PA),
-    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("cycling", Slug))), CategoryCodes.Sport.AFP),
-    SearchPreset(AAP, categoryCodes = CategoryCodes.Cycling.AAP),
+    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Cycling.REUTERS, OR))),
+    SearchPreset(PA, searchTerms = Some(SingleTerm(SingleField("CYCLING", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, OR))),
+    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("cycling", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Cycling.AAP, OR))),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("CYC", Slug))),
-      CategoryCodes.Sport.AP,
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)),
       keyword = Some("Cycling")
     )
   )
 
   private val MotorSport = List(
-    SearchPreset(REUTERS, categoryCodes = CategoryCodes.MotorSport.REUTERS),
+    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.MotorSport.REUTERS, OR))),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("auto OR MOTO", Slug))),
-      categoryCodes = CategoryCodes.Sport.PA ::: List("paCat:RSR")
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:RSR"), OR))
     ),
-    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("auto OR moto", Slug))), CategoryCodes.Sport.AFP),
-    SearchPreset(AAP, categoryCodes = CategoryCodes.MotorSport.AAP),
-    SearchPreset(AP, searchTerms = Some(SingleTerm(SingleField("CAR", Slug))), categoryCodes = CategoryCodes.Sport.AP),
-    SearchPreset(AP, categoryCodes = CategoryCodes.Sport.AP, keywords = List("Automobile racing", "Formula One racing"))
+    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("auto OR moto", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.MotorSport.AAP, OR))),
+    SearchPreset(AP, searchTerms = Some(SingleTerm(SingleField("CAR", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))),
+    SearchPreset(AP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)), keywords = List("Automobile racing", "Formula One racing"))
   )
 
   private val Golf = List(
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("-(OPTA)", BodyText))),
-      CategoryCodes.Golf.REUTERS
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Golf.REUTERS, OR))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("GOLF", Slug))),
       categoryCodesExcl = List("paCat:RSR")
     ),
-    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("golf", Slug))), CategoryCodes.Sport.AFP),
-    SearchPreset(AAP, categoryCodes = CategoryCodes.Golf.AAP),
+    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("golf", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Golf.AAP, OR))),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("GLF -Scores", Slug))),
-      CategoryCodes.Sport.AP,
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)),
       keyword = Some("Golf")
     )
   )
@@ -781,12 +781,12 @@ object SearchPresets {
     SearchPreset(
       REUTERS,
       searchTerms = Some(SingleTerm(SingleField("(OPTA)", BodyText))),
-      CategoryCodes.Golf.REUTERS
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Golf.REUTERS, OR))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("GOLF", Slug))),
-      categoryCodes = List("paCat:RSR")
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), OR))
     ),
     SearchPreset(
       AP,
@@ -799,19 +799,19 @@ object SearchPresets {
           )
         )
       ),
-      CategoryCodes.Sport.AP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
     )
   )
 
   private val Boxing = List(
-    SearchPreset(REUTERS, categoryCodes = CategoryCodes.Boxing.REUTERS),
+    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Boxing.REUTERS, OR))),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("BOXING", Slug))),
-      categoryCodes = List("paCat:SRS", "paCat:SSS")
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:SRS", "paCat:SSS"), OR))
     ),
-    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("Box", Slug))), CategoryCodes.Sport.AFP),
-    SearchPreset(AAP, categoryCodes = CategoryCodes.Boxing.AAP),
+    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("Box", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Boxing.AAP, OR))),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("BOX", Slug))),
@@ -820,59 +820,59 @@ object SearchPresets {
   )
 
   private val HorseRacing = List(
-    SearchPreset(REUTERS, categoryCodes = CategoryCodes.HorseRacing.REUTERS),
-    SearchPreset(PA, categoryCodes = CategoryCodes.HorseRacing.PA),
-    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("racing", Slug))), CategoryCodes.Sport.AFP),
-    SearchPreset(AAP, categoryCodes = CategoryCodes.HorseRacing.AAP),
-    SearchPreset(AP, categoryCodes = CategoryCodes.Sport.AP, keyword = Some("Horse racing"))
+    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.HorseRacing.REUTERS, OR))),
+    SearchPreset(PA, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.HorseRacing.PA, OR))),
+    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("racing", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.HorseRacing.AAP, OR))),
+    SearchPreset(AP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)), keyword = Some("Horse racing"))
   )
 
   private val IceHockey = List(
     SearchPreset(
       REUTERS,
-      categoryCodes = List("N2:ICEH", "N2:NHL", "subj:15031000")
+      categoryCodes = Some(CategoryCodesCondition(List("N2:ICEH", "N2:NHL", "subj:15031000"), OR))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("ICEHOCKEY", Slug))),
-      CategoryCodes.Sport.PA ::: List("paCat:RSR")
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:RSR"), OR))
     ),
     SearchPreset(
       AFP,
       searchTerms = Some(SingleTerm(SingleField("IHockey", Slug))),
-      categoryCodes = CategoryCodes.Sport.AFP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))
     ),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("HKN OR HKW", Slug))),
-      CategoryCodes.Sport.AP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
     ),
     SearchPreset(
       AP,
       keywords = List("Hockey", "NHL hockey"),
-      categoryCodes = CategoryCodes.Sport.AP
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR))
     )
   )
 
   private val Athletics = List(
-    SearchPreset(REUTERS, categoryCodes = CategoryCodes.Athletics.REUTERS),
+    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Athletics.REUTERS, OR))),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("ATHLETICS", Slug))),
-      CategoryCodes.Sport.PA
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, OR))
     ),
-    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("ATHLETICS", Slug))), CategoryCodes.Sport.AFP),
-    SearchPreset(AAP, categoryCodes = CategoryCodes.Athletics.AAP),
+    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("ATHLETICS", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Athletics.AAP, OR))),
     SearchPreset(
       AP,
       searchTerms = Some(SingleTerm(SingleField("ATH", Slug))),
-      CategoryCodes.Sport.AP,
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)),
       keyword = Some("Track and field")
     )
   )
 
   private val Olympics = List(
-    SearchPreset(REUTERS, categoryCodes = CategoryCodes.Olympics.REUTERS),
+    SearchPreset(REUTERS, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Olympics.REUTERS, OR))),
     SearchPreset(
       PA,
       searchTerms = Some(
@@ -881,16 +881,16 @@ object SearchPresets {
           OR
         )
       ),
-      CategoryCodes.Sport.PA
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, OR))
     ),
-    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("Oly", Slug))), CategoryCodes.Sport.AFP),
-    SearchPreset(AAP, categoryCodes = CategoryCodes.Olympics.AAP),
+    SearchPreset(AFP, searchTerms = Some(SingleTerm(SingleField("Oly", Slug))), categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AFP, OR))),
+    SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Olympics.AAP, OR))),
     SearchPreset(
       AP,
-      categoryCodes = CategoryCodes.Sport.AP,
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)),
       keywords = List("Olympic games", "2026 Milan Cortina Olympic Games")
     ),
-    SearchPreset(AP, categoryCodes = CategoryCodes.Sport.AP, searchTerms = Some(SingleTerm(SingleField("OLY-", Slug))))
+    SearchPreset(AP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, OR)), searchTerms = Some(SingleTerm(SingleField("OLY-", Slug))))
   )
 
   private val AllDataFormats = List(

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -244,7 +244,7 @@ object FingerpostWireEntry
       // https://jdbc.postgresql.org/documentation/query/#using-the-statement-or-preparedstatement-interface
       sqls"(${alias.content} -> 'keywords') ??| ${textArray(keywords)}"
 
-    private def categoryCodeOrConditions(
+    private def categoryCodeSomeConditions(
         alias: QuerySQLSyntaxProvider[SQLSyntaxSupport[
           FingerpostWireEntry
         ], FingerpostWireEntry],
@@ -253,7 +253,7 @@ object FingerpostWireEntry
       sqls"${alias.categoryCodes} && ${textArray(categoryCodes)}"
     }
 
-    private def categoryCodeAndConditions(
+    private def categoryCodeAllConditions(
         alias: QuerySQLSyntaxProvider[SQLSyntaxSupport[
           FingerpostWireEntry
         ], FingerpostWireEntry],
@@ -357,16 +357,16 @@ object FingerpostWireEntry
       (categoryCodes: CategoryCodesCondition) =>
         categoryCodes match {
           case CategoryCodesCondition(codes, SOME) =>
-            categoryCodeOrConditions(syn, codes)
+            categoryCodeSomeConditions(syn, codes)
           case CategoryCodesCondition(codes, ALL) =>
-            categoryCodeAndConditions(syn, codes)
+            categoryCodeAllConditions(syn, codes)
         }
 
     lazy val categoryCodeExclSQL =
       (categoryCodesExcl: List[String]) => {
         val cce = syntax("categoryCodesExcl")
         exclusionCondition(cce)(
-          categoryCodeOrConditions(cce, categoryCodesExcl)
+          categoryCodeSomeConditions(cce, categoryCodesExcl)
         )
       }
 

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -2,10 +2,12 @@ package db
 
 import conf.SearchTerm.CombinedFields
 import conf.{
+  ALL,
   AND,
   CategoryCodesCondition,
   ComboTerm,
   OR,
+  SOME,
   SearchField,
   SearchTerm,
   SearchTerms,
@@ -354,9 +356,9 @@ object FingerpostWireEntry
     lazy val categoryCodeSQL =
       (categoryCodes: CategoryCodesCondition) =>
         categoryCodes match {
-          case CategoryCodesCondition(codes, OR) =>
+          case CategoryCodesCondition(codes, SOME) =>
             categoryCodeOrConditions(syn, codes)
-          case CategoryCodesCondition(codes, AND) =>
+          case CategoryCodesCondition(codes, ALL) =>
             categoryCodeAndConditions(syn, codes)
         }
 

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -353,7 +353,7 @@ object FingerpostWireEntry
         exclusionCondition(ke)(keywordCondition(ke, keywords))
       }
 
-    lazy val categoryCodeSQL =
+    lazy val categoryCodeInclSQL =
       (categoryCodes: CategoryCodesCondition) =>
         categoryCodes match {
           case CategoryCodesCondition(codes, SOME) =>
@@ -461,9 +461,10 @@ object FingerpostWireEntry
       case keywords => Some(Filters.keywordsExclSQL(keywords))
     }
 
-    val categoryCodesInclQuery = filters.categoryCodes match {
+    val categoryCodesInclQuery = filters.categoryCodesIncl match {
       case None                => None
-      case Some(categoryCodes) => Some(Filters.categoryCodeSQL(categoryCodes))
+      case Some(categoryCodes) =>
+        Some(Filters.categoryCodeInclSQL(categoryCodes))
     }
 
     val categoryCodesExclQuery = filters.categoryCodesExcl match {

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -3,6 +3,7 @@ package db
 import conf.SearchTerm.CombinedFields
 import conf.{
   AND,
+  CategoryCodesCondition,
   ComboTerm,
   OR,
   SearchField,
@@ -241,13 +242,22 @@ object FingerpostWireEntry
       // https://jdbc.postgresql.org/documentation/query/#using-the-statement-or-preparedstatement-interface
       sqls"(${alias.content} -> 'keywords') ??| ${textArray(keywords)}"
 
-    private def categoryCodeConditions(
+    private def categoryCodeOrConditions(
         alias: QuerySQLSyntaxProvider[SQLSyntaxSupport[
           FingerpostWireEntry
         ], FingerpostWireEntry],
         categoryCodes: List[String]
     ) = {
       sqls"${alias.categoryCodes} && ${textArray(categoryCodes)}"
+    }
+
+    private def categoryCodeAndConditions(
+        alias: QuerySQLSyntaxProvider[SQLSyntaxSupport[
+          FingerpostWireEntry
+        ], FingerpostWireEntry],
+        categoryCodes: List[String]
+    ) = {
+      sqls"${alias.categoryCodes} @> ${textArray(categoryCodes)}"
     }
 
     private def preComputedCategoriesConditions(
@@ -341,14 +351,21 @@ object FingerpostWireEntry
         exclusionCondition(ke)(keywordCondition(ke, keywords))
       }
 
-    lazy val categoryCodeInclSQL =
-      (categoryCodes: List[String]) =>
-        categoryCodeConditions(syn, categoryCodes)
+    lazy val categoryCodeSQL =
+      (categoryCodes: CategoryCodesCondition) =>
+        categoryCodes match {
+          case CategoryCodesCondition(codes, OR) =>
+            categoryCodeOrConditions(syn, codes)
+          case CategoryCodesCondition(codes, AND) =>
+            categoryCodeAndConditions(syn, codes)
+        }
 
     lazy val categoryCodeExclSQL =
       (categoryCodesExcl: List[String]) => {
         val cce = syntax("categoryCodesExcl")
-        exclusionCondition(cce)(categoryCodeConditions(cce, categoryCodesExcl))
+        exclusionCondition(cce)(
+          categoryCodeOrConditions(cce, categoryCodesExcl)
+        )
       }
 
     lazy val dataFormattingSQL =
@@ -442,9 +459,9 @@ object FingerpostWireEntry
       case keywords => Some(Filters.keywordsExclSQL(keywords))
     }
 
-    val categoryCodesInclQuery = filters.categoryCodesIncl match {
-      case Nil           => None
-      case categoryCodes => Some(Filters.categoryCodeInclSQL(categoryCodes))
+    val categoryCodesInclQuery = filters.categoryCodes match {
+      case None                => None
+      case Some(categoryCodes) => Some(Filters.categoryCodeSQL(categoryCodes))
     }
 
     val categoryCodesExclQuery = filters.categoryCodesExcl match {

--- a/newswires/app/models/SearchParams.scala
+++ b/newswires/app/models/SearchParams.scala
@@ -1,6 +1,6 @@
 package models
 
-import conf.{CategoryCodesCondition, OR, SearchTerms}
+import conf.{CategoryCodesCondition, OR, SOME, SearchTerms}
 import play.api.mvc.Request
 import service.FeatureSwitchProvider
 
@@ -49,7 +49,7 @@ object SearchParams {
         ),
         categoryCodes =
           if (baseParams.categoryCode.nonEmpty)
-            Some(CategoryCodesCondition(baseParams.categoryCode, OR))
+            Some(CategoryCodesCondition(baseParams.categoryCode, SOME))
           else None,
         categoryCodesExcl = baseParams.categoryCodeExcl,
         hasDataFormatting = baseParams.hasDataFormatting,

--- a/newswires/app/models/SearchParams.scala
+++ b/newswires/app/models/SearchParams.scala
@@ -10,7 +10,7 @@ case class FilterParams(
     keywordExcl: List[String],
     suppliersIncl: List[String],
     suppliersExcl: List[String],
-    categoryCodes: Option[CategoryCodesCondition],
+    categoryCodesIncl: Option[CategoryCodesCondition],
     categoryCodesExcl: List[String],
     hasDataFormatting: Option[Boolean],
     preComputedCategories: List[String],
@@ -47,7 +47,7 @@ object SearchParams {
           featureSwitch.ShowGuSuppliers.isOn(req),
           baseParams.suppliers
         ),
-        categoryCodes =
+        categoryCodesIncl =
           if (baseParams.categoryCode.nonEmpty)
             Some(CategoryCodesCondition(baseParams.categoryCode, SOME))
           else None,

--- a/newswires/app/models/SearchParams.scala
+++ b/newswires/app/models/SearchParams.scala
@@ -1,6 +1,6 @@
 package models
 
-import conf.SearchTerms
+import conf.{CategoryCodesCondition, OR, SearchTerms}
 import play.api.mvc.Request
 import service.FeatureSwitchProvider
 
@@ -10,7 +10,7 @@ case class FilterParams(
     keywordExcl: List[String],
     suppliersIncl: List[String],
     suppliersExcl: List[String],
-    categoryCodesIncl: List[String],
+    categoryCodes: Option[CategoryCodesCondition],
     categoryCodesExcl: List[String],
     hasDataFormatting: Option[Boolean],
     preComputedCategories: List[String],
@@ -47,7 +47,10 @@ object SearchParams {
           featureSwitch.ShowGuSuppliers.isOn(req),
           baseParams.suppliers
         ),
-        categoryCodesIncl = baseParams.categoryCode,
+        categoryCodes =
+          if (baseParams.categoryCode.nonEmpty)
+            Some(CategoryCodesCondition(baseParams.categoryCode, OR))
+          else None,
         categoryCodesExcl = baseParams.categoryCodeExcl,
         hasDataFormatting = baseParams.hasDataFormatting,
         preComputedCategories = Nil,

--- a/newswires/app/models/SearchParams.scala
+++ b/newswires/app/models/SearchParams.scala
@@ -1,6 +1,6 @@
 package models
 
-import conf.{CategoryCodesCondition, OR, SOME, SearchTerms}
+import conf.{CategoryCodesCondition, SOME, SearchTerms}
 import play.api.mvc.Request
 import service.FeatureSwitchProvider
 

--- a/newswires/test/db/FingerpostWireEntrySpec.scala
+++ b/newswires/test/db/FingerpostWireEntrySpec.scala
@@ -1,6 +1,14 @@
 package db
 
-import conf.{AND, ComboTerm, OR, SearchField, SearchTerm, SingleTerm}
+import conf.{
+  AND,
+  CategoryCodesCondition,
+  ComboTerm,
+  OR,
+  SearchField,
+  SearchTerm,
+  SingleTerm
+}
 import io.circe.parser.decode
 import helpers.SqlSnippetMatcher.matchSqlSnippet
 import helpers.models
@@ -119,13 +127,13 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
         SingleTerm(SearchTerm.SingleField("News Summary", SearchField.Headline))
       ),
       suppliersIncl = List("REUTERS"),
-      categoryCodesIncl = List("N2:GB")
+      categoryCodes = Some(CategoryCodesCondition(List("N2:GB"), OR))
     )
 
     val presetFilterParams2 = emptyFilterParams.copy(
       searchTerms = Some(SingleTerm(SearchTerm.SingleField("soccer"))),
       suppliersIncl = List("AFP"),
-      categoryCodesIncl = List("afpCat:SPO")
+      categoryCodes = Some(CategoryCodesCondition(List("afpCat:SPO"), OR))
     )
 
     val preset1Clause =
@@ -228,14 +236,19 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
         )
       ),
       suppliersIncl = List("REUTERS"),
-      categoryCodesIncl = List(
-        "N2:GB"
+      categoryCodes = Some(
+        CategoryCodesCondition(
+          List(
+            "N2:GB"
+          ),
+          OR
+        )
       )
     )
     val presetSearchParams2 = emptyFilterParams.copy(
       searchTerms = Some(SingleTerm(SearchTerm.SingleField("soccer"))),
       suppliersIncl = List("AFP"),
-      categoryCodesIncl = List("afpCat:SPO")
+      categoryCodes = Some(CategoryCodesCondition(List("afpCat:SPO"), OR))
     )
 
     val customParamsClause = FingerpostWireEntry
@@ -347,7 +360,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
     val multiClauses =
       emptyFilterParams
         .copy(suppliersIncl = List("supplier"))
-        .copy(categoryCodesIncl = List("code"))
+        .copy(categoryCodes = Some(CategoryCodesCondition(List("code"), OR)))
     val snippets = FingerpostWireEntry.filtersBuilder(multiClauses)
 
     val rendered = sqls"${snippets.get}".value
@@ -359,10 +372,11 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
     val multiClauses =
       emptyFilterParams
         .copy(suppliersIncl = List("supplier"))
-        .copy(categoryCodesIncl = List("code"))
+        .copy(categoryCodes = Some(CategoryCodesCondition(List("code"), OR)))
 
     val supplierClause = Filters.supplierSQL(List("supplier"))
-    val codeClause = Filters.categoryCodeInclSQL(List("code"))
+    val codeClause =
+      Filters.categoryCodeSQL(CategoryCodesCondition(List("code"), OR))
 
     val snippets = FingerpostWireEntry.filtersBuilder(multiClauses)
 
@@ -386,7 +400,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
       keywordExcl = List("kw2"),
       suppliersIncl = List("s1"),
       suppliersExcl = List("s2"),
-      categoryCodesIncl = List("c1"),
+      categoryCodes = Some(CategoryCodesCondition(List("c1"), OR)),
       categoryCodesExcl = List("c2"),
       hasDataFormatting = Some(true),
       preComputedCategories = List("p1"),
@@ -400,7 +414,9 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
     val snippets = FingerpostWireEntry.filtersBuilder(fullParams)
     val keywordsClause = FingerpostWireEntry.Filters.keywordsSQL(List("kw1"))
     val categoryCodesClause =
-      FingerpostWireEntry.Filters.categoryCodeInclSQL(List("c1"))
+      FingerpostWireEntry.Filters.categoryCodeSQL(
+        CategoryCodesCondition(List("c1"), OR)
+      )
     val keywordsExclClause =
       FingerpostWireEntry.Filters.keywordsExclSQL(List("kw2"))
     val textSearchClause = FingerpostWireEntry.Filters.searchQuerySqlCombined(
@@ -627,7 +643,9 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
   behavior of "category code SQL helpers"
   it should "create the correct sql snippet for categoryCodesIncl" in {
     val categoryCodesSQL =
-      FingerpostWireEntry.Filters.categoryCodeInclSQL(List("code"))
+      FingerpostWireEntry.Filters.categoryCodeSQL(
+        CategoryCodesCondition(List("code"), OR)
+      )
     categoryCodesSQL should matchSqlSnippet(
       expectedClause = "fm.category_codes && ?",
       expectedParams = List(List("code"))

--- a/newswires/test/db/FingerpostWireEntrySpec.scala
+++ b/newswires/test/db/FingerpostWireEntrySpec.scala
@@ -5,6 +5,7 @@ import conf.{
   CategoryCodesCondition,
   ComboTerm,
   OR,
+  SOME,
   SearchField,
   SearchTerm,
   SingleTerm
@@ -127,13 +128,13 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
         SingleTerm(SearchTerm.SingleField("News Summary", SearchField.Headline))
       ),
       suppliersIncl = List("REUTERS"),
-      categoryCodes = Some(CategoryCodesCondition(List("N2:GB"), OR))
+      categoryCodes = Some(CategoryCodesCondition(List("N2:GB"), SOME))
     )
 
     val presetFilterParams2 = emptyFilterParams.copy(
       searchTerms = Some(SingleTerm(SearchTerm.SingleField("soccer"))),
       suppliersIncl = List("AFP"),
-      categoryCodes = Some(CategoryCodesCondition(List("afpCat:SPO"), OR))
+      categoryCodes = Some(CategoryCodesCondition(List("afpCat:SPO"), SOME))
     )
 
     val preset1Clause =
@@ -241,14 +242,14 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
           List(
             "N2:GB"
           ),
-          OR
+          SOME
         )
       )
     )
     val presetSearchParams2 = emptyFilterParams.copy(
       searchTerms = Some(SingleTerm(SearchTerm.SingleField("soccer"))),
       suppliersIncl = List("AFP"),
-      categoryCodes = Some(CategoryCodesCondition(List("afpCat:SPO"), OR))
+      categoryCodes = Some(CategoryCodesCondition(List("afpCat:SPO"), SOME))
     )
 
     val customParamsClause = FingerpostWireEntry
@@ -360,7 +361,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
     val multiClauses =
       emptyFilterParams
         .copy(suppliersIncl = List("supplier"))
-        .copy(categoryCodes = Some(CategoryCodesCondition(List("code"), OR)))
+        .copy(categoryCodes = Some(CategoryCodesCondition(List("code"), SOME)))
     val snippets = FingerpostWireEntry.filtersBuilder(multiClauses)
 
     val rendered = sqls"${snippets.get}".value
@@ -372,11 +373,11 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
     val multiClauses =
       emptyFilterParams
         .copy(suppliersIncl = List("supplier"))
-        .copy(categoryCodes = Some(CategoryCodesCondition(List("code"), OR)))
+        .copy(categoryCodes = Some(CategoryCodesCondition(List("code"), SOME)))
 
     val supplierClause = Filters.supplierSQL(List("supplier"))
     val codeClause =
-      Filters.categoryCodeSQL(CategoryCodesCondition(List("code"), OR))
+      Filters.categoryCodeSQL(CategoryCodesCondition(List("code"), SOME))
 
     val snippets = FingerpostWireEntry.filtersBuilder(multiClauses)
 
@@ -400,7 +401,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
       keywordExcl = List("kw2"),
       suppliersIncl = List("s1"),
       suppliersExcl = List("s2"),
-      categoryCodes = Some(CategoryCodesCondition(List("c1"), OR)),
+      categoryCodes = Some(CategoryCodesCondition(List("c1"), SOME)),
       categoryCodesExcl = List("c2"),
       hasDataFormatting = Some(true),
       preComputedCategories = List("p1"),
@@ -415,7 +416,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
     val keywordsClause = FingerpostWireEntry.Filters.keywordsSQL(List("kw1"))
     val categoryCodesClause =
       FingerpostWireEntry.Filters.categoryCodeSQL(
-        CategoryCodesCondition(List("c1"), OR)
+        CategoryCodesCondition(List("c1"), SOME)
       )
     val keywordsExclClause =
       FingerpostWireEntry.Filters.keywordsExclSQL(List("kw2"))
@@ -644,7 +645,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
   it should "create the correct sql snippet for categoryCodesIncl" in {
     val categoryCodesSQL =
       FingerpostWireEntry.Filters.categoryCodeSQL(
-        CategoryCodesCondition(List("code"), OR)
+        CategoryCodesCondition(List("code"), SOME)
       )
     categoryCodesSQL should matchSqlSnippet(
       expectedClause = "fm.category_codes && ?",

--- a/newswires/test/db/FingerpostWireEntrySpec.scala
+++ b/newswires/test/db/FingerpostWireEntrySpec.scala
@@ -1,6 +1,7 @@
 package db
 
 import conf.{
+  ALL,
   AND,
   CategoryCodesCondition,
   ComboTerm,
@@ -128,13 +129,13 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
         SingleTerm(SearchTerm.SingleField("News Summary", SearchField.Headline))
       ),
       suppliersIncl = List("REUTERS"),
-      categoryCodes = Some(CategoryCodesCondition(List("N2:GB"), SOME))
+      categoryCodesIncl = Some(CategoryCodesCondition(List("N2:GB"), SOME))
     )
 
     val presetFilterParams2 = emptyFilterParams.copy(
       searchTerms = Some(SingleTerm(SearchTerm.SingleField("soccer"))),
       suppliersIncl = List("AFP"),
-      categoryCodes = Some(CategoryCodesCondition(List("afpCat:SPO"), SOME))
+      categoryCodesIncl = Some(CategoryCodesCondition(List("afpCat:SPO"), SOME))
     )
 
     val preset1Clause =
@@ -237,7 +238,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
         )
       ),
       suppliersIncl = List("REUTERS"),
-      categoryCodes = Some(
+      categoryCodesIncl = Some(
         CategoryCodesCondition(
           List(
             "N2:GB"
@@ -249,7 +250,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
     val presetSearchParams2 = emptyFilterParams.copy(
       searchTerms = Some(SingleTerm(SearchTerm.SingleField("soccer"))),
       suppliersIncl = List("AFP"),
-      categoryCodes = Some(CategoryCodesCondition(List("afpCat:SPO"), SOME))
+      categoryCodesIncl = Some(CategoryCodesCondition(List("afpCat:SPO"), SOME))
     )
 
     val customParamsClause = FingerpostWireEntry
@@ -361,7 +362,9 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
     val multiClauses =
       emptyFilterParams
         .copy(suppliersIncl = List("supplier"))
-        .copy(categoryCodes = Some(CategoryCodesCondition(List("code"), SOME)))
+        .copy(categoryCodesIncl =
+          Some(CategoryCodesCondition(List("code"), SOME))
+        )
     val snippets = FingerpostWireEntry.filtersBuilder(multiClauses)
 
     val rendered = sqls"${snippets.get}".value
@@ -373,11 +376,13 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
     val multiClauses =
       emptyFilterParams
         .copy(suppliersIncl = List("supplier"))
-        .copy(categoryCodes = Some(CategoryCodesCondition(List("code"), SOME)))
+        .copy(categoryCodesIncl =
+          Some(CategoryCodesCondition(List("code"), SOME))
+        )
 
     val supplierClause = Filters.supplierSQL(List("supplier"))
     val codeClause =
-      Filters.categoryCodeSQL(CategoryCodesCondition(List("code"), SOME))
+      Filters.categoryCodeInclSQL(CategoryCodesCondition(List("code"), SOME))
 
     val snippets = FingerpostWireEntry.filtersBuilder(multiClauses)
 
@@ -401,7 +406,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
       keywordExcl = List("kw2"),
       suppliersIncl = List("s1"),
       suppliersExcl = List("s2"),
-      categoryCodes = Some(CategoryCodesCondition(List("c1"), SOME)),
+      categoryCodesIncl = Some(CategoryCodesCondition(List("c1"), SOME)),
       categoryCodesExcl = List("c2"),
       hasDataFormatting = Some(true),
       preComputedCategories = List("p1"),
@@ -415,7 +420,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
     val snippets = FingerpostWireEntry.filtersBuilder(fullParams)
     val keywordsClause = FingerpostWireEntry.Filters.keywordsSQL(List("kw1"))
     val categoryCodesClause =
-      FingerpostWireEntry.Filters.categoryCodeSQL(
+      FingerpostWireEntry.Filters.categoryCodeInclSQL(
         CategoryCodesCondition(List("c1"), SOME)
       )
     val keywordsExclClause =
@@ -642,13 +647,24 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
   }
 
   behavior of "category code SQL helpers"
-  it should "create the correct sql snippet for categoryCodesIncl" in {
+  it should "create the correct sql snippet for categoryCodesIncl with SOME" in {
     val categoryCodesSQL =
-      FingerpostWireEntry.Filters.categoryCodeSQL(
+      FingerpostWireEntry.Filters.categoryCodeInclSQL(
         CategoryCodesCondition(List("code"), SOME)
       )
     categoryCodesSQL should matchSqlSnippet(
       expectedClause = "fm.category_codes && ?",
+      expectedParams = List(List("code"))
+    )
+  }
+
+  it should "create the correct sql snippet for categoryCodesIncl with ALL" in {
+    val categoryCodesSQL =
+      FingerpostWireEntry.Filters.categoryCodeInclSQL(
+        CategoryCodesCondition(List("code"), ALL)
+      )
+    categoryCodesSQL should matchSqlSnippet(
+      expectedClause = "fm.category_codes @> ?",
       expectedParams = List(List("code"))
     )
   }

--- a/newswires/test/helpers/models.scala
+++ b/newswires/test/helpers/models.scala
@@ -301,7 +301,7 @@ trait models {
     keywordExcl = Nil,
     suppliersIncl = Nil,
     suppliersExcl = Nil,
-    categoryCodes = None,
+    categoryCodesIncl = None,
     categoryCodesExcl = Nil,
     hasDataFormatting = None,
     preComputedCategories = Nil,

--- a/newswires/test/helpers/models.scala
+++ b/newswires/test/helpers/models.scala
@@ -301,7 +301,7 @@ trait models {
     keywordExcl = Nil,
     suppliersIncl = Nil,
     suppliersExcl = Nil,
-    categoryCodesIncl = Nil,
+    categoryCodes = None,
     categoryCodesExcl = Nil,
     hasDataFormatting = None,
     preComputedCategories = Nil,

--- a/newswires/test/models/SearchParamsSpec.scala
+++ b/newswires/test/models/SearchParamsSpec.scala
@@ -1,7 +1,7 @@
 package models
 
 import conf.SearchField.Slug
-import conf.{AND, ComboTerm, OR, SearchTerm}
+import conf.{AND, CategoryCodesCondition, ComboTerm, OR, SearchTerm}
 import helpers.models
 import org.mockito.Mockito.when
 import org.scalatest.flatspec.AnyFlatSpec
@@ -90,7 +90,7 @@ class SearchParamsSpec extends AnyFlatSpec with models {
         keywordExcl = Nil,
         suppliersIncl = List("supplier1"),
         suppliersExcl = List("UNAUTHED_EMAIL_FEED"),
-        categoryCodesIncl = List("code1"),
+        categoryCodes = Some(CategoryCodesCondition(List("code1"), OR)),
         categoryCodesExcl = List("code2"),
         hasDataFormatting = Some(true),
         collectionId = Some(1),

--- a/newswires/test/models/SearchParamsSpec.scala
+++ b/newswires/test/models/SearchParamsSpec.scala
@@ -90,7 +90,7 @@ class SearchParamsSpec extends AnyFlatSpec with models {
         keywordExcl = Nil,
         suppliersIncl = List("supplier1"),
         suppliersExcl = List("UNAUTHED_EMAIL_FEED"),
-        categoryCodes = Some(CategoryCodesCondition(List("code1"), SOME)),
+        categoryCodesIncl = Some(CategoryCodesCondition(List("code1"), SOME)),
         categoryCodesExcl = List("code2"),
         hasDataFormatting = Some(true),
         collectionId = Some(1),

--- a/newswires/test/models/SearchParamsSpec.scala
+++ b/newswires/test/models/SearchParamsSpec.scala
@@ -1,7 +1,7 @@
 package models
 
 import conf.SearchField.Slug
-import conf.{AND, CategoryCodesCondition, ComboTerm, OR, SearchTerm}
+import conf.{AND, CategoryCodesCondition, ComboTerm, OR, SOME, SearchTerm}
 import helpers.models
 import org.mockito.Mockito.when
 import org.scalatest.flatspec.AnyFlatSpec
@@ -90,7 +90,7 @@ class SearchParamsSpec extends AnyFlatSpec with models {
         keywordExcl = Nil,
         suppliersIncl = List("supplier1"),
         suppliersExcl = List("UNAUTHED_EMAIL_FEED"),
-        categoryCodes = Some(CategoryCodesCondition(List("code1"), OR)),
+        categoryCodes = Some(CategoryCodesCondition(List("code1"), SOME)),
         categoryCodesExcl = List("code2"),
         hasDataFormatting = Some(true),
         collectionId = Some(1),


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add a wrapper to the list of category codes for `categoryCodesIncl` which specifies whether the category codes need to all be present, or just some of them (the difference is [between `@>` and `&&`](https://www.postgresql.org/docs/current/functions-array.html#FUNCTIONS-ARRAY) in the ultimate Postgres query).

The implementation follows the pattern we've got for `SearchTerm`. All existing uses of `categoryCodesIncl` have been given `SOME`, which was implicitly the only option before. This PR should be a no-op refactor, but we will add some uses of `ALL` in follow-up PRs.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Run locally, do some searches involving presets and category code inclusion/exclusion. Compare the same searches with CODE; they should be the same.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD