### PR TITLE
Don't return 501 in response to requests with an unsupported method

### DIFF
--- a/newswires/app/lib/UnknownMethodParsingErrorHandler.scala
+++ b/newswires/app/lib/UnknownMethodParsingErrorHandler.scala
@@ -1,0 +1,43 @@
+package lib
+
+import org.apache.pekko.event.LoggingAdapter
+import org.apache.pekko.http.scaladsl.model.{
+  ErrorInfo,
+  HttpResponse,
+  StatusCode,
+  StatusCodes
+}
+import org.apache.pekko.http.scaladsl.settings.ServerSettings
+import org.apache.pekko.http.{DefaultParsingErrorHandler, ParsingErrorHandler}
+import play.api.Logging
+
+import scala.annotation.unused
+
+/*
+  Coerces responses from Pekko in response to unknown HTTP methods from 501 to 400.
+  Technically HTTP spec requires 501s in this case, but this allows external parties
+  to spam our 5xx alarms with silly requests. We're comfortable treating these as "Bad
+  requests" instead.
+ */
+@unused
+object UnknownMethodParsingErrorHandler
+    extends ParsingErrorHandler
+    with Logging {
+  override def handle(
+      status: StatusCode,
+      error: ErrorInfo,
+      log: LoggingAdapter,
+      settings: ServerSettings
+  ): HttpResponse = {
+    if (
+      status == StatusCodes.NotImplemented && error.summary == "Unsupported HTTP method"
+    ) {
+      logger.warn(
+        s"Client attempted to use unknown HTTP method '${error.detail}'. Returning 400 instead of 501."
+      )
+      HttpResponse(StatusCodes.BadRequest)
+    } else {
+      DefaultParsingErrorHandler.handle(status, error, log, settings)
+    }
+  }
+}

--- a/newswires/conf/application.conf
+++ b/newswires/conf/application.conf
@@ -10,3 +10,5 @@ play.filters.hosts {
 }
 
 play.assets.cache."/public/index.html" = "no-cache"
+
+pekko.http.server.parsing.error-handler = "lib.UnknownMethodParsingErrorHandler$"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

There are a bunch of methods which we don't support, and the app is currently returning 501s for any requests with these, as per the HTTP spec. We have alarms based on the number of 5XXs, which normally indicate something has gone wrong. However, we keep getting spammed with unsupported methods which is making our alarms noisy for something that's not an actionable issue. 

See https://github.com/guardian/grid/pull/4528 for more info on considerations and implementation.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Deploy to CODE and `curl` the load balancer *directly* with an unrecognised method (e.g. `-X PROPFIND` (requests to the dev-gutools.co.uk URL will be handled by Cloudfront before they hit the new code path). You should get a 400 instead of a 501 in response.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD