### PR TITLE
Add more domestic news to Reuters US

### DIFF
--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -206,6 +206,14 @@ object SearchPresets {
         "business-related-topic-codes",
         "business-related-news-codes"
       )
+    ),
+    SearchPreset(
+      REUTERS,
+      categoryCodes = Some(CategoryCodesCondition(List("N2:NAMER", "a1312cat:a"), ALL))
+    ),
+    SearchPreset(
+      REUTERS,
+      categoryCodes = Some(CategoryCodesCondition(List("N2:NAMER", "a1312cat:p"), ALL))
     )
   )
 


### PR DESCRIPTION
Add more domestic news to Reuters US:

* `a1312cat:a`: "Domestic, non-Washington, general news item."
* `a1312cat:p`: "National political."

Combined with `N2:NAMER`, this seems to be pretty close to what Reuters Connect shows when you select News + North America.

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD