### PR TITLE
Add 'data:finance' to the list of PA Business codes

### DIFF
--- a/newswires/app/conf/Categories.scala
+++ b/newswires/app/conf/Categories.scala
@@ -43,7 +43,7 @@ private[conf] object CategoryCodes {
 
   object Business {
     val AP: List[String] = List("apCat:f")
-    val PA: List[String] = List("paCat:FFF", "paCat:GXX")
+    val PA: List[String] = List("paCat:FFF", "paCat:GXX", "data:finance")
     val AAP: List[String] = Categories.businessRelatedNewsCodes
     val REUTERS: List[String] = Categories.businessRelatedTopicCodes
   }


### PR DESCRIPTION
We've got business stories arriving which don't have any of the previously recognised PA business category codes, but which do have `data:finance`, so we should add them into the Business presets (and thereby take them out of Sport, which is where they were showing up by default 😮)