### PR TITLE
Remove UK election from nav

### DIFF
--- a/newswires/client/src/presets.ts
+++ b/newswires/client/src/presets.ts
@@ -138,7 +138,7 @@ export const allPresets: Preset[] = [
 	{ id: topLevelPresetId, name: 'All' },
 	{ id: 'all-world', name: 'World' },
 	{ id: 'all-uk', name: 'UK' },
-	{ id: 'uk-election', name: 'UK Election' },
+	// { id: 'uk-election', name: 'UK Election' }, // UK election feed is only relevant when there's an actual election going on, so removing it from the nav for now.
 	{ id: 'all-us', name: 'US' },
 	{ id: 'world-plus-uk', name: 'World + UK' },
 	{ id: 'all-business', name: 'Business' },


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Comment out the lines that add the UK election preset to the side nav.

I'm in two minds about whether to comment out or delete. There's some business logic in the actual preset definition which we definitely don't want to lose, but the client side code is a bit different.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- Run locally
- Check that 'UK Election' is not in the nav anymore
- But other presets work as normal

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD