### PR TITLE
Add basketball scores preset

### DIFF
--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -63,6 +63,7 @@ object SearchPresets {
     case "australian-rules"     => Some(SearchPreset(AustralianRules, Nil))
     case "baseball"             => Some(SearchPreset(Baseball, Nil))
     case "basketball"           => Some(SearchPreset(Basketball, Nil))
+    case "basketball-scores"    => Some(SearchPreset(BasketballScores, Nil))
     case "college-sports"       => Some(SearchPreset(CollegeSports, Nil))
     case "cricket"              => Some(SearchPreset(Cricket, Nil))
     case "cricket-scores"       => Some(SearchPreset(CricketScores, Nil))
@@ -518,12 +519,14 @@ object SearchPresets {
   private val Basketball = List(
     SearchPreset(
       REUTERS,
+      searchTerms = Some(SingleTerm(SingleField("-/RESULTS -/STANDINGS", Slug))),
       categoryCodes = Some(CategoryCodesCondition(List("N2:BASK", "subj:15008000", "subj:15008001"), SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("BASKETBALL", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:RSR"), SOME))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME)),
+      categoryCodesExcl = List("paCat:RSR")
     ),
     SearchPreset(
       AAP,
@@ -536,7 +539,25 @@ object SearchPresets {
     ),
     SearchPreset(
       AP,
-      searchTerms = Some(SingleTerm(SingleField("-BKC -BKW BKN OR BKL", Slug))),
+      searchTerms = Some(SingleTerm(SingleField("AP-BKN OR AP-BKL", Slug))),
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME))
+    )
+  )
+
+  private val BasketballScores = List(
+    SearchPreset(
+      REUTERS,
+      searchTerms = Some(SingleTerm(SingleField("/RESULTS OR /STANDINGS", Slug))),
+      categoryCodes = Some(CategoryCodesCondition(List("N2:BASK", "subj:15008000", "subj:15008001"), SOME))
+    ),
+    SearchPreset(
+      PA,
+      searchTerms = Some(SingleTerm(SingleField("BASKETBALL", Slug))),
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME))
+    ),
+    SearchPreset(
+      AP,
+      searchTerms = Some(SingleTerm(SingleField("BC-BKN OR BC-BKL", Slug))),
       categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.AP, SOME))
     )
   )

--- a/newswires/client/src/presets.ts
+++ b/newswires/client/src/presets.ts
@@ -59,6 +59,10 @@ export const sportPresets: Preset[] = [
 		id: 'basketball',
 	},
 	{
+		name: 'Basketball scores',
+		id: 'basketball-scores',
+	},
+	{
 		name: 'Boxing',
 		id: 'boxing',
 	},


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add a basketball scores preset to declutter the basketball preset. The new preset includes results, standings and some brief "previews" from AP (the soccer scores preset includes previews of this sort so including here seems to make sense).

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD