### PR TITLE
Add AP feature codes to US presets

### DIFF
--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -209,7 +209,7 @@ object SearchPresets {
   private val AllUs = List(
     SearchPreset(
       AP,
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.US.AP, SOME))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.US.AP ++ List("apCat:l", "apCat:o", "apCat:e"), SOME))
     ),
     SearchPreset(
       AP,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Adds AP codes for 'lifestyle', 'entertainment' and 'weather' to the US preset, which currently focuses on news stories.

Although news desks may not be interested in these stories, there are comparatively few of them. Without this change, anyone who is interested in these stories can only find them via a search or in the 'all' preset which contains 1000s of stories.

## How to test

Tested on CODE. Compared number of stories appearing for the feature codes with US preset selected and saw more on CODE than on PROD.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD