### PR TITLE
Re-enable PA PA source feed

### DIFF
--- a/newswires/app/models/SearchParams.scala
+++ b/newswires/app/models/SearchParams.scala
@@ -98,7 +98,6 @@ object SearchParams {
     "PA THE ACADEMY OF MEDICAL SCIENCES",
     "PA PA SPORT LATEST",
     "PA PRESSWIRE",
-    "PA PA",
     "PA GLOBENEWSWIRE",
     "PA EQS NEWSWIRE",
     "PA LATEST",


### PR DESCRIPTION
Election results are coming through on this feed.

Looks like all and only election stories are coming through on this feed, so it should be safe (and sufficient) to re-enable it for now.

```
newswires=> select distinct(gu_source_feed) from fingerpost_wire_entry
where exists (
        select 1
        from unnest(category_codes) as code
        where code ilike '%:x%'
) and ingested_at::text > '2026-050-08';
  gu_source_feed
-------------------
 Reuters-Newswires
 PA PA TEST
 REUTERS
 PA PA
(4 rows)
```

```
 With results available from two out of 32 London councils, the state   | {paCat:XTH}
 Hammersmith + Fulham                                                   | {paCat:XLR}
 00Hammersmith + Fulham                                                 | {paCat:XLD}
 With results available from 32 out of 136 councils, the state of       | {paCat:XTH}
 With results available from three out of 32 London councils, the state | {paCat:XTH}
 00Merton                                                               | {paCat:XLD}
 Merton                                                                 | {paCat:XLR}
 With results available from 34 out of 136 councils, the state of       | {paCat:XTH}
 With results available from 22 out of 136 councils, the state of       | {paCat:XTH}
 Correction: Hart No overall control No change                          | {paCat:XTJ}
 Lincoln                                                                | {paCat:XLR}
 With results available from ten out of 136 councils, the state of      | {paCat:XTH}
 00Lincoln                                                              | {paCat:XLD}
 00Salford                                                              | {paCat:XLD}
 With results available from 23 out of 136 councils, the state of       | {paCat:XTH}
 Richmond-upon-Thames                                                   | {paCat:XLR}
 00Bolton                                                               | {paCat:XLD}
 00Halton                                                               | {paCat:XLD}
 With results available from one out of 32 London councils, the state   | {paCat:XTH}
 With results available from 24 out of 136 councils, the state of       | {paCat:XTH}
 00Halton                                                               | {paCat:XLD}
 00North East Lincolnshire                                              | {paCat:XLD}
 North East Lincolnshire                                                | {paCat:XLR}
 With results available from 14 out of 136 councils, the state of       | {paCat:XTH}
 Lab lose Hartlepool to no overall control                              | {paCat:XTJ}
 00Hartlepool                                                           | {paCat:XLD}
 With results available from two out of 136 councils, the state of      | {paCat:XTH}
 Hartlepool                                                             | {paCat:XLR}
 Labour lose to NOC                                                     | {paCat:XTH}
 00Redditch                                                             | {paCat:XLD}
 Lab lose Redditch to no overall control                                | {paCat:XTJ}
 With results available from three out of 136 councils, the state of    | {paCat:XTH}
 Broxbourne (C)                                                         | {paCat:XTH}
 00Reading                                                              | {paCat:XLD}
 With results available from 25 out of 136 councils, the state of       | {paCat:XTH}
 00Portsmouth                                                           | {paCat:XLD}
 00Richmond-upon-Thames                                                 | {paCat:XLD}
 With results available from 17 out of 136 councils, the state of       | {paCat:XTH}
 Portsmouth                                                             | {paCat:XLR}
 00Hull                                                                 | {paCat:XLD}
 Brentwood                                                              | {paCat:XLR}
 With results available from 18 out of 136 councils, the state of       | {paCat:XTH}
 00Brentwood                                                            | {paCat:XLD}
 00Hart                                                                 | {paCat:XLD}
 With results available from six out of 136 councils, the state of      | {paCat:XTH}
 Hart                                                                   | {paCat:XLR}
 With results available from 26 out of 136 councils, the state of       | {paCat:XTH}
 Wigan                                                                  | {paCat:XLR}
 Halton                                                                 | {paCat:XLR}
 Broxbourne                                                             | {paCat:XLR}
(177 rows)
```