### PR TITLE
Remove the refresh button in the date picker

### DIFF
--- a/newswires/client/src/DatePicker.tsx
+++ b/newswires/client/src/DatePicker.tsx
@@ -54,6 +54,7 @@ export const DatePicker = ({ width = 'auto' }: { width?: 'full' | 'auto' }) => {
 					customQuickSelectRender={customQuickSelectRender}
 					dateFormat={'MMM D • HH:mm'}
 					commonlyUsedRanges={timeRangeOptions()}
+					showUpdateButton={false}
 				/>
 			</div>
 		</StopShortcutPropagationWrapper>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This updates the settings in the `EuiSuperDatePicker` so that the refresh button doesn't display because this was confusing to the end user. 

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

Before
<img width="227" height="71" alt="image" src="https://github.com/user-attachments/assets/a08b2ee3-0b43-45af-94be-ecadb34752f2" />

After
<img width="173" height="78" alt="image" src="https://github.com/user-attachments/assets/f8db0d0c-f147-435b-b61e-67783c7d1eb9" />



## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD