### PR TITLE
use 2 instances in PROD

### DIFF
--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -456,10 +456,10 @@ export class Newswires extends GuStack {
 			type: 'String',
 		});
 
-		const scaling = {
-			minimumInstances: 1,
-			maximumInstances: 2,
-		};
+		const scaling =
+			this.stage === 'PROD'
+				? { minimumInstances: 2, maximumInstances: 4 }
+				: { minimumInstances: 1, maximumInstances: 2 };
 
 		const monitoringConfiguration: Alarms | NoMonitoring = enableMonitoring
 			? {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Update to use 2 instances in PROD.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD