### PR TITLE
Add international + Canada to AP US definition

### DIFF
--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -198,6 +198,10 @@ object SearchPresets {
       categoryCodes = Some(CategoryCodesCondition(CategoryCodes.US.AP, SOME))
     ),
     SearchPreset(
+      AP,
+      categoryCodes = Some(CategoryCodesCondition(List("apCat:i", "experimentalCountryCode:CA"), ALL))
+    ),
+    SearchPreset(
       REUTERS,
       categoryCodes = Some(CategoryCodesCondition(CategoryCodes.US.REUTERS, SOME)),
       preComputedCategoriesExcl = List(


### PR DESCRIPTION
From a quick sense check, and a discussion with some US-based folks, it looks like this will add a few relevant stories, and not many non-relevant stories. 

~6 in total over 24 hours, some of which are quite relevant.