### PR TITLE
Add switch to hide remaining media direct source feeds

### DIFF
--- a/newswires/app/models/SearchParams.scala
+++ b/newswires/app/models/SearchParams.scala
@@ -57,7 +57,11 @@ object SearchParams {
         preComputedCategoriesExcl = Nil,
         collectionId = baseParams.maybeCollectionId,
         guSourceFeeds = baseParams.guSourceFeeds,
-        guSourceFeedsExcl = baseParams.guSourceFeedsExcl,
+        guSourceFeedsExcl = computeGuSourceFeedExcl(
+          hideMediaDirectFeeds = featureSwitch.HideMediaDirectFeeds.isOn(req),
+          guSourceFeeds = baseParams.guSourceFeeds,
+          guSourceFeedsExcl = baseParams.guSourceFeedsExcl
+        ),
         eventCode = baseParams.eventCode
       ),
       DateRange(
@@ -84,5 +88,26 @@ object SearchParams {
       query.get("supplierExcl").map(_.toList).getOrElse(Nil)
 
     dotCopyExclusion ::: guSuppliersExclusion ::: exclusionFromParams
+  }
+
+  val mediaDirectSourceFeeds = List(
+    "PA",
+    "PA PA RACING DATA",
+    "PA DATA FORMATTING",
+    "PA PA SPORT DATA"
+  )
+
+  def computeGuSourceFeedExcl(
+      hideMediaDirectFeeds: Boolean,
+      guSourceFeeds: List[String],
+      guSourceFeedsExcl: List[String]
+  ): List[String] = {
+    if (guSourceFeeds.nonEmpty || guSourceFeedsExcl.nonEmpty) {
+      guSourceFeedsExcl
+    } else if (hideMediaDirectFeeds) {
+      mediaDirectSourceFeeds
+    } else {
+      Nil
+    }
   }
 }

--- a/newswires/app/service/FeatureSwitchProvider.scala
+++ b/newswires/app/service/FeatureSwitchProvider.scala
@@ -23,8 +23,21 @@ class FeatureSwitchProvider(stage: String) {
       isOn = _ => stage.toUpperCase() != "PROD"
     )
 
+  val HideMediaDirectFeeds: FeatureSwitch =
+    FeatureSwitch(
+      name = "HideMediaDirectFeeds",
+      safeState = Off,
+      description =
+        "Hide media direct source feeds (PA, PA PA RACING DATA, PA DATA FORMATTING, PA PA SPORT DATA)",
+      exposeToClient = true,
+      isOn = _.getQueryString("hideMediaDirectFeeds")
+        .flatMap(_.toBooleanOption)
+        .getOrElse(false)
+    )
+
   private val switches = List(
-    ShowGuSuppliers
+    ShowGuSuppliers,
+    HideMediaDirectFeeds
   )
   def clientSideSwitchStates(request: Request[_]): Map[String, Boolean] =
     switches.filter(_.exposeToClient).map(s => s.name -> s.isOn(request)).toMap

--- a/newswires/app/service/FeatureSwitchProvider.scala
+++ b/newswires/app/service/FeatureSwitchProvider.scala
@@ -27,9 +27,7 @@ class FeatureSwitchProvider(stage: String) {
     FeatureSwitch(
       name = "HideMediaDirectFeeds",
       safeState = Off,
-      description =
-        "Hide media direct source feeds (PA, PA PA RACING DATA, PA DATA FORMATTING, PA PA SPORT DATA)",
-      exposeToClient = true,
+      description = "Hide media direct source feeds",
       isOn = _.getQueryString("hideMediaDirectFeeds")
         .flatMap(_.toBooleanOption)
         .getOrElse(false)

--- a/newswires/client/src/SearchSummary/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary/SearchSummary.tsx
@@ -29,6 +29,7 @@ const SearchTermBadgeLabelLookup: Record<DeselectableQueryKey, string> = {
 	categoryCode: 'Category',
 	categoryCodeExcl: '(NOT) Category',
 	hasDataFormatting: 'Has data formatting',
+	hideMediaDirectFeeds: 'Hide media direct feeds',
 	keyword: 'Keyword',
 	keywordExcl: '(NOT) Keyword',
 	guSourceFeed: 'Source feed',
@@ -99,6 +100,7 @@ const Summary = ({
 		categoryCode,
 		categoryCodeExcl,
 		hasDataFormatting,
+		hideMediaDirectFeeds,
 		collectionId,
 		eventCode: eventCode,
 	} = query;
@@ -132,6 +134,7 @@ const Summary = ({
 		displayGuSourceFeeds ||
 		displayExcludedGuSourceFeeds ||
 		hasDataFormatting !== undefined ||
+		hideMediaDirectFeeds !== undefined ||
 		collectionId !== undefined ||
 		eventCode !== undefined;
 
@@ -244,6 +247,14 @@ const Summary = ({
 					keyValuePair={{
 						key: 'hasDataFormatting',
 						value: hasDataFormatting ? 'true' : 'false',
+					}}
+				/>
+			)}
+			{hideMediaDirectFeeds !== undefined && (
+				<SummaryBadge
+					keyValuePair={{
+						key: 'hideMediaDirectFeeds',
+						value: hideMediaDirectFeeds ? 'true' : 'false',
 					}}
 				/>
 			)}

--- a/newswires/client/src/SettingsMenu.tsx
+++ b/newswires/client/src/SettingsMenu.tsx
@@ -9,7 +9,10 @@ import {
 } from '@elastic/eui';
 import moment from 'moment-timezone';
 import { useState } from 'react';
-import { SHOW_GU_SUPPLIERS } from './app-configuration';
+import {
+	HIDE_MEDIA_DIRECT_FEEDS,
+	SHOW_GU_SUPPLIERS,
+} from './app-configuration';
 import { StopShortcutPropagationWrapper } from './context/KeyboardShortcutsContext';
 import { useUserSettings } from './context/UserSettingsContext';
 import { useSettingsSwitches } from './SettingsSwitches.tsx';
@@ -96,6 +99,9 @@ export const SettingsMenu = () => {
 			items: [
 				{
 					name: `Show Gu suppliers: ${SHOW_GU_SUPPLIERS ? 'On' : 'Off'}`,
+				},
+				{
+					name: `Hide media direct feeds: ${HIDE_MEDIA_DIRECT_FEEDS ? 'On' : 'Off'}`,
 				},
 			],
 		},

--- a/newswires/client/src/app-configuration.ts
+++ b/newswires/client/src/app-configuration.ts
@@ -13,6 +13,7 @@ const configLookup: AppConfiguration = isJest
 	? {
 			switches: {
 				ShowGuSuppliers: false,
+				HideMediaDirectFeeds: false,
 			},
 			stage: 'test',
 			sendTelemetryAsDev: true,
@@ -21,6 +22,8 @@ const configLookup: AppConfiguration = isJest
 	: window.configuration;
 
 export const SHOW_GU_SUPPLIERS = configLookup.switches.ShowGuSuppliers;
+export const HIDE_MEDIA_DIRECT_FEEDS =
+	configLookup.switches.HideMediaDirectFeeds;
 
 /**
  * The list of suppliers to exclude from the list of 'recognised suppliers' that

--- a/newswires/client/src/queryHelpers.ts
+++ b/newswires/client/src/queryHelpers.ts
@@ -43,9 +43,14 @@ export const queryAfterDeselection = (
 		};
 	}
 	if (
-		['hasDataFormatting', 'start', 'end', 'collectionId', 'eventCode'].includes(
-			key,
-		)
+		[
+			'hasDataFormatting',
+			'hideMediaDirectFeeds',
+			'start',
+			'end',
+			'collectionId',
+			'eventCode',
+		].includes(key)
 	) {
 		return { ...query, [key]: undefined };
 	}

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -178,6 +178,7 @@ export const BaseQuerySchema = z.object({
 	start: EuiDateStringSchema.optional(),
 	end: EuiDateStringSchema.optional(),
 	hasDataFormatting: z.boolean().optional(),
+	hideMediaDirectFeeds: z.boolean().optional(),
 	eventCode: z.string().optional(),
 });
 export type BaseQuery = z.infer<typeof BaseQuerySchema>;

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -18,6 +18,7 @@ export const defaultQuery: Query = {
 	start: DEFAULT_DATE_RANGE.start,
 	end: DEFAULT_DATE_RANGE.end,
 	hasDataFormatting: undefined,
+	hideMediaDirectFeeds: undefined,
 	collectionId: undefined,
 	eventCode: undefined,
 };
@@ -71,6 +72,9 @@ function searchParamsToQuery(params: URLSearchParams): Query {
 	const hasDataFormatting = maybeStringToBooleanOrUndefined(
 		params.get('hasDataFormatting'),
 	);
+	const hideMediaDirectFeeds = maybeStringToBooleanOrUndefined(
+		params.get('hideMediaDirectFeeds'),
+	);
 	const eventCode = params.get('eventCode') ?? undefined;
 	let collectionId: number | undefined = undefined;
 
@@ -103,6 +107,7 @@ function searchParamsToQuery(params: URLSearchParams): Query {
 		start,
 		end,
 		hasDataFormatting,
+		hideMediaDirectFeeds,
 		eventCode,
 	};
 

--- a/newswires/client/src/windowConfigType.ts
+++ b/newswires/client/src/windowConfigType.ts
@@ -1,5 +1,6 @@
 interface FeatureSwitches {
 	ShowGuSuppliers: boolean;
+	HideMediaDirectFeeds: boolean;
 }
 
 export interface AppConfiguration {

--- a/newswires/test/models/SearchParamsSpec.scala
+++ b/newswires/test/models/SearchParamsSpec.scala
@@ -203,6 +203,13 @@ class SearchParamsSpec extends AnyFlatSpec with models {
       guSourceFeedsExcl = List("excluded-feed")
     )
     result shouldEqual List("excluded-feed")
+
+    val result2 = SearchParams.computeGuSourceFeedExcl(
+      hideMediaDirectFeeds = true,
+      guSourceFeeds = List("some-feed"),
+      guSourceFeedsExcl = Nil
+    )
+    result2 shouldEqual Nil
   }
 
   it should "pass through guSourceFeedsExcl unchanged when guSourceFeedsExcl is non-empty" in new searchParamsMocks {

--- a/newswires/test/models/SearchParamsSpec.scala
+++ b/newswires/test/models/SearchParamsSpec.scala
@@ -1,7 +1,7 @@
 package models
 
 import conf.SearchField.Slug
-import conf.{AND, CategoryCodesCondition, ComboTerm, OR, SOME, SearchTerm}
+import conf._
 import helpers.models
 import org.mockito.Mockito.when
 import org.scalatest.flatspec.AnyFlatSpec
@@ -178,6 +178,50 @@ class SearchParamsSpec extends AnyFlatSpec with models {
 
   behavior of "computeGuSourceFeedExcl"
 
+  it should "return empty list when hideMediaDirectFeeds is false and no guSourceFeed is explicitly set" in new searchParamsMocks {
+    val result = SearchParams.computeGuSourceFeedExcl(
+      hideMediaDirectFeeds = false,
+      guSourceFeeds = Nil,
+      guSourceFeedsExcl = Nil
+    )
+    result shouldEqual Nil
+  }
+
+  it should "exclude media direct source feeds when hideMediaDirectFeeds is true and no guSourceFeed is explicitly set" in new searchParamsMocks {
+    val result = SearchParams.computeGuSourceFeedExcl(
+      hideMediaDirectFeeds = true,
+      guSourceFeeds = Nil,
+      guSourceFeedsExcl = Nil
+    )
+    result shouldEqual SearchParams.mediaDirectSourceFeeds
+  }
+
+  it should "pass through guSourceFeedsExcl unchanged when guSourceFeeds is non-empty" in new searchParamsMocks {
+    val result = SearchParams.computeGuSourceFeedExcl(
+      hideMediaDirectFeeds = true,
+      guSourceFeeds = List("some-feed"),
+      guSourceFeedsExcl = List("excluded-feed")
+    )
+    result shouldEqual List("excluded-feed")
+  }
+
+  it should "pass through guSourceFeedsExcl unchanged when guSourceFeedsExcl is non-empty" in new searchParamsMocks {
+    val result = SearchParams.computeGuSourceFeedExcl(
+      hideMediaDirectFeeds = true,
+      guSourceFeeds = Nil,
+      guSourceFeedsExcl = List("excluded-feed")
+    )
+    result shouldEqual List("excluded-feed")
+  }
+
+  it should "apply media direct feed exclusions via SearchParams.build when hideMediaDirectFeeds is on" in new searchParamsMocks {
+    val result = SearchParams.build(
+      emptyQueryString,
+      emptyBaseParams,
+      hideMediaDirectFeedsOn
+    )(FakeRequest())
+    result.filters.guSourceFeedsExcl shouldEqual SearchParams.mediaDirectSourceFeeds
+  }
 }
 
 trait searchParamsMocks {
@@ -185,6 +229,7 @@ trait searchParamsMocks {
   val emptyQueryString = Map[String, Seq[String]]()
   val featureSwitchesOn = mock[FeatureSwitchProvider]
   val showGuSuppliersFeatureOff = mock[FeatureSwitchProvider]
+  val hideMediaDirectFeedsOn = mock[FeatureSwitchProvider]
   val featureSwitch = FeatureSwitch(
     name = "",
     safeState = Off,
@@ -193,7 +238,15 @@ trait searchParamsMocks {
     isOn = _ => true
   )
   when(featureSwitchesOn.ShowGuSuppliers).thenReturn(featureSwitch)
+  when(featureSwitchesOn.HideMediaDirectFeeds).thenReturn(
+    featureSwitch.copy(isOn = _ => false)
+  )
   when(showGuSuppliersFeatureOff.ShowGuSuppliers).thenReturn(
     featureSwitch.copy(isOn = _ => false)
   )
+  when(showGuSuppliersFeatureOff.HideMediaDirectFeeds).thenReturn(
+    featureSwitch.copy(isOn = _ => false)
+  )
+  when(hideMediaDirectFeedsOn.ShowGuSuppliers).thenReturn(featureSwitch)
+  when(hideMediaDirectFeedsOn.HideMediaDirectFeeds).thenReturn(featureSwitch)
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add a switch to hide remaining 'media direct' source feeds which PA are replacing with their API. Off by default at the moment, but can be set using `?hideMediaDirectFeeds=true`

Modelled after the switch we had before, removed in 3546e6eb. Given that we had a full, clear example of what to do, it seemed like a good example to test out asking Claude to generate the whole thing. I have subsequently reviewed each of the changes by hand though, and tweaked a couple of the test cases. The initial generation was much quicker than it would have taken me to restore the old code and then tweak it accordingly. That said, I then spent a lot more time reviewing it before opening this PR, compared to what I would have done with code I'd hand-written, so I'm not sure if it saved time overall. The initial generation from the example + a minimal prompt was very good, though, even with Sonnet.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Run locally or in CODE
- [x] Verify that nothing is hidden by default
- [x] Visit `feed?hideMediaDirectFeeds=true` and verify that media direct feeds are not hidden
- [x] Visit `feed?hideMediaDirectFeeds=true` and verify that media direct feeds are hidden
- [x] Set some explicit exclusions or inclusions and verify that they override the top-level switch.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD