### PR TITLE
Show 'US domestic news' to everyone, removing switch

### DIFF
--- a/newswires/client/src/Item.stories.tsx
+++ b/newswires/client/src/Item.stories.tsx
@@ -76,8 +76,6 @@ const meta = {
 							toggleEnableAutoScroll: () => {},
 							selectedTimezone: 'Europe/London',
 							changeTimezoneSelection: () => {},
-							previewUSDomestic: false,
-							togglePreviewUSDomestic: () => {},
 						}}
 					>
 						<SearchContextProvider>

--- a/newswires/client/src/SettingsSwitches.tsx
+++ b/newswires/client/src/SettingsSwitches.tsx
@@ -13,8 +13,6 @@ export const useSettingsSwitches = () => {
 		toggleShowTastedList,
 		enableAutoScroll,
 		toggleEnableAutoScroll,
-		previewUSDomestic,
-		togglePreviewUSDomestic,
 	} = useUserSettings();
 
 	const embeddedCodeSwitchId__1 = useGeneratedHtmlId({
@@ -30,9 +28,6 @@ export const useSettingsSwitches = () => {
 		prefix: 'embeddedCodeSwitchId',
 	});
 	const embeddedCodeSwitchId__5 = useGeneratedHtmlId({
-		prefix: 'embeddedCodeSwitchId',
-	});
-	const embeddedCodeSwitchId__6 = useGeneratedHtmlId({
 		prefix: 'embeddedCodeSwitchId',
 	});
 
@@ -74,13 +69,6 @@ export const useSettingsSwitches = () => {
 			onChange: () => toggleEnableAutoScroll(),
 			helpText:
 				'Automatically scroll to the top when new items are loaded (only works on tickers)',
-		},
-		{
-			id: embeddedCodeSwitchId__6,
-			label: 'Preview new US Domestic preset',
-			checked: previewUSDomestic,
-			onChange: () => togglePreviewUSDomestic(),
-			helpText: "Preview the new US Domestic preset while we're testing",
 		},
 	];
 };

--- a/newswires/client/src/context/UserSettingsContext.tsx
+++ b/newswires/client/src/context/UserSettingsContext.tsx
@@ -18,8 +18,6 @@ interface UserSettingsContextShape {
 	toggleEnableAutoScroll: () => void;
 	selectedTimezone: TimezoneId;
 	changeTimezoneSelection: (tz: TimezoneId) => void;
-	previewUSDomestic: boolean;
-	togglePreviewUSDomestic: () => void;
 }
 
 export const UserSettingsContext =
@@ -87,11 +85,6 @@ export const UserSettingsContextProvider = ({
 		saveToLocalStorage<TimezoneId>('selectedTimezone', tz);
 	};
 
-	const [previewUSDomestic, togglePreviewUSDomestic] = useBooleanUserSetting(
-		'previewUSDomestic',
-		{ defaultVal: false },
-	);
-
 	const [resizablePanelsDirection, setResizablePanelsDirection] = useState<
 		'vertical' | 'horizontal'
 	>(
@@ -127,8 +120,6 @@ export const UserSettingsContextProvider = ({
 				toggleEnableAutoScroll,
 				selectedTimezone,
 				changeTimezoneSelection,
-				previewUSDomestic,
-				togglePreviewUSDomestic,
 			}}
 		>
 			{children}

--- a/newswires/client/src/presets.ts
+++ b/newswires/client/src/presets.ts
@@ -1,6 +1,5 @@
 import z from 'zod/v4';
 import { IS_DEV_USER } from './app-configuration.ts';
-import { useUserSettings } from './context/UserSettingsContext.tsx';
 
 export const PresetGroupNameSchema = z.union([
 	z.literal('presets'),
@@ -148,13 +147,9 @@ export const allPresets: Preset[] = [
 ];
 
 // Filter out any presets which shouldn't be presented to users.
-// For now, just the all-US preset, depending on the state of the switch
 export const useDisplayablePresets = () => {
-	const { previewUSDomestic } = useUserSettings();
-
 	const presetsToHide = new Set<string>();
 
-	if (!previewUSDomestic) presetsToHide.add('all-us');
 	if (!IS_DEV_USER) presetsToHide.add('uk-election');
 
 	return allPresets.filter((p) => !presetsToHide.has(p.id));


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We're ready to show the new US domestic news preset to everyone, so we need to remove the client-side switch which was controlling whether or not it showed.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Run locally
- [x] Delete any pre-existing preference settings in browser localstorage
- [x] US preset should be present in the side nav, and should work as expected

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD