### PR TITLE
Implement refresh button

### DIFF
--- a/newswires/client/src/DatePicker.tsx
+++ b/newswires/client/src/DatePicker.tsx
@@ -15,7 +15,7 @@ import { timeRangeOptions } from './dateHelpers.ts';
 import { EuiDateStringSchema } from './sharedTypes.ts';
 
 export const DatePicker = ({ width = 'auto' }: { width?: 'full' | 'auto' }) => {
-	const { config, handleEnterQuery } = useSearch();
+	const { config, handleEnterQuery, handleRefresh } = useSearch();
 
 	const onTimeChange = ({ start, end }: { start: string; end: string }) => {
 		handleEnterQuery({
@@ -38,6 +38,10 @@ export const DatePicker = ({ width = 'auto' }: { width?: 'full' | 'auto' }) => {
 		</>
 	);
 
+	const onRefresh = () => {
+		handleRefresh();
+	};
+
 	return (
 		<StopShortcutPropagationWrapper>
 			{/* Wrap date picker so StopShortcutPropagationWrapper can catch and stop its keyboard events */}
@@ -54,6 +58,7 @@ export const DatePicker = ({ width = 'auto' }: { width?: 'full' | 'auto' }) => {
 					customQuickSelectRender={customQuickSelectRender}
 					dateFormat={'MMM D • HH:mm'}
 					commonlyUsedRanges={timeRangeOptions()}
+					onRefresh={onRefresh}
 				/>
 			</div>
 		</StopShortcutPropagationWrapper>

--- a/newswires/client/src/DatePicker.tsx
+++ b/newswires/client/src/DatePicker.tsx
@@ -39,7 +39,7 @@ export const DatePicker = ({ width = 'auto' }: { width?: 'full' | 'auto' }) => {
 	);
 
 	const onRefresh = () => {
-		handleRefresh();
+		handleRefresh(config.query);
 	};
 
 	return (

--- a/newswires/client/src/WireItemList.stories.tsx
+++ b/newswires/client/src/WireItemList.stories.tsx
@@ -78,6 +78,7 @@ const mockSearchContext: SearchContextShape = {
 		error: undefined,
 	},
 	handleEnterQuery: () => {},
+	handleRefresh: () => {},
 	handleRetry: () => {},
 	handleSelectItem: () => {},
 	handleDeselectItem: () => {},

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -381,9 +381,21 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 		dispatch({ type: 'RETRY' });
 	};
 
-	const handleRefresh = (query: Query) => {
-		dispatch({ type: 'ENTER_QUERY', query });
-	};
+	const handleRefresh = useCallback(
+		(query: Query) => {
+			sendTelemetryEvent(
+				'NEWSWIRES_REFRESH',
+				Object.fromEntries(
+					Object.entries(query).map(([key, value]) => [
+						`search-query_${key}`,
+						JSON.stringify(value),
+					]),
+				),
+			);
+			dispatch({ type: 'ENTER_QUERY', query });
+		},
+		[sendTelemetryEvent],
+	);
 
 	const handleSelectItem = (item: string) => {
 		setPreviousItemId(undefined);

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -143,6 +143,7 @@ export type SearchContextShape = {
 	viewedItemIds: string[];
 	handleEnterQuery: (query: Query) => void;
 	handleRetry: () => void;
+	handleRefresh: () => void;
 	handleSelectItem: (item: string) => void;
 	handleDeselectItem: () => void;
 	handleNextItem: () => Promise<void>;
@@ -380,6 +381,10 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 		dispatch({ type: 'RETRY' });
 	};
 
+	const handleRefresh = () => {
+		dispatch({ type: 'ENTER_QUERY', query: currentConfig.query });
+	};
+
 	const handleSelectItem = (item: string) => {
 		setPreviousItemId(undefined);
 
@@ -567,6 +572,7 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 				config: currentConfig,
 				state,
 				handleEnterQuery,
+				handleRefresh,
 				handleRetry,
 				handleSelectItem,
 				handleDeselectItem,

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -143,7 +143,7 @@ export type SearchContextShape = {
 	viewedItemIds: string[];
 	handleEnterQuery: (query: Query) => void;
 	handleRetry: () => void;
-	handleRefresh: () => void;
+	handleRefresh: (query: Query) => void;
 	handleSelectItem: (item: string) => void;
 	handleDeselectItem: () => void;
 	handleNextItem: () => Promise<void>;
@@ -381,8 +381,8 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 		dispatch({ type: 'RETRY' });
 	};
 
-	const handleRefresh = () => {
-		dispatch({ type: 'ENTER_QUERY', query: currentConfig.query });
+	const handleRefresh = (query: Query) => {
+		dispatch({ type: 'ENTER_QUERY', query });
 	};
 
 	const handleSelectItem = (item: string) => {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This implements an API refresh when the UI refresh button has been clicked. 

## How to test

- [x] Clicking the refresh button causes a page reload
- [x] Add a preset and check that the refresh button respects this preset
- [x] Change the date filter and check the refresh respects this

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD