### PR TITLE
Remove semver-specific cooldown option from github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,4 +43,3 @@ updates:
       interval: 'weekly'
     cooldown:
       default-days: 7
-      semver-major-days: 30


### PR DESCRIPTION


github-actions ecosystem does not allow setting options which requires semver understanding https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#configuration-of-cooldown
