### PR TITLE
include status code as 500 in request logs even when result is throwing

### DIFF
--- a/newswires/app/lib/RequestLoggingFilter.scala
+++ b/newswires/app/lib/RequestLoggingFilter.scala
@@ -2,7 +2,7 @@ package lib
 
 import net.logstash.logback.marker.Markers.appendEntries
 import org.apache.pekko.stream.Materializer
-import play.api.mvc.{AnyContent, Filter, Request, RequestHeader, Result}
+import play.api.mvc._
 import play.api.{Logger, Logging, MarkerContext}
 
 import java.util.UUID
@@ -26,11 +26,16 @@ class RequestLoggingFilter(implicit
       next: RequestHeader => Future[Result]
   )(request: RequestHeader): Future[Result] = {
     val start = System.currentTimeMillis()
-    val withID = request.withHeaders(
-      request.headers.replace(
-        RequestLoggingFilter.requestIdHeader -> UUID.randomUUID().toString
-      )
-    )
+
+    val withID =
+      if (request.headers.hasHeader(RequestLoggingFilter.requestIdHeader))
+        request
+      else
+        request.withHeaders(
+          request.headers.replace(
+            RequestLoggingFilter.requestIdHeader -> UUID.randomUUID().toString
+          )
+        )
 
     val resultFuture = next(withID)
 

--- a/newswires/app/lib/RequestLoggingFilter.scala
+++ b/newswires/app/lib/RequestLoggingFilter.scala
@@ -64,19 +64,22 @@ class RequestLoggingFilter(implicit
       "origin" -> originIp,
       "method" -> request.method,
       "duration" -> duration,
-      "path" -> request.path
+      "path" -> request.path,
+      "status" -> outcome.map(_.header.status).toOption.getOrElse(500),
+      "referrer" -> referer
     ) ++ queryStringMap
 
-    val optionalMarkers = Map(
-      "status" -> outcome.map(_.header.status).toOption,
-      "requestId" -> request.headers.get(RequestLoggingFilter.requestIdHeader),
-      "referrer" -> referer
-    ).collect { case (key, Some(value)) =>
-      key -> value
-    }
+    val optionalMarkers: Map[String, Option[String]] = Map(
+      "requestId" -> request.headers.get(RequestLoggingFilter.requestIdHeader)
+    )
+
+    val filteredOptionalMarkers = optionalMarkers
+      .collect { case (key, Some(value)) =>
+        key -> value
+      }
 
     val markers = MarkerContext(
-      appendEntries((mandatoryMarkers ++ optionalMarkers).asJava)
+      appendEntries((mandatoryMarkers ++ filteredOptionalMarkers).asJava)
     )
 
     outcome.fold(
@@ -84,7 +87,9 @@ class RequestLoggingFilter(implicit
         logger.info(
           s"""$originIp - "${request.method} ${request.uri} ${request.version}" ERROR "$referer" ${duration}ms"""
         )(markers)
-        logger.error(s"Error for ${request.method} ${request.uri}", throwable)
+        logger.error(s"Error for ${request.method} ${request.uri}", throwable)(
+          markers
+        )
       },
       response => {
         val length = response.header.headers.getOrElse("Content-Length", 0)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Include the status code marker in request logs even when the outcome of the handler is a throwing exception - Play's default error handler (which we are using) will return a 500 so we can default to that. Previously we would exclude it when we are throwing to the error handler, and only returning the status code defined by a non-throwing (though possibly not "successful") result from the handler.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD