### PR TITLE
upgrade wires db from 16 to 18

### DIFF
--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -2784,7 +2784,7 @@ exports[`The Newswires stack matches the snapshot 1`] = `
         "DeletionProtection": true,
         "EnableIAMDatabaseAuthentication": true,
         "Engine": "postgres",
-        "EngineVersion": "16",
+        "EngineVersion": "18",
         "Iops": 3000,
         "MasterUserPassword": {
           "Fn::Join": [

--- a/cdk/lib/__snapshots__/whole-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/whole-stack.test.ts.snap
@@ -3797,7 +3797,7 @@ exports[`createStacks should create WiresFeeds and Newswires stacks with correct
         "DeletionProtection": true,
         "EnableIAMDatabaseAuthentication": true,
         "Engine": "postgres",
-        "EngineVersion": "16",
+        "EngineVersion": "18",
         "Iops": 3000,
         "MasterUserPassword": {
           "Fn::Join": [

--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -120,7 +120,7 @@ export class Newswires extends GuStack {
 				subnets: privateSubnets,
 			},
 			engine: DatabaseInstanceEngine.postgres({
-				version: PostgresEngineVersion.VER_16,
+				version: PostgresEngineVersion.VER_18,
 			}),
 			storageType: StorageType.GP3,
 			iops: 3000, // the default for gp3 - not required but nice to declare

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,8 +1,6 @@
-version: '3.0'
-
 services:
   test-db:
-    image: postgres:16.4
+    image: postgres:18.3
     container_name: newswires-test-db
     ports:
       - 55432:5432

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-version: '3.0'
-
 services:
   db:
-    image: postgres:16.4
+    image: postgres:18.3
     container_name: newswires-db
     ports:
       - 5432:5432


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Upgrades the database version from 16.x to 18.x in Cloudformation. The upgrade will have been performed manually in the console before this PR is merged (to have better control of the upgrade start time, and to select the latest 18.x veresion), so the deploy from this will not actually perform a modification of the database, merely bring the Cloudformation into line with the actual state of the database.

Also upgrades the postgres versions used by the docker containers to the same version number, to keep us in sync.

## How to test

Tested on CODE - an instance previously upgraded to 18.x was not further modified by this cloudformation change.

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD