### PR TITLE
Pin GHA actions using commit hashes

### DIFF
--- a/.github/workflows/check-latest-migration.yaml
+++ b/.github/workflows/check-latest-migration.yaml
@@ -2,7 +2,7 @@ name: check-latest-migration
 on:
   pull_request:
 
-jobs: 
+jobs:
   check-latest-migration:
     name: Check latest migration
     if: github.actor != 'dependabot[bot]'
@@ -13,13 +13,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: aws-actions/configure-aws-credentials@v6
-        with: 
+        with:
           aws-region: eu-west-1
           role-to-assume: ${{ secrets.SSM_AUTH }}
 
       - name: Check the latest migration version
-        run: 
-          ./scripts/check-latest-migration.sh
+        run: ./scripts/check-latest-migration.sh

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,10 +25,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup node for CDK
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 #v6.2.0
         with:
           cache: 'npm'
           cache-dependency-path: './package-lock.json'

--- a/.github/workflows/sbt-dependency-graph.yaml
+++ b/.github/workflows/sbt-dependency-graph.yaml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: 
+  workflow_dispatch:
 jobs:
   dependency-graph:
     runs-on: ubuntu-latest
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install Java
         id: java
-        uses: guardian/setup-scala@v1
+        uses: guardian/setup-scala@cc7b39e238d789370aa98fa5f07e609b6527657d # v1.1.0
       - name: Submit dependencies
         id: submit
         uses: scalacenter/sbt-dependency-submission@1cc96a7038ea2b014c200c1dae3a0cc92293b91d # v3.2.2


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Following [departmental recommendations](https://github.com/guardian/recommendations/blob/main/github-actions.md), pin actions to particular versions using commit hashes. In the case where we didn't have a fully specified semver version, I've picked the most recent matching version *or* the second-most recent if the most recent had only just been released.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD