### PR TITLE
Exclude remaining media direct stories from presets where we're receiving an alternative feed

### DIFF
--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -882,8 +882,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("GOLF", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME))
     ),
     SearchPreset(
       AP,

--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -19,7 +19,9 @@ object SearchPreset {
       keywordExcl: List[String] = Nil,
       hasDataFormatting: Option[Boolean] = None,
       preComputedCategories: List[String] = Nil,
-      preComputedCategoriesExcl: List[String] = Nil
+      preComputedCategoriesExcl: List[String] = Nil,
+      guSourceFeeds: List[String] = Nil,
+      guSourceFeedsExcl: List[String] = Nil
   ): FilterParams =
     FilterParams(
       searchTerms = searchTerms,
@@ -33,8 +35,8 @@ object SearchPreset {
       preComputedCategories = preComputedCategories,
       preComputedCategoriesExcl = preComputedCategoriesExcl,
       collectionId = None,
-      guSourceFeeds = Nil,
-      guSourceFeedsExcl = Nil,
+      guSourceFeeds = guSourceFeeds,
+      guSourceFeedsExcl = guSourceFeedsExcl,
       eventCode = None
     )
 }

--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -3,7 +3,7 @@ package conf
 import conf.SearchField.{BodyText, Headline, Slug}
 import conf.SearchTerm.SingleField
 import conf.Suppliers._
-import models.{FilterParams}
+import models.{FilterParams, SearchParams}
 
 // Increase max line length to improve readability of search presets
 // scalafmt: { maxColumn = 120 }
@@ -394,7 +394,8 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("-RUGBY -RUGBYU -RUGBYL", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.SoccerScores.PA, SOME))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.SoccerScores.PA, SOME)),
+      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
     ),
     SearchPreset(PA, searchTerms = Some(SingleTerm(SingleField("\"SOCCER TABULATED RESULTS\"", Slug)))),
     SearchPreset(
@@ -419,7 +420,8 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = None,
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.SoccerTables.PA, SOME))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.SoccerTables.PA, SOME)),
+      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
     )
   )
   // SoccerTablesDataFormats
@@ -555,7 +557,8 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("BASKETBALL", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME))
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME)),
+      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
     ),
     SearchPreset(
       AP,
@@ -651,7 +654,8 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("RUGBYL -Scorer", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME)),
+      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
     ),
     SearchPreset(
       AFP,
@@ -661,7 +665,8 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("RUGBYL -SOCCER Summaries", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME)),
+      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
     ),
     SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyLeague.AAP, SOME))),
     SearchPreset(
@@ -681,12 +686,14 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("\"RUGBY UNION\" OR RUGBYU -SOCCER Summaries", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME)),
+      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("\"RUGBY UNION\" OR RUGBYU -Scorer", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:SFF"), SOME))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:SFF"), SOME)),
+      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
     ),
     SearchPreset(
       AFP,
@@ -706,19 +713,22 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("-SOCCER -Summaries", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME)),
+      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("RUGBY", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:RFC"), SOME))
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RFC"), SOME)),
+      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
     ),
     SearchPreset(
       PA,
       searchTerms = Some(
         SingleTerm(SingleField("RUGBYU Scorer OR RUGBYL Scorer", Slug))
       ),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME)),
+      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
     ),
     SearchPreset(
       AFP,
@@ -775,7 +785,8 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("TENNIS -\"ATP Challenger\"", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME))
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME)),
+      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
     ),
     SearchPreset(
       AFP,
@@ -794,7 +805,8 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("CYCLING", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME)),
+      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
     ),
     SearchPreset(
       AFP,
@@ -815,7 +827,8 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("auto OR MOTO", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME)),
+      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
     ),
     SearchPreset(
       AFP,
@@ -869,7 +882,8 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("GOLF", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME))
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME)),
+      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
     ),
     SearchPreset(
       AP,
@@ -930,7 +944,8 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("ICEHOCKEY", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME)),
+      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
     ),
     SearchPreset(
       AFP,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

We're getting the new API feeds for all sports except Cricket and Racing, now. So we can filter out stories received via Media Direct from the following presets:

* Soccer scores
* Soccer tables
* Basketball scores
* Cycling
* ~Golf scores~ (see discussion below)
* Ice hockey
* Motor sport
* Rugby league
* Rugby union
* Rugby scores
* Tennis scores

We don't expect to find MD stories in any other presets (other than Cricket and Racing ones). Filtering these out helps us to preview the switch-off of the MD feeds later this month, while keeping all stories available via 'All' or 'All sports' presets, as a fallback in case there are any gaps in the new API feed.

Co-authored-by: hk-15 <168672047+hk-15@users.noreply.github.com>

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Run locally and compare the following two URLs. You should see some stories in CODE but none in local:
    - https://newswires.code.dev-gutools.co.uk/feed?guSourceFeed=PA+PA+SPORT+DATA&preset=soccer-scores
    - https://newswires.local.dev-gutools.co.uk/feed?guSourceFeed=PA+PA+SPORT+DATA&preset=soccer-scores

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD