### PR TITLE
Test alternative to 'not exists' queries

### DIFF
--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -101,7 +101,8 @@ class QueryController(
       )
 
       val queryResponse = FingerpostWireEntry.query(
-        queryParams
+        queryParams,
+        FingerpostWireEntry.countQueryCap
       )
 
       Ok(

--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -48,7 +48,8 @@ class QueryController(
       hasDataFormatting: Option[Boolean],
       guSourceFeeds: List[String],
       guSourceFeedsExcl: List[String],
-      eventCode: Option[String]
+      eventCode: Option[String],
+      countQueryCap: Option[Long]
   ): Action[AnyContent] = apiAuthAction {
     implicit request: UserRequest[AnyContent] =>
       val baseParams = BaseRequestParams(
@@ -103,7 +104,8 @@ class QueryController(
 
       val queryResponse = FingerpostWireEntry.query(
         queryParams,
-        queryVariant = queryVariant
+        queryVariant = queryVariant,
+        countQueryCap = countQueryCap.getOrElse(COUNT_QUERY_CAP)
       )
 
       Ok(

--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -4,18 +4,11 @@ import com.gu.pandomainauth.PanDomainAuthSettingsRefresher
 import com.gu.pandomainauth.action.UserRequest
 import com.gu.permissions.PermissionsProvider
 import conf.{SearchPresets, SearchTerm}
-import io.circe.syntax.EncoderOps
 import db.FingerpostWireEntry._
-import models.{
-  BaseRequestParams,
-  NextPage,
-  QueryCursor,
-  QueryParams,
-  QueryResponse,
-  SearchParams
-}
 import db._
+import io.circe.syntax.EncoderOps
 import lib.Base64Encoder
+import models._
 import play.api.libs.json.{Json, OFormat}
 import play.api.libs.ws.WSClient
 import play.api.mvc._
@@ -23,6 +16,7 @@ import play.api.{Configuration, Logging}
 import service.FeatureSwitchProvider
 
 import java.time.Instant
+import scala.util.Random
 
 class QueryController(
     val controllerComponents: ControllerComponents,
@@ -100,9 +94,16 @@ class QueryController(
         timeStampColumn = timeStampColumn
       )
 
+      val queryVariant = request.getQueryString("variant") match {
+        case Some("not_exists")        => NotExists
+        case Some("plain_not")         => PlainNot
+        case _ if Random.nextBoolean() => NotExists
+        case _                         => PlainNot
+      }
+
       val queryResponse = FingerpostWireEntry.query(
         queryParams,
-        FingerpostWireEntry.countQueryCap
+        queryVariant = queryVariant
       )
 
       Ok(

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -30,6 +30,7 @@ import play.api.Logging
 import scalikejdbc._
 import io.circe.parser._
 
+import java.io.{File, FileWriter}
 import java.time.Instant
 
 case class WireMaybeToolLinkAndCollection(
@@ -58,6 +59,8 @@ case class FingerpostWireEntry(
 object FingerpostWireEntry
     extends SQLSyntaxSupport[FingerpostWireEntry]
     with Logging {
+
+  val countQueryCap = 100L
 
   implicit val jsonEncoder: Encoder[FingerpostWireEntry] =
     deriveEncoder[FingerpostWireEntry].mapJson(_.dropNullValues)
@@ -204,23 +207,33 @@ object FingerpostWireEntry
       .flatten
   }
 
+  private def formatQueryParam(param: Any): String = param match {
+    case null | None   => "NULL"
+    case Some(v)       => formatQueryParam(v)
+    case list: List[_] =>
+      "ARRAY[" + list
+        .map(e => "'" + e.toString.replace("'", "''") + "'")
+        .mkString(", ") + "]::text[]"
+    case n: Int  => n.toString
+    case n: Long => n.toString
+    case other   => "'" + other.toString.replace("'", "''") + "'"
+  }
+
+  private def _toExecutableQuery(
+      statement: String,
+      parameters: Seq[Any]
+  ): String = {
+    val sentinel = "\u0000"
+    val segments = statement.replace("??", sentinel).split("\\?", -1)
+    val formattedParams = parameters.map(formatQueryParam) :+ ""
+    segments
+      .zip(formattedParams)
+      .map { case (seg, param) => seg + param }
+      .mkString
+      .replace(sentinel, "?") // restore PostgreSQL ?| / ?& operators
+  }
+
   object Filters {
-    private def exclusionCondition(
-        alias: QuerySQLSyntaxProvider[SQLSyntaxSupport[
-          FingerpostWireEntry
-        ], FingerpostWireEntry]
-    )(innerClause: SQLSyntax) = {
-      // unpleasant, but the sort of trick you need to pull
-      // because "NOT IN (...)" doesn't hit an index.
-      // https://stackoverflow.com/a/19364694
-
-      sqls"""|NOT EXISTS (
-             |  SELECT FROM ${FingerpostWireEntry as alias}
-             |  WHERE ${syn.id} = ${alias.id}
-             |    AND $innerClause
-             |)""".stripMargin
-    }
-
     private def supplierCondition(
         alias: QuerySQLSyntaxProvider[SQLSyntaxSupport[
           FingerpostWireEntry
@@ -276,8 +289,7 @@ object FingerpostWireEntry
 
     lazy val supplierExclSQL =
       (suppliersExcl: List[String]) => {
-        val se = syntax("suppliersExcl")
-        exclusionCondition(se)(supplierCondition(se, suppliersExcl))
+        sqls"NOT (${supplierCondition(syn, suppliersExcl)})"
       }
 
     lazy val guSourceFeedSQL: List[String] => SQLSyntax =
@@ -289,12 +301,9 @@ object FingerpostWireEntry
 
     lazy val guSourceFeedExclSQL =
       (guSourceFeedsExcl: List[String]) => {
-        val gsfe = syntax("guSourceFeedExcl")
-        exclusionCondition(gsfe)(
-          sqls.in(
-            sqls"upper(${gsfe.guSourceFeed})",
-            guSourceFeedsExcl.map(feed => sqls"upper($feed)")
-          )
+        sqls.notIn(
+          sqls"upper(${syn.guSourceFeed})",
+          guSourceFeedsExcl.map(feed => sqls"upper($feed)")
         )
       }
 
@@ -349,8 +358,7 @@ object FingerpostWireEntry
 
     lazy val keywordsExclSQL =
       (keywords: List[String]) => {
-        val ke = syntax("keywordsExcl")
-        exclusionCondition(ke)(keywordCondition(ke, keywords))
+        sqls"NOT (${keywordCondition(syn, keywords)})"
       }
 
     lazy val categoryCodeInclSQL =
@@ -364,10 +372,7 @@ object FingerpostWireEntry
 
     lazy val categoryCodeExclSQL =
       (categoryCodesExcl: List[String]) => {
-        val cce = syntax("categoryCodesExcl")
-        exclusionCondition(cce)(
-          categoryCodeSomeConditions(cce, categoryCodesExcl)
-        )
+        sqls"NOT ${categoryCodeSomeConditions(syn, categoryCodesExcl)}"
       }
 
     lazy val dataFormattingSQL =
@@ -410,10 +415,7 @@ object FingerpostWireEntry
 
     lazy val preComputedCategoriesExclSQL =
       (preComputedCategories: List[String]) => {
-        val pce = syntax("preComputedCategoriesExcl")
-        exclusionCondition(pce)(
-          preComputedCategoriesConditions(pce, preComputedCategories)
-        )
+        sqls"NOT ${preComputedCategoriesConditions(syn, preComputedCategories)}"
       }
 
     lazy val collectionIdSQL = (collectionId: Int) =>
@@ -647,7 +649,8 @@ object FingerpostWireEntry
   }
 
   def query(
-      queryParams: QueryParams
+      queryParams: QueryParams,
+      countQueryCap: Long
   ): QueryResponse = DB readOnly { implicit session =>
     val whereClause = buildWhereClause(
       queryParams.searchParams,
@@ -668,6 +671,14 @@ object FingerpostWireEntry
     )
 
     logger.info(s"QUERY: ${query.statement}; PARAMS: ${query.parameters}")
+
+    val fileWriter =
+      new FileWriter(new File(s"/tmp/query-${Instant.now()}.sql"))
+    fileWriter.write(
+      _toExecutableQuery(query.statement, Seq.from(query.parameters))
+    )
+    fileWriter.close()
+
     val rows = query
       .map(rs => {
         val wireEntry = FingerpostWireEntry.fromDb(syn.resultName)(rs)
@@ -683,15 +694,18 @@ object FingerpostWireEntry
       marshallJoinedRowsToWireEntries(rows)
 
     val countQuery =
-      sql"""| SELECT COUNT(*)
-            | FROM ${FingerpostWireEntry as FingerpostWireEntry.syn}
-            | LEFT JOIN ${ToolLink as ToolLink.syn}
-            |  ON ${syn.id} = ${ToolLink.syn.wireId}
-            | LEFT JOIN ${WireEntryForCollection as WireEntryForCollection.syn}
-            |   ON ${WireEntryForCollection.syn.wireEntryId} = ${syn.id}
-            | LEFT JOIN ${Collection as Collection.syn}
-            |   ON ${Collection.syn.id} = ${WireEntryForCollection.syn.collectionId}
-            | WHERE $whereClause
+      sql"""| SELECT COUNT(*) FROM (
+            |   SELECT 1
+            |   FROM ${FingerpostWireEntry as FingerpostWireEntry.syn}
+            |   LEFT JOIN ${ToolLink as ToolLink.syn}
+            |    ON ${syn.id} = ${ToolLink.syn.wireId}
+            |   LEFT JOIN ${WireEntryForCollection as WireEntryForCollection.syn}
+            |     ON ${WireEntryForCollection.syn.wireEntryId} = ${syn.id}
+            |   LEFT JOIN ${Collection as Collection.syn}
+            |     ON ${Collection.syn.id} = ${WireEntryForCollection.syn.collectionId}
+            |   WHERE $whereClause
+            |   LIMIT ${countQueryCap + 1}
+            | ) AS capped
             | """.stripMargin
 
     logger.info(
@@ -710,7 +724,8 @@ object FingerpostWireEntry
 
     QueryResponse(
       results,
-      totalCount /*, keywordCounts*/
+      totalCount,
+      countQueryCap
     )
   }
 

--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -1,36 +1,15 @@
 package db
 
 import conf.SearchTerm.CombinedFields
-import conf.{
-  ALL,
-  AND,
-  CategoryCodesCondition,
-  ComboTerm,
-  OR,
-  SOME,
-  SearchField,
-  SearchTerm,
-  SearchTerms,
-  SingleTerm
-}
+import conf._
 import db.CustomMappers.textArray
-import io.circe.{Decoder, Encoder}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
-import models.{
-  FilterParams,
-  FingerpostWire,
-  NextPage,
-  QueryCursor,
-  QueryParams,
-  QueryResponse,
-  SearchParams,
-  UpdateType
-}
+import io.circe.parser._
+import io.circe.{Decoder, Encoder}
+import models._
 import play.api.Logging
 import scalikejdbc._
-import io.circe.parser._
 
-import java.io.{File, FileWriter}
 import java.time.Instant
 
 case class WireMaybeToolLinkAndCollection(
@@ -60,7 +39,7 @@ object FingerpostWireEntry
     extends SQLSyntaxSupport[FingerpostWireEntry]
     with Logging {
 
-  val countQueryCap = 100L
+  val COUNT_QUERY_CAP = 100L
 
   implicit val jsonEncoder: Encoder[FingerpostWireEntry] =
     deriveEncoder[FingerpostWireEntry].mapJson(_.dropNullValues)
@@ -207,33 +186,29 @@ object FingerpostWireEntry
       .flatten
   }
 
-  private def formatQueryParam(param: Any): String = param match {
-    case null | None   => "NULL"
-    case Some(v)       => formatQueryParam(v)
-    case list: List[_] =>
-      "ARRAY[" + list
-        .map(e => "'" + e.toString.replace("'", "''") + "'")
-        .mkString(", ") + "]::text[]"
-    case n: Int  => n.toString
-    case n: Long => n.toString
-    case other   => "'" + other.toString.replace("'", "''") + "'"
-  }
-
-  private def _toExecutableQuery(
-      statement: String,
-      parameters: Seq[Any]
-  ): String = {
-    val sentinel = "\u0000"
-    val segments = statement.replace("??", sentinel).split("\\?", -1)
-    val formattedParams = parameters.map(formatQueryParam) :+ ""
-    segments
-      .zip(formattedParams)
-      .map { case (seg, param) => seg + param }
-      .mkString
-      .replace(sentinel, "?") // restore PostgreSQL ?| / ?& operators
-  }
-
   object Filters {
+    private def exclusionCondition(
+        alias: QuerySQLSyntaxProvider[SQLSyntaxSupport[
+          FingerpostWireEntry
+        ], FingerpostWireEntry],
+        queryVariant: QueryVariant = PlainNot
+    )(innerClause: SQLSyntax) = {
+      queryVariant match {
+        case NotExists =>
+          // unpleasant, but the sort of trick you need to pull
+          // because "NOT IN (...)" doesn't hit an index.
+          // https://stackoverflow.com/a/19364694
+
+          sqls"""|NOT EXISTS (
+                 |  SELECT FROM ${FingerpostWireEntry as alias}
+                 |  WHERE ${syn.id} = ${alias.id}
+                 |    AND $innerClause
+                 |)""".stripMargin
+
+        case PlainNot => sqls"NOT ($innerClause)"
+      }
+    }
+
     private def supplierCondition(
         alias: QuerySQLSyntaxProvider[SQLSyntaxSupport[
           FingerpostWireEntry
@@ -287,10 +262,14 @@ object FingerpostWireEntry
     lazy val supplierSQL: List[String] => SQLSyntax =
       (suppliers: List[String]) => supplierCondition(syn, suppliers)
 
-    lazy val supplierExclSQL =
-      (suppliersExcl: List[String]) => {
-        sqls"NOT (${supplierCondition(syn, suppliersExcl)})"
-      }
+    def supplierExclSQL(
+        suppliersExcl: List[String],
+        queryVariant: QueryVariant = PlainNot
+    ) = {
+      exclusionCondition(syn, queryVariant)(
+        supplierCondition(syn, suppliersExcl)
+      )
+    }
 
     lazy val guSourceFeedSQL: List[String] => SQLSyntax =
       (guSourceFeeds: List[String]) =>
@@ -299,13 +278,17 @@ object FingerpostWireEntry
           guSourceFeeds.map(feed => sqls"upper($feed)")
         )
 
-    lazy val guSourceFeedExclSQL =
-      (guSourceFeedsExcl: List[String]) => {
-        sqls.notIn(
+    def guSourceFeedExclSQL(
+        guSourceFeedsExcl: List[String],
+        queryVariant: QueryVariant = PlainNot
+    ) = {
+      exclusionCondition(syn, queryVariant)(
+        sqls.in(
           sqls"upper(${syn.guSourceFeed})",
           guSourceFeedsExcl.map(feed => sqls"upper($feed)")
         )
-      }
+      )
+    }
 
     lazy val singleFieldSearchSQL =
       (searchTerm: SearchTerm.SingleField) =>
@@ -356,10 +339,12 @@ object FingerpostWireEntry
     lazy val keywordsSQL =
       (keywords: List[String]) => keywordCondition(syn, keywords)
 
-    lazy val keywordsExclSQL =
-      (keywords: List[String]) => {
-        sqls"NOT (${keywordCondition(syn, keywords)})"
-      }
+    def keywordsExclSQL(
+        keywords: List[String],
+        queryVariant: QueryVariant = PlainNot
+    ): SQLSyntax = {
+      exclusionCondition(syn, queryVariant)(keywordCondition(syn, keywords))
+    }
 
     lazy val categoryCodeInclSQL =
       (categoryCodes: CategoryCodesCondition) =>
@@ -370,10 +355,14 @@ object FingerpostWireEntry
             categoryCodeAllConditions(syn, codes)
         }
 
-    lazy val categoryCodeExclSQL =
-      (categoryCodesExcl: List[String]) => {
-        sqls"NOT ${categoryCodeSomeConditions(syn, categoryCodesExcl)}"
-      }
+    def categoryCodeExclSQL(
+        categoryCodesExcl: List[String],
+        queryVariant: QueryVariant = PlainNot
+    ) = {
+      exclusionCondition(syn, queryVariant)(
+        categoryCodeSomeConditions(syn, categoryCodesExcl)
+      )
+    }
 
     lazy val dataFormattingSQL =
       (hasDataFormatting: Boolean) => {
@@ -413,10 +402,14 @@ object FingerpostWireEntry
         preComputedCategoriesConditions(syn, preComputedCategories)
       }
 
-    lazy val preComputedCategoriesExclSQL =
-      (preComputedCategories: List[String]) => {
-        sqls"NOT ${preComputedCategoriesConditions(syn, preComputedCategories)}"
-      }
+    def preComputedCategoriesExclSQL(
+        preComputedCategories: List[String],
+        queryVariant: QueryVariant = PlainNot
+    ) = {
+      exclusionCondition(syn, queryVariant)(
+        preComputedCategoriesConditions(syn, preComputedCategories)
+      )
+    }
 
     lazy val collectionIdSQL = (collectionId: Int) =>
       sqls"${Collection.syn.id} = ${collectionId}"
@@ -438,7 +431,8 @@ object FingerpostWireEntry
     }
 
   private[db] def filtersBuilder(
-      filters: FilterParams
+      filters: FilterParams,
+      queryVariant: QueryVariant = PlainNot
   ): Option[SQLSyntax] = {
     val suppliersQuery: Option[SQLSyntax] = filters.suppliersIncl match {
       case Nil       => None
@@ -447,7 +441,8 @@ object FingerpostWireEntry
 
     val suppliersExclQuery: Option[SQLSyntax] = filters.suppliersExcl match {
       case Nil           => None
-      case suppliersExcl => Some(Filters.supplierExclSQL(suppliersExcl))
+      case suppliersExcl =>
+        Some(Filters.supplierExclSQL(suppliersExcl, queryVariant))
     }
 
     val searchQuery: Option[SQLSyntax] =
@@ -460,7 +455,7 @@ object FingerpostWireEntry
 
     val keywordsExclQuery = filters.keywordExcl match {
       case Nil      => None
-      case keywords => Some(Filters.keywordsExclSQL(keywords))
+      case keywords => Some(Filters.keywordsExclSQL(keywords, queryVariant))
     }
 
     val categoryCodesInclQuery = filters.categoryCodesIncl match {
@@ -472,7 +467,7 @@ object FingerpostWireEntry
     val categoryCodesExclQuery = filters.categoryCodesExcl match {
       case Nil               => None
       case categoryCodesExcl =>
-        Some(Filters.categoryCodeExclSQL(categoryCodesExcl))
+        Some(Filters.categoryCodeExclSQL(categoryCodesExcl, queryVariant))
     }
 
     val hasDataFormattingQuery = filters.hasDataFormatting match {
@@ -491,7 +486,12 @@ object FingerpostWireEntry
       filters.preComputedCategoriesExcl match {
         case Nil                  => None
         case presetCategoriesExcl =>
-          Some(Filters.preComputedCategoriesExclSQL(presetCategoriesExcl))
+          Some(
+            Filters.preComputedCategoriesExclSQL(
+              presetCategoriesExcl,
+              queryVariant
+            )
+          )
       }
 
     val collectionIdQuery = filters.collectionId match {
@@ -506,7 +506,8 @@ object FingerpostWireEntry
 
     val guSourceFeedExclQuery = filters.guSourceFeedsExcl match {
       case Nil             => None
-      case sourceFeedsExcl => Some(Filters.guSourceFeedExclSQL(sourceFeedsExcl))
+      case sourceFeedsExcl =>
+        Some(Filters.guSourceFeedExclSQL(sourceFeedsExcl, queryVariant))
     }
 
     val eventCodeQuery = filters.eventCode match {
@@ -534,9 +535,10 @@ object FingerpostWireEntry
   }
 
   private[db] def presetsBuilder(
-      presets: List[FilterParams]
+      presets: List[FilterParams],
+      queryVariant: QueryVariant = PlainNot
   ): Option[SQLSyntax] = {
-    val andClauses = presets.flatMap(filtersBuilder)
+    val andClauses = presets.flatMap(p => filtersBuilder(p, queryVariant))
     orAll(andClauses)
   }
 
@@ -560,7 +562,8 @@ object FingerpostWireEntry
       queryCursor: QueryCursor,
       queryOrdering: TimeStampColumn,
       searchPresets: List[FilterParams] = Nil,
-      negatedSearchPresets: List[FilterParams] = Nil
+      negatedSearchPresets: List[FilterParams] = Nil,
+      queryVariant: QueryVariant = PlainNot
   ): SQLSyntax = {
 
     val dataOnlyWhereClauses = queryCursorQuery(queryCursor, queryOrdering)
@@ -569,8 +572,8 @@ object FingerpostWireEntry
       searchParams.dateRange.end,
       queryOrdering
     )
-    val customSearchClauses = filtersBuilder(searchParams.filters)
-    val presetSearchClauses = presetsBuilder(searchPresets)
+    val customSearchClauses = filtersBuilder(searchParams.filters, queryVariant)
+    val presetSearchClauses = presetsBuilder(searchPresets, queryVariant)
     val negatedPresetSearchClauses =
       presetsBuilder(negatedSearchPresets).map(clause => sqls"NOT $clause")
 
@@ -650,7 +653,8 @@ object FingerpostWireEntry
 
   def query(
       queryParams: QueryParams,
-      countQueryCap: Long
+      countQueryCap: Long = COUNT_QUERY_CAP,
+      queryVariant: QueryVariant = PlainNot
   ): QueryResponse = DB readOnly { implicit session =>
     val whereClause = buildWhereClause(
       queryParams.searchParams,
@@ -671,14 +675,6 @@ object FingerpostWireEntry
     )
 
     logger.info(s"QUERY: ${query.statement}; PARAMS: ${query.parameters}")
-
-    val fileWriter =
-      new FileWriter(new File(s"/tmp/query-${Instant.now()}.sql"))
-    fileWriter.write(
-      _toExecutableQuery(query.statement, Seq.from(query.parameters))
-    )
-    fileWriter.close()
-
     val rows = query
       .map(rs => {
         val wireEntry = FingerpostWireEntry.fromDb(syn.resultName)(rs)
@@ -725,7 +721,8 @@ object FingerpostWireEntry
     QueryResponse(
       results,
       totalCount,
-      countQueryCap
+      countQueryCap,
+      queryVariant
     )
   }
 

--- a/newswires/app/db/QueryVariant.scala
+++ b/newswires/app/db/QueryVariant.scala
@@ -1,0 +1,34 @@
+package db
+
+import io.circe.{Decoder, Encoder}
+
+sealed abstract class QueryVariant(
+    val name: String,
+    val description: String
+)
+
+object QueryVariant {
+  implicit val encoder: Encoder[QueryVariant] =
+    Encoder.forProduct2("name", "description")(v => (v.name, v.description))
+
+  implicit val decoder: Decoder[QueryVariant] =
+    Decoder[String].emap {
+      case "not_exists" => Right(NotExists)
+      case "plain_not"  => Right(PlainNot)
+      case other        => Left(s"Unknown QueryVariant: $other")
+    }
+}
+
+object NotExists
+    extends QueryVariant(
+      name = "not_exists",
+      description =
+        "Uses a 'NOT EXISTS (...)' clause to exclude results that match the search term"
+    )
+
+object PlainNot
+    extends QueryVariant(
+      name = "plain_not",
+      description =
+        "Uses a plain NOT clause to exclude results that match the search term"
+    )

--- a/newswires/app/models/QueryResponse.scala
+++ b/newswires/app/models/QueryResponse.scala
@@ -6,7 +6,8 @@ import io.circe.{Decoder, Encoder}
 
 case class QueryResponse(
     results: List[FingerpostWireEntry],
-    totalCount: Long = 10
+    totalCount: Long,
+    countQueryCap: Long
     //      keywordCounts: Map[String, Int]
 )
 

--- a/newswires/app/models/QueryResponse.scala
+++ b/newswires/app/models/QueryResponse.scala
@@ -1,13 +1,14 @@
 package models
 
-import db.{FingerpostWireEntry, TimeStampColumn, ToolLink}
+import db.{FingerpostWireEntry, QueryVariant, TimeStampColumn, ToolLink}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
 
 case class QueryResponse(
     results: List[FingerpostWireEntry],
     totalCount: Long,
-    countQueryCap: Long
+    countQueryCap: Long,
+    queryVariant: QueryVariant
     //      keywordCounts: Map[String, Int]
 )
 

--- a/newswires/client/src/Feed.tsx
+++ b/newswires/client/src/Feed.tsx
@@ -157,7 +157,10 @@ export const Feed = ({ containerRef, setSideNavIsOpen }: FeedProps) => {
 						<EuiEmptyPrompt
 							body={
 								<>
-									<SearchSummary setSideNavIsOpen={setSideNavIsOpen} />
+									<SearchSummary
+										queryData={queryData}
+										setSideNavIsOpen={setSideNavIsOpen}
+									/>
 									<p>Try another search or reset filters.</p>
 								</>
 							}
@@ -174,7 +177,10 @@ export const Feed = ({ containerRef, setSideNavIsOpen }: FeedProps) => {
 						<div>
 							<EuiFlexGroup css={[baseStyles, isColumn && columnStyles]}>
 								<EuiFlexItem style={{ flex: 1 }}>
-									<SearchSummary setSideNavIsOpen={setSideNavIsOpen} />
+									<SearchSummary
+										queryData={queryData}
+										setSideNavIsOpen={setSideNavIsOpen}
+									/>
 								</EuiFlexItem>
 								{!isPoppedOut && (
 									<EuiFlexItem grow={false}>

--- a/newswires/client/src/Feed.tsx
+++ b/newswires/client/src/Feed.tsx
@@ -13,7 +13,7 @@ import { sortByTimeStamp } from './context/timestamp-compare.ts';
 import { useUserSettings } from './context/UserSettingsContext.tsx';
 import { DatePicker } from './DatePicker.tsx';
 import { ScrollToTopButton } from './ScrollToTopButton.tsx';
-import { SearchSummary } from './SearchSummary.tsx';
+import { SearchSummary } from './SearchSummary/SearchSummary.tsx';
 import type { SortBy } from './sharedTypes.ts';
 import {
 	isSortByAddedToCollectionAt,
@@ -157,10 +157,7 @@ export const Feed = ({ containerRef, setSideNavIsOpen }: FeedProps) => {
 						<EuiEmptyPrompt
 							body={
 								<>
-									<SearchSummary
-										queryData={queryData}
-										setSideNavIsOpen={setSideNavIsOpen}
-									/>
+									<SearchSummary setSideNavIsOpen={setSideNavIsOpen} />
 									<p>Try another search or reset filters.</p>
 								</>
 							}
@@ -177,10 +174,7 @@ export const Feed = ({ containerRef, setSideNavIsOpen }: FeedProps) => {
 						<div>
 							<EuiFlexGroup css={[baseStyles, isColumn && columnStyles]}>
 								<EuiFlexItem style={{ flex: 1 }}>
-									<SearchSummary
-										queryData={queryData}
-										setSideNavIsOpen={setSideNavIsOpen}
-									/>
+									<SearchSummary setSideNavIsOpen={setSideNavIsOpen} />
 								</EuiFlexItem>
 								{!isPoppedOut && (
 									<EuiFlexItem grow={false}>

--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -16,7 +16,7 @@ import type {
 	DeselectableQueryKeyValue,
 } from './queryHelpers.ts';
 import { queryAfterDeselection } from './queryHelpers.ts';
-import type { Query } from './sharedTypes.ts';
+import type { Query, WiresQueryData } from './sharedTypes.ts';
 import { Tooltip } from './Tooltip.tsx';
 
 const SearchTermBadgeLabelLookup: Record<DeselectableQueryKey, string> = {
@@ -258,13 +258,27 @@ const Summary = ({
 	);
 };
 
+function decideSearchSummaryLabel(
+	queryData: WiresQueryData | undefined,
+): string {
+	if (queryData === undefined || queryData.totalCount === 0) {
+		return 'No results found';
+	}
+	if (queryData.totalCount > queryData.countQueryCap) {
+		return `Showing ${queryData.countQueryCap}+ results`;
+	}
+	return `Showing ${Intl.NumberFormat('en-GB').format(queryData.totalCount)} result${queryData.totalCount > 1 ? 's' : ''}`;
+}
+
 export const SearchSummary = ({
 	setSideNavIsOpen,
+	queryData,
 }: {
 	setSideNavIsOpen: (isOpen: boolean) => void;
+	queryData: WiresQueryData | undefined;
 }) => {
 	const {
-		state: { queryData, status, lastUpdate },
+		state: { status, lastUpdate },
 		config,
 		openTicker,
 	} = useSearch();
@@ -272,10 +286,7 @@ export const SearchSummary = ({
 
 	const isSmallScreen = useIsWithinBreakpoints(['xs', 's', 'm']);
 
-	const searchSummary =
-		queryData && queryData.totalCount > 0
-			? `Showing ${Intl.NumberFormat('en-GB').format(queryData.totalCount)} result${queryData.totalCount > 1 ? 's' : ''}`
-			: 'No results found';
+	const searchSummaryLabel = decideSearchSummaryLabel(queryData);
 
 	return (
 		<div
@@ -341,7 +352,7 @@ export const SearchSummary = ({
 				)}
 			<Summary
 				query={config.query}
-				searchSummaryLabel={!isPoppedOut && searchSummary}
+				searchSummaryLabel={!isPoppedOut && searchSummaryLabel}
 			/>
 
 			{isPoppedOut && (

--- a/newswires/client/src/SearchSummary/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary/SearchSummary.tsx
@@ -7,17 +7,18 @@ import {
 	usePrettyDuration,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
-import { useSearch } from './context/SearchContext.tsx';
-import { DEFAULT_DATE_RANGE } from './dateConstants.ts';
-import { isRestricted } from './dateHelpers.ts';
-import { presetLabel, TASTED_COLLECTION } from './presets.ts';
+import { useSearch } from '../context/SearchContext.tsx';
+import { DEFAULT_DATE_RANGE } from '../dateConstants.ts';
+import { isRestricted } from '../dateHelpers.ts';
+import { presetLabel, TASTED_COLLECTION } from '../presets.ts';
 import type {
 	DeselectableQueryKey,
 	DeselectableQueryKeyValue,
-} from './queryHelpers.ts';
-import { queryAfterDeselection } from './queryHelpers.ts';
-import type { Query, WiresQueryData } from './sharedTypes.ts';
-import { Tooltip } from './Tooltip.tsx';
+} from '../queryHelpers.ts';
+import { queryAfterDeselection } from '../queryHelpers.ts';
+import type { Query } from '../sharedTypes.ts';
+import { Tooltip } from '../Tooltip.tsx';
+import { decideSearchSummaryLabel } from './decideSearchSummaryLabel.tsx';
 
 const SearchTermBadgeLabelLookup: Record<DeselectableQueryKey, string> = {
 	q: 'Search term',
@@ -258,27 +259,13 @@ const Summary = ({
 	);
 };
 
-function decideSearchSummaryLabel(
-	queryData: WiresQueryData | undefined,
-): string {
-	if (queryData === undefined || queryData.totalCount === 0) {
-		return 'No results found';
-	}
-	if (queryData.totalCount > queryData.countQueryCap) {
-		return `Showing ${queryData.countQueryCap}+ results`;
-	}
-	return `Showing ${Intl.NumberFormat('en-GB').format(queryData.totalCount)} result${queryData.totalCount > 1 ? 's' : ''}`;
-}
-
 export const SearchSummary = ({
 	setSideNavIsOpen,
-	queryData,
 }: {
 	setSideNavIsOpen: (isOpen: boolean) => void;
-	queryData: WiresQueryData | undefined;
 }) => {
 	const {
-		state: { status, lastUpdate },
+		state: { status, lastUpdate, queryData },
 		config,
 		openTicker,
 	} = useSearch();

--- a/newswires/client/src/SearchSummary/decideSearchSummaryLabel.test.tsx
+++ b/newswires/client/src/SearchSummary/decideSearchSummaryLabel.test.tsx
@@ -1,0 +1,43 @@
+import { decideSearchSummaryLabel } from './decideSearchSummaryLabel';
+
+describe('decideSearchSummaryLabel', () => {
+	it('should return "No results found" when queryData is undefined', () => {
+		expect(decideSearchSummaryLabel(undefined)).toContain('No results');
+	});
+	it('should return "1 result" when totalCount is 1', () => {
+		expect(
+			decideSearchSummaryLabel({
+				totalCount: 1,
+				countQueryCap: 100,
+				results: [],
+			}),
+		).toContain('1 result');
+	});
+	it('should return "0 results" when totalCount is 0', () => {
+		expect(
+			decideSearchSummaryLabel({
+				totalCount: 0,
+				countQueryCap: 100,
+				results: [],
+			}),
+		).toContain('No results');
+	});
+	it('should return "100+ results" when totalCount is greater than 100', () => {
+		expect(
+			decideSearchSummaryLabel({
+				totalCount: 150,
+				countQueryCap: 100,
+				results: [],
+			}),
+		).toContain('100+ results');
+	});
+	it('should return "50 results" when totalCount is 50', () => {
+		expect(
+			decideSearchSummaryLabel({
+				totalCount: 50,
+				countQueryCap: 100,
+				results: [],
+			}),
+		).toContain('50 results');
+	});
+});

--- a/newswires/client/src/SearchSummary/decideSearchSummaryLabel.tsx
+++ b/newswires/client/src/SearchSummary/decideSearchSummaryLabel.tsx
@@ -1,0 +1,19 @@
+import type { WiresQueryData } from '../sharedTypes';
+
+export function decideSearchSummaryLabel(
+	queryData: WiresQueryData | undefined,
+): string {
+	if (queryData === undefined || queryData.totalCount === 0) {
+		return 'No results found';
+	}
+	/**
+	 * The actual LIMIT in the SQL is `countQueryCap + 1`.
+	 * Say that the cap is 500. Having the actual limit be 501 means that we can
+	 * differentiate in the UI between there being exactly 500 and there being
+	 * '500+'.
+	 * */
+	if (queryData.totalCount > queryData.countQueryCap) {
+		return `Showing ${queryData.countQueryCap}+ results`;
+	}
+	return `Showing ${Intl.NumberFormat('en-GB').format(queryData.totalCount)} result${queryData.totalCount > 1 ? 's' : ''}`;
+}

--- a/newswires/client/src/WireItemList.stories.tsx
+++ b/newswires/client/src/WireItemList.stories.tsx
@@ -69,6 +69,7 @@ const mockSearchContext: SearchContextShape = {
 		queryData: {
 			results: [],
 			totalCount: 0,
+			countQueryCap: 100,
 		},
 		successfulQueryHistory: [],
 		autoUpdate: false,

--- a/newswires/client/src/context/SearchContext.test.tsx
+++ b/newswires/client/src/context/SearchContext.test.tsx
@@ -1,5 +1,5 @@
 import { act, render } from '@testing-library/react';
-import type { Query } from '../sharedTypes.ts';
+import type { Query, WiresQueryResponse } from '../sharedTypes.ts';
 import { disableLogs, flushPendingPromises } from '../tests/testHelpers.ts';
 import type { SearchContextShape } from './SearchContext.tsx';
 import { SearchContextProvider, useSearch } from './SearchContext.tsx';
@@ -7,13 +7,15 @@ import { TelemetryContextProvider } from './TelemetryContext.tsx';
 
 jest.useFakeTimers();
 
+const mockResponseData: WiresQueryResponse = {
+	results: [],
+	totalCount: 0,
+	countQueryCap: 100,
+};
+
 global.fetch = jest.fn(() =>
 	Promise.resolve({
-		json: () =>
-			Promise.resolve({
-				results: [],
-				totalCount: 0,
-			}),
+		json: () => Promise.resolve(mockResponseData),
 		ok: () => true,
 	}),
 ) as jest.Mock;
@@ -66,6 +68,7 @@ describe('SearchContext', () => {
 		expect(contextRef.current.state.queryData).toEqual({
 			results: [],
 			totalCount: 0,
+			countQueryCap: 100,
 		});
 		expect(contextRef.current.state.successfulQueryHistory).toEqual([]);
 	});

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -273,29 +273,19 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 		const abortController = new AbortController();
 
 		if (state.status === 'loading') {
-			const start = performance.now();
+			const startedAt = performance.now();
 			refreshesSinceLastTelemetrySend.current = 0;
 			fetchResults({ query: currentConfig.query, view: currentConfig.view })
 				.then((data) => {
-					sendTelemetryEvent('NEWSWIRES_FETCHED_RESULTS', {
-						...Object.fromEntries(
-							Object.entries(currentConfig.query).map(([key, value]) => [
-								`search-query_${key}`,
-								JSON.stringify(value),
-							]),
-						),
-						duration: performance.now() - start,
-						resultsCount: data.results.length,
-						resultsIds: data.results.map((wire) => wire.id).join(','),
-						totalCount: data.totalCount,
-						isRefresh: false,
-						...Object.fromEntries(
-							Object.entries(currentConfig.query).map(([key, value]) => [
-								`query-variant_${key}`,
-								JSON.stringify(value),
-							]),
-						),
-					});
+					sendTelemetryEvent(
+						'NEWSWIRES_FETCHED_RESULTS',
+						createFetchedResultsTelemetryData({
+							query: currentConfig.query,
+							data,
+							startedAt,
+							isRefresh: true,
+						}),
+					);
 					setHasBeenVisibleItemIds([]);
 					dispatch({ type: 'FETCH_SUCCESS', data, query: currentConfig.query });
 				})
@@ -309,7 +299,7 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 						state.queryData.results,
 						state.sortBy,
 					);
-					const start = performance.now();
+					const startedAt = performance.now();
 					fetchResults({
 						query: currentConfig.query,
 						afterTimeStamp,
@@ -324,19 +314,15 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 								60_000 / REFRESH_INTERVAL_MS
 							) {
 								refreshesSinceLastTelemetrySend.current = 0;
-								sendTelemetryEvent('NEWSWIRES_FETCHED_RESULTS', {
-									...Object.fromEntries(
-										Object.entries(currentConfig.query).map(([key, value]) => [
-											`search-query_${key}`,
-											JSON.stringify(value),
-										]),
-									),
-									duration: performance.now() - start,
-									resultsCount: data.results.length,
-									resultsIds: data.results.map((wire) => wire.id).join(','),
-									totalCount: data.totalCount,
-									isRefresh: true,
-								});
+								sendTelemetryEvent(
+									'NEWSWIRES_FETCHED_RESULTS',
+									createFetchedResultsTelemetryData({
+										query: currentConfig.query,
+										data,
+										startedAt,
+										isRefresh: true,
+									}),
+								);
 							}
 							if (!abortController.signal.aborted) {
 								dispatch({
@@ -605,3 +591,35 @@ export const useSearch = () => {
 	}
 	return searchContext;
 };
+
+function createFetchedResultsTelemetryData({
+	query,
+	data,
+	startedAt,
+	isRefresh,
+}: {
+	query: Query;
+	data: WiresQueryData;
+	startedAt: number;
+	isRefresh: boolean;
+}) {
+	return {
+		...Object.fromEntries(
+			Object.entries(query).map(([key, value]) => [
+				`search-query_${key}`,
+				JSON.stringify(value),
+			]),
+		),
+		duration: performance.now() - startedAt,
+		resultsCount: data.results.length,
+		resultsIds: data.results.map((wire) => wire.id).join(','),
+		totalCount: data.totalCount,
+		isRefresh,
+		...Object.fromEntries(
+			Object.entries(data.queryVariant ?? {}).map(([key, value]) => [
+				`query-variant_${key}`,
+				JSON.stringify(value),
+			]),
+		),
+	};
+}

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -289,6 +289,12 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 						resultsIds: data.results.map((wire) => wire.id).join(','),
 						totalCount: data.totalCount,
 						isRefresh: false,
+						...Object.fromEntries(
+							Object.entries(currentConfig.query).map(([key, value]) => [
+								`query-variant_${key}`,
+								JSON.stringify(value),
+							]),
+						),
 					});
 					setHasBeenVisibleItemIds([]);
 					dispatch({ type: 'FETCH_SUCCESS', data, query: currentConfig.query });

--- a/newswires/client/src/context/SearchReducer.test.ts
+++ b/newswires/client/src/context/SearchReducer.test.ts
@@ -25,6 +25,7 @@ describe('SearchReducer', () => {
 		queryData: {
 			results: [{ ...sampleWireData }],
 			totalCount: 1,
+			countQueryCap: 100,
 		},
 	};
 
@@ -33,6 +34,7 @@ describe('SearchReducer', () => {
 		queryData: {
 			results: [{ ...sampleWireData }],
 			totalCount: 1,
+			countQueryCap: 100,
 		},
 		successfulQueryHistory: [],
 		error: 'Network error',
@@ -46,6 +48,7 @@ describe('SearchReducer', () => {
 		queryData: {
 			results: [{ ...sampleWireData }],
 			totalCount: 1,
+			countQueryCap: 100,
 		},
 		successfulQueryHistory: [],
 		error: 'Fetch error',
@@ -57,7 +60,7 @@ describe('SearchReducer', () => {
 	it('should handle FETCH_SUCCESS action in loading state', () => {
 		const action: Action = {
 			type: 'FETCH_SUCCESS',
-			data: { results: [sampleWireData], totalCount: 1 },
+			data: { results: [sampleWireData], totalCount: 1, countQueryCap: 100 },
 			query: { q: 'test', collectionId: undefined, preset: undefined },
 		};
 
@@ -66,6 +69,7 @@ describe('SearchReducer', () => {
 		expect(newState.status).toBe('success');
 		expect(newState.queryData?.results).toHaveLength(1);
 		expect(newState.queryData?.totalCount).toBe(1);
+		expect(newState.queryData?.countQueryCap).toBe(100);
 		expect(newState.queryData?.results).toContainEqual({
 			...sampleWireData,
 			id: 1,
@@ -115,6 +119,7 @@ describe('SearchReducer', () => {
 						},
 					],
 					totalCount: 1,
+					countQueryCap: 100,
 				},
 				query: { q: 'test', collectionId: undefined, preset: undefined },
 			};
@@ -124,6 +129,7 @@ describe('SearchReducer', () => {
 			expect(newState.status).toBe('success');
 			expect(newState.queryData?.results).toHaveLength(2);
 			expect(newState.queryData?.totalCount).toBe(2);
+			expect(newState.queryData?.countQueryCap).toBe(100);
 			expect(newState.queryData?.results).toContainEqual({
 				...sampleWireData,
 				id: 2,
@@ -147,6 +153,7 @@ describe('SearchReducer', () => {
 							{ ...sampleWireData, id: 2, ingestedAt: '2025-01-01T02:04:00Z' },
 						],
 						totalCount: 2,
+						countQueryCap: 100,
 					},
 				};
 
@@ -166,6 +173,7 @@ describe('SearchReducer', () => {
 							},
 						],
 						totalCount: 2,
+						countQueryCap: 100,
 					},
 					query: {
 						q: 'test',
@@ -222,6 +230,7 @@ describe('SearchReducer', () => {
 							},
 						],
 						totalCount: 2,
+						countQueryCap: 100,
 					},
 				};
 
@@ -253,6 +262,7 @@ describe('SearchReducer', () => {
 							},
 						],
 						totalCount: 2,
+						countQueryCap: 100,
 					},
 					query: {
 						q: 'test',
@@ -289,6 +299,7 @@ describe('SearchReducer', () => {
 				queryData: {
 					results: [itemOne],
 					totalCount: 1,
+					countQueryCap: 100,
 				},
 			};
 
@@ -297,6 +308,7 @@ describe('SearchReducer', () => {
 				data: {
 					results: [itemOne, itemTwo],
 					totalCount: 2,
+					countQueryCap: 100,
 				},
 				query: {
 					q: 'test',
@@ -318,6 +330,7 @@ describe('SearchReducer', () => {
 			expect(newState.queryData?.results).toContainEqual(itemOne);
 
 			expect(newState.queryData?.results).not.toContainEqual(itemTwo);
+			expect(newState.queryData?.countQueryCap).toBe(100);
 		});
 	});
 
@@ -327,12 +340,17 @@ describe('SearchReducer', () => {
 			queryData: {
 				results: [{ ...sampleWireData, id: 2 }],
 				totalCount: 2,
+				countQueryCap: 100,
 			},
 		};
 
 		const action: Action = {
 			type: 'APPEND_RESULTS',
-			data: { results: [{ ...sampleWireData, id: 1 }], totalCount: 1 },
+			data: {
+				results: [{ ...sampleWireData, id: 1 }],
+				totalCount: 1,
+				countQueryCap: 100,
+			},
 		};
 
 		const newState = SearchReducer(state, action);
@@ -356,6 +374,7 @@ describe('SearchReducer', () => {
 			queryData: {
 				results: [{ ...sampleWireData, id: 2 }],
 				totalCount: 2,
+				countQueryCap: 100,
 			},
 		};
 
@@ -367,6 +386,7 @@ describe('SearchReducer', () => {
 					{ ...sampleWireData, id: 2 },
 				],
 				totalCount: 2,
+				countQueryCap: 100,
 			},
 		};
 
@@ -383,6 +403,7 @@ describe('SearchReducer', () => {
 			...sampleWireData,
 			id: 2,
 		});
+		expect(newState.queryData?.countQueryCap).toBe(100);
 	});
 
 	[

--- a/newswires/client/src/context/SearchReducer.test.ts
+++ b/newswires/client/src/context/SearchReducer.test.ts
@@ -10,6 +10,12 @@ register('Etc/GMT');
 const FIXED_TIMESTAMP = new Date('2025-01-01T02:04:00Z').getTime();
 jest.spyOn(Date, 'now').mockImplementation(() => FIXED_TIMESTAMP);
 
+const sampleQueryData = {
+	results: [{ ...sampleWireData }],
+	totalCount: 1,
+	countQueryCap: 100,
+};
+
 describe('SearchReducer', () => {
 	const initialState: State = {
 		status: 'loading',
@@ -22,20 +28,12 @@ describe('SearchReducer', () => {
 	const successState: State = {
 		...initialState,
 		status: 'success',
-		queryData: {
-			results: [{ ...sampleWireData }],
-			totalCount: 1,
-			countQueryCap: 100,
-		},
+		queryData: sampleQueryData,
 	};
 
 	const offlineState: State = {
 		status: 'offline',
-		queryData: {
-			results: [{ ...sampleWireData }],
-			totalCount: 1,
-			countQueryCap: 100,
-		},
+		queryData: sampleQueryData,
 		successfulQueryHistory: [],
 		error: 'Network error',
 		autoUpdate: true,
@@ -45,11 +43,7 @@ describe('SearchReducer', () => {
 
 	const errorState: State = {
 		status: 'error',
-		queryData: {
-			results: [{ ...sampleWireData }],
-			totalCount: 1,
-			countQueryCap: 100,
-		},
+		queryData: sampleQueryData,
 		successfulQueryHistory: [],
 		error: 'Fetch error',
 		autoUpdate: true,
@@ -60,7 +54,7 @@ describe('SearchReducer', () => {
 	it('should handle FETCH_SUCCESS action in loading state', () => {
 		const action: Action = {
 			type: 'FETCH_SUCCESS',
-			data: { results: [sampleWireData], totalCount: 1, countQueryCap: 100 },
+			data: sampleQueryData,
 			query: { q: 'test', collectionId: undefined, preset: undefined },
 		};
 
@@ -112,14 +106,13 @@ describe('SearchReducer', () => {
 			const action: Action = {
 				type: 'UPDATE_RESULTS',
 				data: {
+					...sampleQueryData,
 					results: [
 						{
 							...sampleWireData,
 							id: 2,
 						},
 					],
-					totalCount: 1,
-					countQueryCap: 100,
 				},
 				query: { q: 'test', collectionId: undefined, preset: undefined },
 			};

--- a/newswires/client/src/context/fetchResults.test.ts
+++ b/newswires/client/src/context/fetchResults.test.ts
@@ -1,4 +1,5 @@
 import { pandaFetch } from '../panda-session';
+import type { WiresQueryResponse } from '../sharedTypes.ts';
 import { EuiDateStringSchema } from '../sharedTypes.ts';
 import { sampleWireResponse } from '../tests/fixtures/wireData.ts';
 import { paramsToQuerystring } from '../urlState.ts';
@@ -10,12 +11,16 @@ jest
 	.spyOn(Date, 'now')
 	.mockReturnValue(new Date('2024-02-24T16:15:00.000Z').getTime());
 
+const mockResponseData: WiresQueryResponse = {
+	results: [sampleWireResponse],
+	totalCount: 0,
+	countQueryCap: 100,
+};
+
 jest.mock('../panda-session', () => ({
 	pandaFetch: jest.fn(() =>
 		Promise.resolve({
-			json: jest
-				.fn()
-				.mockResolvedValue({ results: [sampleWireResponse], totalCount: 0 }),
+			json: jest.fn().mockResolvedValue(mockResponseData),
 			ok: true,
 		}),
 	),
@@ -74,21 +79,14 @@ describe('fetchResults', () => {
 	});
 
 	it('should return parsed data if response is valid', async () => {
-		const mockResponseData = {
-			results: [],
-			totalCount: 0,
-		};
-
-		(pandaFetch as jest.Mock).mockResolvedValueOnce({
-			json: jest.fn().mockResolvedValue(mockResponseData),
-			ok: true,
-		});
-
 		const result = await fetchResults({
 			query: { q: 'value', collectionId: undefined, preset: undefined },
 			view: 'feed',
 		});
-		expect(result).toEqual(mockResponseData);
+		expect(result).toEqual({
+			...mockResponseData,
+			results: [...mockResponseData.results.map(transformWireItemQueryResult)],
+		});
 	});
 
 	it('should append afterTimeStamp to the query if provided', async () => {

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -94,6 +94,7 @@ export type WireDataFromAPI = z.infer<typeof WireDataFromAPISchema>;
 export const WiresQueryResponseSchema = z.object({
 	results: z.array(WireDataFromAPISchema),
 	totalCount: z.number(),
+	countQueryCap: z.number(),
 	// keywordCounts: z.record(z.string(), z.number()),
 });
 
@@ -141,6 +142,7 @@ export type WireData = Omit<WireDataFromAPI, 'supplier'> & {
 export type WiresQueryData = {
 	results: WireData[];
 	totalCount: number;
+	countQueryCap: number;
 };
 
 export const isValidDateValue = (value: string): value is EuiDateString =>

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -95,6 +95,12 @@ export const WiresQueryResponseSchema = z.object({
 	results: z.array(WireDataFromAPISchema),
 	totalCount: z.number(),
 	countQueryCap: z.number(),
+	queryVariant: z
+		.object({
+			name: z.string(),
+			description: z.string(),
+		})
+		.optional(),
 	// keywordCounts: z.record(z.string(), z.number()),
 });
 
@@ -143,6 +149,10 @@ export type WiresQueryData = {
 	results: WireData[];
 	totalCount: number;
 	countQueryCap: number;
+	queryVariant?: {
+		name: string;
+		description: string;
+	};
 };
 
 export const isValidDateValue = (value: string): value is EuiDateString =>

--- a/newswires/conf/routes
+++ b/newswires/conf/routes
@@ -4,36 +4,36 @@
 # ~~~~
 
 # An example controller showing a sample home page
-GET     /                           controllers.ViteController.index()
-GET     /feed                       controllers.ViteController.index()
-GET     /item/*id                   controllers.ViteController.item(id: String)
-GET     /ticker/feed                controllers.ViteController.index()
-GET     /ticker/item/*id            controllers.ViteController.item(id: String)
-GET     /api/search                 controllers.QueryController.query(q: Option[String], keyword: List[String], supplier: List[String], categoryCode: List[String], categoryCodeExcl: List[String], collectionId: Option[Int], start: Option[String], end: Option[String], beforeTimeStamp: Option[String], afterTimeStamp : Option[String], hasDataFormatting: Option[Boolean], guSourceFeed: List[String], guSourceFeedExcl: List[String], eventCode: Option[String])
-GET     /api/keywords               controllers.QueryController.keywords(inLastHours: Option[Int], limit:Option[Int])
-GET     /api/item/:id               controllers.QueryController.item(id: Int, q: Option[String])
+GET         /                                                         controllers.ViteController.index()
+GET         /feed                                                     controllers.ViteController.index()
+GET         /item/*id                                                 controllers.ViteController.item(id: String)
+GET         /ticker/feed                                              controllers.ViteController.index()
+GET         /ticker/item/*id                                          controllers.ViteController.item(id: String)
+GET         /api/search                                               controllers.QueryController.query(q: Option[String], keyword: List[String], supplier: List[String], categoryCode: List[String], categoryCodeExcl: List[String], collectionId: Option[Int], start: Option[String], end: Option[String], beforeTimeStamp: Option[String], afterTimeStamp : Option[String], hasDataFormatting: Option[Boolean], guSourceFeed: List[String], guSourceFeedExcl: List[String], eventCode: Option[String], countQueryCap: Option[Long])
+GET         /api/keywords                                             controllers.QueryController.keywords(inLastHours: Option[Int], limit:Option[Int])
+GET         /api/item/:id                                             controllers.QueryController.item(id: Int, q: Option[String])
 
 +nocsrf # justification: body only used to query, makes no change to database
-POST    /api/toollinks              controllers.QueryController.toolLinksForWires
-GET     /api/toollinks/:wireId      controllers.QueryController.toolLinksForWire(wireId: Long)
-GET     /api/collections            controllers.CollectionsController.collections()
-PUT     /api/collections            controllers.CollectionsController.createCollection(name: String)
+POST        /api/toollinks                                            controllers.QueryController.toolLinksForWires
+GET         /api/toollinks/:wireId                                    controllers.QueryController.toolLinksForWire(wireId: Long)
+GET         /api/collections                                          controllers.CollectionsController.collections()
+PUT         /api/collections                                          controllers.CollectionsController.createCollection(name: String)
 +nocsrf # justification: we are only processing very minimal information here -- a collection id and an item id. Given that this endpoint will be called from the SPA, we expect it to cause user-facing issues in the same way we found for the tool links endpoints.
-PUT     /api/collections/:collectionId/add-item/:itemId  controllers.CollectionsController.addToCollection(collectionId: Long, itemId: Int)
+PUT         /api/collections/:collectionId/add-item/:itemId           controllers.CollectionsController.addToCollection(collectionId: Long, itemId: Int)
 +nocsrf # justification: we are only processing very minimal information here -- a collection id and an item id. Given that this endpoint will be called from the SPA, we expect it to cause user-facing issues in the same way we found for the tool links endpoints.
-PUT     /api/collections/:collectionId/remove-item/:itemId  controllers.CollectionsController.removeFromCollection(collectionId: Long, itemId: Int)
+PUT         /api/collections/:collectionId/remove-item/:itemId        controllers.CollectionsController.removeFromCollection(collectionId: Long, itemId: Int)
 
 +nocsrf # justification: we are only processing very minimal information here -- composer ID and who the article was sent by. And CSRF protections have caused multiple issues for users. But if we ever start processing more information, or loosen CORS configuration, then we should look at adding CSRF protections back.
-PUT     /api/item/:id/composerId    controllers.QueryController.linkToComposer(id: Int)
+PUT         /api/item/:id/composerId                                  controllers.QueryController.linkToComposer(id: Int)
 +nocsrf # justification
-POST     /api/item/:id/incopy       controllers.QueryController.getIncopyImportUrl(id: Int)
+POST        /api/item/:id/incopy                                      controllers.QueryController.getIncopyImportUrl(id: Int)
 
-GET     /oauthCallback              controllers.AuthController.oauthCallback()
+GET         /oauthCallback                                            controllers.AuthController.oauthCallback()
 
-GET     /api/client-refresh-message controllers.ManagementController.clientRefreshMessage()
-GET     /healthcheck                controllers.ManagementController.healthcheck()
-GET     /_prout                     controllers.ManagementController.gitHash()
+GET         /api/client-refresh-message                               controllers.ManagementController.clientRefreshMessage()
+GET         /healthcheck                                              controllers.ManagementController.healthcheck()
+GET         /_prout                                                   controllers.ManagementController.gitHash()
 
 
 # Map static resources from the /public folder to the /assets URL path
-GET     /assets/*file               controllers.ViteController.asset(file)
+GET         /assets/*file                                             controllers.ViteController.asset(file)

--- a/newswires/test/db/FingerpostWireEntrySpec.scala
+++ b/newswires/test/db/FingerpostWireEntrySpec.scala
@@ -635,9 +635,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
 
   it should "create the correct sql snippet for suppliersExcl" in {
     val supplierExclClause =
-      """NOT EXISTS ( SELECT FROM fingerpost_wire_entry suppliersExcl
-                |WHERE fm.id = suppliersExcl.id
-                |AND upper(suppliersExcl.supplier) in (upper(?)) )""".stripMargin
+      "NOT ( upper(fm.supplier) in (upper(?)))"
     val suppliersExclSQL =
       FingerpostWireEntry.Filters.supplierExclSQL(List("supplier"))
     suppliersExclSQL should matchSqlSnippet(
@@ -671,9 +669,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
 
   it should "create the correct sql snippet for categoryCodesExcl" in {
     val categoryExclClause =
-      """NOT EXISTS ( SELECT FROM fingerpost_wire_entry categoryCodesExcl
-                |WHERE fm.id = categoryCodesExcl.id
-                |AND categoryCodesExcl.category_codes && ? )""".stripMargin
+      "NOT fm.category_codes && ?"
 
     val categoryCodesExcl =
       FingerpostWireEntry.Filters.categoryCodeExclSQL(List("code"))
@@ -695,9 +691,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
   }
   it should "create the correct sql snippet for precomputedCategoriesExcl" in {
     val precomputedCategoriesExclClause =
-      """NOT EXISTS ( SELECT FROM fingerpost_wire_entry preComputedCategoriesExcl
-        |WHERE fm.id = preComputedCategoriesExcl.id
-        |AND preComputedCategoriesExcl.precomputed_categories && ? )""".stripMargin
+      "NOT fm.precomputed_categories && ?"
 
     val precomputedCategoriesExcl =
       FingerpostWireEntry.Filters.preComputedCategoriesExclSQL(List("category"))
@@ -800,9 +794,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
 
   it should "create the correct sql snippet for keywordExcl" in {
     val keywordExclClause =
-      """NOT EXISTS ( SELECT FROM fingerpost_wire_entry keywordsExcl
-              |WHERE fm.id = keywordsExcl.id
-              |AND (keywordsExcl.content -> 'keywords') ??| ? )""".stripMargin
+      "NOT ((fm.content -> 'keywords') ??| ?)"
     val keywordExclSQL =
       FingerpostWireEntry.Filters.keywordsExclSQL(List("keyword"))
     keywordExclSQL should matchSqlSnippet(

--- a/newswires/test/db/FingerpostWireEntrySpec.scala
+++ b/newswires/test/db/FingerpostWireEntrySpec.scala
@@ -1,34 +1,17 @@
 package db
 
-import conf.{
-  ALL,
-  AND,
-  CategoryCodesCondition,
-  ComboTerm,
-  OR,
-  SOME,
-  SearchField,
-  SearchTerm,
-  SingleTerm
-}
-import io.circe.parser.decode
-import helpers.SqlSnippetMatcher.matchSqlSnippet
-import helpers.models
-import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.matchers.should.Matchers
-import io.circe.syntax.EncoderOps
-import _root_.models.{
-  DateRange,
-  FilterParams,
-  MostRecent,
-  NextPage,
-  QueryParams,
-  SearchParams
-}
+import _root_.models._
 import conf.SearchField.{BodyText, Slug}
 import conf.SearchTerm.{CombinedFields, SingleField}
-import db.FingerpostWireEntry.{Filters, decideSortDirection}
-import scalikejdbc.{scalikejdbcSQLInterpolationImplicitDef, sqls}
+import conf._
+import db.FingerpostWireEntry.Filters
+import helpers.SqlSnippetMatcher.matchSqlSnippet
+import helpers.models
+import io.circe.parser.decode
+import io.circe.syntax.EncoderOps
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import scalikejdbc.scalikejdbcSQLInterpolationImplicitDef
 
 class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
 
@@ -797,6 +780,51 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
       "NOT ((fm.content -> 'keywords') ??| ?)"
     val keywordExclSQL =
       FingerpostWireEntry.Filters.keywordsExclSQL(List("keyword"))
+    keywordExclSQL should matchSqlSnippet(
+      expectedClause = keywordExclClause,
+      expectedParams = List(List("keyword"))
+    )
+  }
+
+  behavior of "exclusion clauses when NotExists variant is specified"
+  it should "create the correct sql snippet for suppliersExcl when NotExists variant is specified" in {
+    val supplierExclClause =
+      "NOT EXISTS ( SELECT FROM fingerpost_wire_entry fm WHERE fm.id = fm.id AND upper(fm.supplier) in (upper(?)) )"
+    val suppliersExclSQL =
+      FingerpostWireEntry.Filters.supplierExclSQL(List("supplier"), NotExists)
+    suppliersExclSQL should matchSqlSnippet(
+      expectedClause = supplierExclClause,
+      expectedParams = List("supplier")
+    )
+  }
+  it should "create the correct sql snippet for categoryCodesExcl when NotExists variant is specified" in {
+    val categoryExclClause =
+      "NOT EXISTS ( SELECT FROM fingerpost_wire_entry fm WHERE fm.id = fm.id AND fm.category_codes && ? )"
+    val categoryCodesExcl =
+      FingerpostWireEntry.Filters.categoryCodeExclSQL(List("code"), NotExists)
+    categoryCodesExcl should matchSqlSnippet(
+      expectedClause = categoryExclClause,
+      expectedParams = List(List("code"))
+    )
+  }
+  it should "create the correct sql snippet for precomputedCategoriesExcl when NotExists variant is specified" in {
+    val precomputedCategoriesExclClause =
+      "NOT EXISTS ( SELECT FROM fingerpost_wire_entry fm WHERE fm.id = fm.id AND fm.precomputed_categories && ? )"
+    val precomputedCategoriesExcl =
+      FingerpostWireEntry.Filters.preComputedCategoriesExclSQL(
+        List("category"),
+        NotExists
+      )
+    precomputedCategoriesExcl should matchSqlSnippet(
+      expectedClause = precomputedCategoriesExclClause,
+      expectedParams = List(List("category"))
+    )
+  }
+  it should "create the correct sql snippet for keywordsExcl when NotExists variant is specified" in {
+    val keywordExclClause =
+      "NOT EXISTS ( SELECT FROM fingerpost_wire_entry fm WHERE fm.id = fm.id AND (fm.content -> 'keywords') ??| ? )"
+    val keywordExclSQL =
+      FingerpostWireEntry.Filters.keywordsExclSQL(List("keyword"), NotExists)
     keywordExclSQL should matchSqlSnippet(
       expectedClause = keywordExclClause,
       expectedParams = List(List("keyword"))

--- a/newswires/test/db/FingerpostWireEntrySpec.scala
+++ b/newswires/test/db/FingerpostWireEntrySpec.scala
@@ -669,7 +669,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
 
   it should "create the correct sql snippet for categoryCodesExcl" in {
     val categoryExclClause =
-      "NOT fm.category_codes && ?"
+      "NOT (fm.category_codes && ?)"
 
     val categoryCodesExcl =
       FingerpostWireEntry.Filters.categoryCodeExclSQL(List("code"))
@@ -691,7 +691,7 @@ class FingerpostWireEntrySpec extends AnyFlatSpec with Matchers with models {
   }
   it should "create the correct sql snippet for precomputedCategoriesExcl" in {
     val precomputedCategoriesExclClause =
-      "NOT fm.precomputed_categories && ?"
+      "NOT (fm.precomputed_categories && ?)"
 
     val precomputedCategoriesExcl =
       FingerpostWireEntry.Filters.preComputedCategoriesExclSQL(List("category"))

--- a/newswires/test/models/QueryResponseSpec.scala
+++ b/newswires/test/models/QueryResponseSpec.scala
@@ -1,6 +1,6 @@
 package models
 
-import db.{AddedToCollectionAtTime, IngestedAtTime}
+import db.{AddedToCollectionAtTime, FingerpostWireEntry, IngestedAtTime}
 import helpers.models
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -8,6 +8,16 @@ import org.scalatest.matchers.should.Matchers
 import java.time.Instant
 
 class QueryResponseSpec extends AnyFlatSpec with Matchers with models {
+
+  def queryResponseFromResultsList(
+      results: List[FingerpostWireEntry]
+  ): QueryResponse =
+    QueryResponse(
+      results = results,
+      totalCount = results.length,
+      countQueryCap = FingerpostWireEntry.countQueryCap
+    )
+
   behavior of "QueryResponse.display"
   it should "sort results by ingested_at in descending order when given IngestedAtTimestamp" in {
 
@@ -21,7 +31,7 @@ class QueryResponseSpec extends AnyFlatSpec with Matchers with models {
       ingestedAt = entry1.ingestedAt.plusSeconds(10)
     )
 
-    val queryResponse = QueryResponse(
+    val queryResponse = queryResponseFromResultsList(
       results = List(entry2, entry1)
     )
 
@@ -62,7 +72,7 @@ class QueryResponseSpec extends AnyFlatSpec with Matchers with models {
       ingestedAt = baseInstant
     )
 
-    val queryResponse = QueryResponse(
+    val queryResponse = queryResponseFromResultsList(
       results = List(entry2, entry1)
     )
 
@@ -85,7 +95,7 @@ class QueryResponseSpec extends AnyFlatSpec with Matchers with models {
       toolLinks = List(toolLink1, toolLink2),
       collections = Nil
     )
-    val queryResponse = QueryResponse(
+    val queryResponse = queryResponseFromResultsList(
       results = List(entry)
     )
     val displayed = QueryResponse.display(
@@ -108,7 +118,7 @@ class QueryResponseSpec extends AnyFlatSpec with Matchers with models {
       toolLinks = List(toolLink1, toolLink2),
       collections = Nil
     )
-    val queryResponse = QueryResponse(
+    val queryResponse = queryResponseFromResultsList(
       results = List(entry)
     )
     val displayed = QueryResponse.display(

--- a/newswires/test/models/QueryResponseSpec.scala
+++ b/newswires/test/models/QueryResponseSpec.scala
@@ -1,6 +1,11 @@
 package models
 
-import db.{AddedToCollectionAtTime, FingerpostWireEntry, IngestedAtTime}
+import db.{
+  AddedToCollectionAtTime,
+  FingerpostWireEntry,
+  IngestedAtTime,
+  PlainNot
+}
 import helpers.models
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
@@ -15,7 +20,8 @@ class QueryResponseSpec extends AnyFlatSpec with Matchers with models {
     QueryResponse(
       results = results,
       totalCount = results.length,
-      countQueryCap = FingerpostWireEntry.countQueryCap
+      countQueryCap = FingerpostWireEntry.COUNT_QUERY_CAP,
+      queryVariant = PlainNot
     )
 
   behavior of "QueryResponse.display"


### PR DESCRIPTION
## New query logic

Change `exclusionCondition` so that now takes a `queryVariant` parameter.

* Given `not_exists` it will produce the same query as before, using `NOT EXISTS (SELECT FROM ...)`.
* Given `plain_not` (or if unspecified) it will just wrap the provided clause in `NOT (...)`

Testing in CODE shows that the new variant speeds up the most expensive queries dramatically (`World + UK, 1 Week` goes down from ~17s to ~1s).

The reason for this seems to be that the `NOT EXISTS` queries need to do joins across a lot of rows before it selects the top 30. The 'plain not' variant tends to inline the checks as it loops through candidate rows, knowing that it's likely to be able to exit early once it's found 30 matching items.

## 'a/b test' implementation

We've stress tested this a bit in CODE, and found that generally performance with the new variant seems to be about the same as, or in some cases significantly better than, the old variant.

However, we theorised that complex queries with sparse results might be slower, and @paperboyo found at least one case which is significantly slower in the new vs. the old variant: text search for an uncommon term within the `No Sport` preset. (Text search within `has data formatting` was catastrophically slow, but seems to have been resolved by adding an index.)

It's difficult to map out all the implications with confidence in advance, so I'm proposing that we do an 'a/b test' where the server will pick a query variant at random, passing it through to the client so that the variant can be included in our performance telemetry. This should allow us to compare the two strategies based on a larger amount of real user data.

## Count query changes

The speed-up for complex and long-range queries is largely due to the db not needing to process all matching entries when it only needs 30. This doesn't apply to a count query, however! Slowing the user experience down significantly just for the sake of getting an accurate count doesn't seem right.

I've experimented with some ways of improving the count query performance, but haven't had any success yet. On discussion with the team, we decided that it would be best to get this change tested and out, with a simple cap on the count query. Then, in the future, we can look into either improving the performance of the count, or loading it asynchronously on the client after the results are fetched.

## Todo

- [x] Test how it performs for other presets
- [x] Check interaction with custom filters
- [x] See whether the `NOT EXISTS` -> `NOT` conversion makes sense in every case, or just some.
- [x] Reconcile the UI with the fact that we aren't expecting full counts anymore (or find a way to optimise the original count query)
- [ ] Check that the performance against CODE isn't too influenced by the fact that I bumped the statistics for the category_codes column from ~100 to ~600.
