### PR TITLE
Add missing RugbyL and RugbyU fixtures to scores preset

### DIFF
--- a/newswires/app/conf/Categories.scala
+++ b/newswires/app/conf/Categories.scala
@@ -224,7 +224,8 @@ private[conf] object CategoryCodes {
       "paCat:SFU",
       "paCat:STE",
       "paCat:SSD",
-      "paCat:STF"
+      "paCat:STF",
+      "paCat:SSF"
     )
   }
   object HorseRacing {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Some advance fixtures (lists of upcoming Rugby Union and Rugby League games) were being excluded from the rugby presets. This adds them into the Rugby Scores preset.