### PR TITLE
Add index for `hasDataFormatting` queries

### DIFF
--- a/db/migrations/V33__Create_hasDataFormatting_index.sql
+++ b/db/migrations/V33__Create_hasDataFormatting_index.sql
@@ -1,0 +1,3 @@
+CREATE INDEX CONCURRENTLY IF NOT EXISTS fingerpost_wire_entry_ingested_at_dataformat_idx
+ON public.fingerpost_wire_entry (ingested_at DESC)
+WHERE ((content -> 'dataformat'::text) IS NOT NULL);


### PR DESCRIPTION
We don't have an index that covers the query we use for `hasDataFormatting`. When you combine this with a long time window and a text search which returns few or no results, it's very slow!

Adding the partial index on ingestion time + dataformat seems to help.

Before and after queries seem to confirm that using the Newswires query for dataformatting does hit the index after it's been added.

```
EXPLAIN (ANALYZE, BUFFERS, VERBOSE)
SELECT id
FROM fingerpost_wire_entry
WHERE (content->'dataformat') IS NOT NULL and (to_tsvector('english_unaccent',
        coalesce(content->>'headline', '') || ' ' ||
        coalesce(content->>'subhead', '') || ' ' ||
        coalesce(content->>'keywords', '') || ' ' ||
        coalesce(content->>'body_text', '') || ' ' ||
        coalesce(content->>'byline', '') || ' ' ||
        coalesce(content->>'abstract', '') || ' ' ||
        coalesce(content->>'slug', '')
      ) @@ websearch_to_tsquery ('english_unaccent', 'uk')  or websearch_to_tsquery('simple', lower('uk')) @@ slug_text_tsv_simple) order by ingested_at desc limit 30;
```

## Before:

```
 Limit  (cost=0.29..724.92 rows=30 width=16) (actual time=102190.039..102190.040 rows=0.00 loops=1)          Output: id, ingested_at                                                                                   Buffers: shared hit=981492 read=156931 dirtied=3                                                          I/O Timings: shared read=87506.441
   ->  Index Scan Backward using ingested_at_index on public.fingerpost_wire_entry  (cost=0.29..144516.10 rows=5983 width=16) (actual time=102190.038..102190.038 rows=0.00 loops=1)
         Output: id, ingested_at
         Filter: (((fingerpost_wire_entry.content -> 'dataformat'::text) IS NOT NULL) AND ((to_tsvector('english_unaccent'::regconfig, ((((((((((((COALESCE((fingerpost_wire_entry.content ->> 'headline'::text), ''::text) || ' '::text) || COALESCE((fingerpost_wire_entry.content ->> 'subhead'::text), ''::text)) || ' '::text) || COALESCE((fingerpost_wire_entry.content ->> 'keywords'::text), ''::text)) || ' '::text) || COALESCE((fingerpost_wire_entry.content ->> 'body_text'::text), ''::text)) || ' '::text) || COALESCE((fingerpost_wire_entry.content ->> 'byline'::text), ''::text)) || ' '::text) || COALESCE((fingerpost_wire_entry.content ->> 'abstract'::text), ''::text)) || ' '::text) || COALESCE((fingerpost_wire_entry.content ->> 'slug'::text), ''::text))) @@ '''uk'''::tsquery) OR ('''uk'''::tsquery @@ fingerpost_wire_entry.slug_text_tsv_simple)))                                                                                                              Rows Removed by Filter: 130661                                                                            Index Searches: 1                                                                                         Buffers: shared hit=981492 read=156931 dirtied=3                                                          I/O Timings: shared read=87506.441
 Query Identifier: -3354047358249077507
 Planning:
   Buffers: shared hit=79 read=4
   I/O Timings: shared read=3.508
 Planning Time: 6.703 ms
 Execution Time: 102190.082 ms
(17 rows)
```

## After:

```
 Limit  (cost=0.29..690.93 rows=30 width=16) (actual time=26459.613..26459.614 rows=0.00 loops=1)
   Output: id, ingested_at
   Buffers: shared hit=467745 read=27794
   I/O Timings: shared read=15332.510
   ->  Index Scan using fingerpost_wire_entry_ingested_at_dataformat_idx on public.fingerpost_wire_entry  (cost=0.29..140936.98 rows=6122 width=16) (actual time=26459.612..26459.612 rows=0.00 loops=1)
         Output: id, ingested_at
         Filter: ((to_tsvector('english_unaccent'::regconfig, ((((((((((((COALESCE((fingerpost_wire_entry.content ->> 'headline'::text), ''::text) || ' '::text) || COALESCE((fingerpost_wire_entry.content ->> 'subhead'::text), ''::text)) || ' '::text) || COALESCE((fingerpost_wire_entry.content ->> 'keywords'::text), ''::text)) || ' '::text) || COALESCE((fingerpost_wire_entry.content ->> 'body_text'::text), ''::text)) || ' '::text) || COALESCE((fingerpost_wire_entry.content ->> 'byline'::text), ''::text)) || ' '::text) || COALESCE((fingerpost_wire_entry.content ->> 'abstract'::text), ''::text)) || ' '::text) || COALESCE((fingerpost_wire_entry.content ->> 'slug'::text), ''::text))) @@ '''uk'''::tsquery) OR ('''uk'''::tsquery @@ fingerpost_wire_entry.slug_text_tsv_simple))
         Rows Removed by Filter: 16594
         Index Searches: 1
         Buffers: shared hit=467745 read=27794
         I/O Timings: shared read=15332.510
 Query Identifier: -3354047358249077507
 Planning:
   Buffers: shared hit=17
 Planning Time: 0.445 ms
 Execution Time: 26459.646 ms
 ```