### PR TITLE
Add advance fixtures to Soccer Scores preset

### DIFF
--- a/newswires/app/conf/Categories.scala
+++ b/newswires/app/conf/Categories.scala
@@ -97,7 +97,8 @@ private[conf] object CategoryCodes {
       "paCat:SSD",
       "paCat:RRD",
       "paCat:RMS",
-      "paCat:RRA"
+      "paCat:RRA",
+      "paCat:SSF"
     )
   }
 


### PR DESCRIPTION
Advance fixtures (lists of upcoming football matches) were being excluded from all of the soccer presets. This adds them into the Soccer Scores preset (to parallel inclusion of similar fixtures in Rugby Scores).