### PR TITLE
Wire up UkElection preset, shown in nav only to dev users

### DIFF
--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -49,6 +49,7 @@ object SearchPresets {
     case "afp-world"            => Some(SearchPreset(AfpWorld, Nil))
     case "minor-agencies-world" => Some(SearchPreset(MinorAgenciesWorld, Nil))
     case "all-uk"               => Some(SearchPreset(AllUk, Nil))
+    case "uk-election"          => Some(SearchPreset(PaElection, Nil))
     case "all-us"               => Some(SearchPreset(AllUs, Nil))
     case "world-plus-uk"        => Some(SearchPreset(WorldPlusUK, Nil))
     case "all-business"         => Some(SearchPreset(AllBusiness, Nil))

--- a/newswires/client/src/app-configuration.ts
+++ b/newswires/client/src/app-configuration.ts
@@ -33,6 +33,8 @@ export const SUPPLIERS_TO_EXCLUDE =
 
 export const STAGE = configLookup.stage;
 
-export const SEND_TELEMETRY_AS_DEV = configLookup.sendTelemetryAsDev;
+export const IS_DEV_USER = configLookup.sendTelemetryAsDev;
+
+export const SEND_TELEMETRY_AS_DEV = IS_DEV_USER;
 
 export const GIT_COMMIT_ID = configLookup.gitCommitId;

--- a/newswires/client/src/presets.ts
+++ b/newswires/client/src/presets.ts
@@ -1,4 +1,5 @@
 import z from 'zod/v4';
+import { IS_DEV_USER } from './app-configuration.ts';
 import { useUserSettings } from './context/UserSettingsContext.tsx';
 
 export const PresetGroupNameSchema = z.union([
@@ -139,6 +140,7 @@ export const allPresets: Preset[] = [
 	{ id: topLevelPresetId, name: 'All' },
 	{ id: 'all-world', name: 'World' },
 	{ id: 'all-uk', name: 'UK' },
+	{ id: 'uk-election', name: 'UK Election (Dev only)' },
 	{ id: 'all-us', name: 'US' },
 	{ id: 'world-plus-uk', name: 'World + UK' },
 	{ id: 'all-business', name: 'Business' },
@@ -153,6 +155,7 @@ export const useDisplayablePresets = () => {
 	const presetsToHide = new Set<string>();
 
 	if (!previewUSDomestic) presetsToHide.add('all-us');
+	if (!IS_DEV_USER) presetsToHide.add('uk-election');
 
 	return allPresets.filter((p) => !presetsToHide.has(p.id));
 };


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We started getting a lot of election test stories today, which were ending up in Sport, but filtered out in #835. As it stands, this leaves them with no alternative home. We might want to add them to the UK preset (for UK elections) or create a separate preset, but for the time being it'll probably be useful for us to be able to see them while we're developing.

Depends on the list of dev users (developers and other team members) that we use to enable us to see which telemetry events are coming from our own testing. This feels like a reasonable group/mechanism to use for this purpose, too.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD