### PR TITLE
Remove temporary filtering of legacy PA source feeds

### DIFF
--- a/newswires/app/models/SearchParams.scala
+++ b/newswires/app/models/SearchParams.scala
@@ -57,11 +57,7 @@ object SearchParams {
         preComputedCategoriesExcl = Nil,
         collectionId = baseParams.maybeCollectionId,
         guSourceFeeds = baseParams.guSourceFeeds,
-        guSourceFeedsExcl = computeGuSourceFeedExcl(
-          showPAAPI = featureSwitch.ShowPAAPI.isOn(req),
-          guSourceFeeds = baseParams.guSourceFeeds,
-          guSourceFeedsExcl = baseParams.guSourceFeedsExcl
-        ),
+        guSourceFeedsExcl = baseParams.guSourceFeedsExcl,
         eventCode = baseParams.eventCode
       ),
       DateRange(
@@ -88,51 +84,5 @@ object SearchParams {
       query.get("supplierExcl").map(_.toList).getOrElse(Nil)
 
     dotCopyExclusion ::: guSuppliersExclusion ::: exclusionFromParams
-  }
-
-  val legacyPaSourceFeeds = List(
-    "PA PR NEWSWIRE",
-    "PA PA MEDIA PRESS CENTRES",
-    "PA PA MEDIA ASSIGNMENTS",
-    "PA BUSINESSWIRE",
-    "PA THE ACADEMY OF MEDICAL SCIENCES",
-    "PA PA SPORT LATEST",
-    "PA PRESSWIRE",
-    "PA GLOBENEWSWIRE",
-    "PA EQS NEWSWIRE",
-    "PA LATEST",
-    "PA RESPONSESOURCE",
-    "PA ACCESS NEWSWIRE",
-    "PA UK GOVERNMENT AND PUBLIC SECTOR",
-    "PA PA SPORT",
-    "PA PA ADVISORY",
-    "PA AGILITY PR SOLUTIONS",
-    "PA NEWS AKTUELL",
-    "PA ADVISORY",
-    "PA MARKETTIERS",
-    "PA RNS",
-    "PA",
-    "PA PA SPORT SNAP",
-    "PA NEWSFILE",
-    "PA PRESSAT",
-    "PA SNAP"
-  )
-
-  val newPaSourceFeeds = List(
-    "PA_API",
-    "PA_API DATA FORMATTING"
-  )
-
-  def computeGuSourceFeedExcl(
-      showPAAPI: Boolean,
-      guSourceFeeds: List[String],
-      guSourceFeedsExcl: List[String]
-  ) = {
-    if (guSourceFeeds.nonEmpty || guSourceFeedsExcl.nonEmpty) {
-      guSourceFeedsExcl
-    } else if (showPAAPI) {
-      legacyPaSourceFeeds
-    } else
-      newPaSourceFeeds
   }
 }

--- a/newswires/app/service/FeatureSwitchProvider.scala
+++ b/newswires/app/service/FeatureSwitchProvider.scala
@@ -23,19 +23,8 @@ class FeatureSwitchProvider(stage: String) {
       isOn = _ => stage.toUpperCase() != "PROD"
     )
 
-  val ShowPAAPI: FeatureSwitch =
-    FeatureSwitch(
-      name = "ShowPAAPI",
-      safeState = Off,
-      description = "Show new PA API in the feed",
-      exposeToClient = true,
-      isOn = _.getQueryString("previewPaApi")
-        .flatMap(_.toBooleanOption)
-        .getOrElse(true)
-    )
   private val switches = List(
-    ShowGuSuppliers,
-    ShowPAAPI
+    ShowGuSuppliers
   )
   def clientSideSwitchStates(request: Request[_]): Map[String, Boolean] =
     switches.filter(_.exposeToClient).map(s => s.name -> s.isOn(request)).toMap

--- a/newswires/client/src/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary.tsx
@@ -28,7 +28,6 @@ const SearchTermBadgeLabelLookup: Record<DeselectableQueryKey, string> = {
 	categoryCode: 'Category',
 	categoryCodeExcl: '(NOT) Category',
 	hasDataFormatting: 'Has data formatting',
-	previewPaApi: 'Previewing PA API switchover',
 	keyword: 'Keyword',
 	keywordExcl: '(NOT) Keyword',
 	guSourceFeed: 'Source feed',
@@ -99,7 +98,6 @@ const Summary = ({
 		categoryCode,
 		categoryCodeExcl,
 		hasDataFormatting,
-		previewPaApi,
 		collectionId,
 		eventCode: eventCode,
 	} = query;
@@ -133,7 +131,6 @@ const Summary = ({
 		displayGuSourceFeeds ||
 		displayExcludedGuSourceFeeds ||
 		hasDataFormatting !== undefined ||
-		previewPaApi !== undefined ||
 		collectionId !== undefined ||
 		eventCode !== undefined;
 
@@ -246,14 +243,6 @@ const Summary = ({
 					keyValuePair={{
 						key: 'hasDataFormatting',
 						value: hasDataFormatting ? 'true' : 'false',
-					}}
-				/>
-			)}
-			{previewPaApi !== undefined && (
-				<SummaryBadge
-					keyValuePair={{
-						key: 'previewPaApi',
-						value: previewPaApi ? 'true' : 'false',
 					}}
 				/>
 			)}

--- a/newswires/client/src/SettingsMenu.tsx
+++ b/newswires/client/src/SettingsMenu.tsx
@@ -9,7 +9,7 @@ import {
 } from '@elastic/eui';
 import moment from 'moment-timezone';
 import { useState } from 'react';
-import { SHOW_GU_SUPPLIERS, SHOW_PAAPI } from './app-configuration';
+import { SHOW_GU_SUPPLIERS } from './app-configuration';
 import { StopShortcutPropagationWrapper } from './context/KeyboardShortcutsContext';
 import { useUserSettings } from './context/UserSettingsContext';
 import { useSettingsSwitches } from './SettingsSwitches.tsx';
@@ -96,9 +96,6 @@ export const SettingsMenu = () => {
 			items: [
 				{
 					name: `Show Gu suppliers: ${SHOW_GU_SUPPLIERS ? 'On' : 'Off'}`,
-				},
-				{
-					name: `Show PAAPI: ${SHOW_PAAPI ? 'On' : 'Off'}`,
 				},
 			],
 		},

--- a/newswires/client/src/app-configuration.ts
+++ b/newswires/client/src/app-configuration.ts
@@ -13,7 +13,6 @@ const configLookup: AppConfiguration = isJest
 	? {
 			switches: {
 				ShowGuSuppliers: false,
-				ShowPAAPI: false,
 			},
 			stage: 'test',
 			sendTelemetryAsDev: true,
@@ -22,7 +21,6 @@ const configLookup: AppConfiguration = isJest
 	: window.configuration;
 
 export const SHOW_GU_SUPPLIERS = configLookup.switches.ShowGuSuppliers;
-export const SHOW_PAAPI = configLookup.switches.ShowPAAPI;
 
 /**
  * The list of suppliers to exclude from the list of 'recognised suppliers' that

--- a/newswires/client/src/queryHelpers.ts
+++ b/newswires/client/src/queryHelpers.ts
@@ -57,7 +57,6 @@ export const queryAfterDeselection = (
 			'keywordExcl',
 			'guSourceFeed',
 			'guSourceFeedExcl',
-			'previewPaApi',
 		].includes(key)
 	) {
 		const current = query[key] as string[] | undefined;

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -166,7 +166,6 @@ export const BaseQuerySchema = z.object({
 	start: EuiDateStringSchema.optional(),
 	end: EuiDateStringSchema.optional(),
 	hasDataFormatting: z.boolean().optional(),
-	previewPaApi: z.boolean().optional(),
 	eventCode: z.string().optional(),
 });
 export type BaseQuery = z.infer<typeof BaseQuerySchema>;

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -18,7 +18,6 @@ export const defaultQuery: Query = {
 	start: DEFAULT_DATE_RANGE.start,
 	end: DEFAULT_DATE_RANGE.end,
 	hasDataFormatting: undefined,
-	previewPaApi: undefined,
 	collectionId: undefined,
 	eventCode: undefined,
 };
@@ -72,9 +71,6 @@ function searchParamsToQuery(params: URLSearchParams): Query {
 	const hasDataFormatting = maybeStringToBooleanOrUndefined(
 		params.get('hasDataFormatting'),
 	);
-	const previewPaApi = maybeStringToBooleanOrUndefined(
-		params.get('previewPaApi'),
-	);
 	const eventCode = params.get('eventCode') ?? undefined;
 	let collectionId: number | undefined = undefined;
 
@@ -107,7 +103,6 @@ function searchParamsToQuery(params: URLSearchParams): Query {
 		start,
 		end,
 		hasDataFormatting,
-		previewPaApi,
 		eventCode,
 	};
 

--- a/newswires/client/src/windowConfigType.ts
+++ b/newswires/client/src/windowConfigType.ts
@@ -1,6 +1,5 @@
 interface FeatureSwitches {
 	ShowGuSuppliers: boolean;
-	ShowPAAPI: boolean;
 }
 
 export interface AppConfiguration {

--- a/newswires/test/models/SearchParamsSpec.scala
+++ b/newswires/test/models/SearchParamsSpec.scala
@@ -21,8 +21,7 @@ class SearchParamsSpec extends AnyFlatSpec with models {
       featureSwitchesOn
     )(FakeRequest()) shouldEqual emptySearchParams.copy(filters =
       emptyFilterParams.copy(
-        suppliersExcl = List("UNAUTHED_EMAIL_FEED"),
-        guSourceFeedsExcl = SearchParams.legacyPaSourceFeeds
+        suppliersExcl = List("UNAUTHED_EMAIL_FEED")
       )
     )
   }
@@ -121,16 +120,6 @@ class SearchParamsSpec extends AnyFlatSpec with models {
     )
   }
 
-  it should "include new PA API feed exclusions when the showPAAPI feature switch is off " in new searchParamsMocks {
-    val result =
-      SearchParams.build(
-        emptyQueryString,
-        emptyBaseParams,
-        showPAAPIFeatureOff
-      )(FakeRequest())
-    result.filters.guSourceFeedsExcl shouldEqual SearchParams.newPaSourceFeeds
-  }
-
   behavior of "computeSupplierExcl"
 
   it should "return dotcopy exclusion when no additional exclusion params are set and showGuSuppliers is true" in new searchParamsMocks {
@@ -189,52 +178,6 @@ class SearchParamsSpec extends AnyFlatSpec with models {
 
   behavior of "computeGuSourceFeedExcl"
 
-  it should "return PA_API exclusions when showPAAPI is false and no guSourceFeed is explicitly set in the query" in new searchParamsMocks {
-    val result = SearchParams.computeGuSourceFeedExcl(
-      showPAAPI = false,
-      guSourceFeeds = Nil,
-      guSourceFeedsExcl = Nil
-    )
-    result shouldEqual List("PA_API", "PA_API DATA FORMATTING")
-  }
-  it should "return legacy PA exclusions when showPAAPI is true and guSourceFeeds and guSourceFeedsExcl are not set" in new searchParamsMocks {
-    val result = SearchParams.computeGuSourceFeedExcl(
-      showPAAPI = true,
-      guSourceFeeds = Nil,
-      guSourceFeedsExcl = Nil
-    )
-    result shouldEqual SearchParams.legacyPaSourceFeeds
-  }
-  it should "return whatever is set in guSourceFeedsExcl when guSourceFeeds is set, regardless of the showPAAPI switch" in new searchParamsMocks {
-    val showPAAPI_OFF = SearchParams.computeGuSourceFeedExcl(
-      showPAAPI = false,
-      guSourceFeeds = List("FEED TO INCLUDE"),
-      guSourceFeedsExcl = Nil
-    )
-    showPAAPI_OFF shouldEqual Nil
-
-    val showPAAPI_ON = SearchParams.computeGuSourceFeedExcl(
-      showPAAPI = true,
-      guSourceFeeds = List("FEED TO INCLUDE"),
-      guSourceFeedsExcl = Nil
-    )
-    showPAAPI_ON shouldEqual Nil
-  }
-  it should "return whatever is set in guSourceFeedsExcl when guSourceFeedsExcl is set, regardless of the showPAAPI switch" in new searchParamsMocks {
-    val showPAAPI_OFF = SearchParams.computeGuSourceFeedExcl(
-      showPAAPI = false,
-      guSourceFeeds = Nil,
-      guSourceFeedsExcl = List("FEED TO EXCLUDE")
-    )
-    showPAAPI_OFF shouldEqual List("FEED TO EXCLUDE")
-
-    val showPAAPI_ON = SearchParams.computeGuSourceFeedExcl(
-      showPAAPI = true,
-      guSourceFeeds = Nil,
-      guSourceFeedsExcl = List("FEED TO EXCLUDE")
-    )
-    showPAAPI_ON shouldEqual List("FEED TO EXCLUDE")
-  }
 }
 
 trait searchParamsMocks {
@@ -242,7 +185,6 @@ trait searchParamsMocks {
   val emptyQueryString = Map[String, Seq[String]]()
   val featureSwitchesOn = mock[FeatureSwitchProvider]
   val showGuSuppliersFeatureOff = mock[FeatureSwitchProvider]
-  val showPAAPIFeatureOff = mock[FeatureSwitchProvider]
   val featureSwitch = FeatureSwitch(
     name = "",
     safeState = Off,
@@ -251,17 +193,7 @@ trait searchParamsMocks {
     isOn = _ => true
   )
   when(featureSwitchesOn.ShowGuSuppliers).thenReturn(featureSwitch)
-  when(featureSwitchesOn.ShowPAAPI).thenReturn(featureSwitch)
   when(showGuSuppliersFeatureOff.ShowGuSuppliers).thenReturn(
-    featureSwitch.copy(isOn = _ => false)
-  )
-  when(showGuSuppliersFeatureOff.ShowPAAPI).thenReturn(
-    featureSwitch
-  )
-  when(showPAAPIFeatureOff.ShowGuSuppliers).thenReturn(
-    featureSwitch
-  )
-  when(showPAAPIFeatureOff.ShowPAAPI).thenReturn(
     featureSwitch.copy(isOn = _ => false)
   )
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Remove the PA API preview logic, now that the switchover is complete. We shouldn't be getting anything in from these source feeds any longer, but if anything should pop up then we can allow it to be displayed, as its presumbly something we haven't considered (like election night results :( )

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD