### PR TITLE
Add missing sports results to presets

### DIFF
--- a/newswires/app/conf/Categories.scala
+++ b/newswires/app/conf/Categories.scala
@@ -68,6 +68,7 @@ private[conf] object CategoryCodes {
     val PA: List[String] = List(
       "paCat:SRS", // General Sport News
       "paCat:SSS", // General Sport News
+      "paCat:RSR", // General Sport Results
       "paCat:SSO", // Soccer News
       "paCat:SCR", // Cricket News
       "paCat:SRR", // Racing News

--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -747,7 +747,8 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("TENNIS", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME)),
+      categoryCodesExcl = List("paCat:RSR")
     ),
     SearchPreset(
       AFP,
@@ -812,7 +813,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("auto OR MOTO", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:RSR"), SOME))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
     ),
     SearchPreset(
       AFP,
@@ -927,7 +928,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("ICEHOCKEY", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:RSR"), SOME))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
     ),
     SearchPreset(
       AFP,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The cycling preset was missing results content from PA. This adds the general sport results category code to the list of PA sport codes to correct this. This change also adds missing results to the athletics preset.

## How to test

Missing results in cycling and athletics present in the presets on this branch, checked against PROD. 
