### PR TITLE
Show elections feed to all users

### DIFF
--- a/newswires/client/src/SideNav/TopLevelListPreset.tsx
+++ b/newswires/client/src/SideNav/TopLevelListPreset.tsx
@@ -1,10 +1,6 @@
 import { EuiListGroup } from '@elastic/eui';
 import { useSearch } from '../context/SearchContext';
-import {
-	sportPresets,
-	topLevelPresetId,
-	useDisplayablePresets,
-} from '../presets';
+import { allPresets, sportPresets, topLevelPresetId } from '../presets';
 import { defaultConfig } from '../urlState';
 import type { PanelProps } from './PanelProps';
 import { SideNavListItem } from './SideNavListItem';
@@ -18,11 +14,9 @@ export const TopLevelListPresetPanel = ({
 		(_) => _.id === activePreset,
 	);
 
-	const presets = useDisplayablePresets();
-
 	return (
 		<EuiListGroup flush={true} gutterSize="none">
-			{presets.map((item) => (
+			{allPresets.map((item) => (
 				<SideNavListItem
 					label={item.name}
 					key={item.id}

--- a/newswires/client/src/presets.ts
+++ b/newswires/client/src/presets.ts
@@ -1,5 +1,4 @@
 import z from 'zod/v4';
-import { IS_DEV_USER } from './app-configuration.ts';
 
 export const PresetGroupNameSchema = z.union([
 	z.literal('presets'),
@@ -139,21 +138,12 @@ export const allPresets: Preset[] = [
 	{ id: topLevelPresetId, name: 'All' },
 	{ id: 'all-world', name: 'World' },
 	{ id: 'all-uk', name: 'UK' },
-	{ id: 'uk-election', name: 'UK Election (Dev only)' },
+	{ id: 'uk-election', name: 'UK Election' },
 	{ id: 'all-us', name: 'US' },
 	{ id: 'world-plus-uk', name: 'World + UK' },
 	{ id: 'all-business', name: 'Business' },
 	{ id: topLevelSportId, name: 'Sport', child: 'sportPresets' },
 ];
-
-// Filter out any presets which shouldn't be presented to users.
-export const useDisplayablePresets = () => {
-	const presetsToHide = new Set<string>();
-
-	if (!IS_DEV_USER) presetsToHide.add('uk-election');
-
-	return allPresets.filter((p) => !presetsToHide.has(p.id));
-};
 
 export const TASTED_COLLECTION = { id: 1, name: 'Tasted' };
 


### PR DESCRIPTION
Shows the 'Election UK' preset to all users. We've got local elections coming up next week, so we're planning to show the preset for a few days either side and then hide it again afterwards.