### PR TITLE
Add badge to media direct stories

### DIFF
--- a/newswires/client/src/Item.stories.tsx
+++ b/newswires/client/src/Item.stories.tsx
@@ -48,6 +48,7 @@ const sampleItemData: WireData = {
 	collections: [],
 	isAlert: false,
 	isLead: false,
+	isMediaDirectItem: false,
 	ingestedAtMoment: new InstantMoment(moment('2025-02-26T09:58:22.000Z')),
 };
 

--- a/newswires/client/src/Item.stories.tsx
+++ b/newswires/client/src/Item.stories.tsx
@@ -154,6 +154,27 @@ export const WithAlertLabel: Story = {
 	},
 };
 
+export const WithMultipleLabels: Story = {
+	args: {
+		itemData: {
+			...sampleItemData,
+			isAlert: true,
+			isLead: true,
+			isMediaDirectItem: true,
+			content: {
+				...sampleItemData.content,
+				slug: 'SAMPLE-WIRE-WITH-EXTRA-LONG-HEADLINE AND-SUBHEAD-With-no-breaks-to-test-overflow-handling-in-the-UI',
+			},
+		},
+		error: undefined,
+		handleDeselectItem: () => console.log('deselect clicked'),
+		handlePreviousItem: () => console.log('previous item clicked'),
+		handleNextItem: () => Promise.resolve(console.log('next item clicked')),
+		addToolLink: () => console.log('add tool link'),
+		refreshItemData: () => console.log('refresh item data'),
+	},
+};
+
 export const WithToolLinks: Story = {
 	args: {
 		itemData: {

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -40,7 +40,11 @@ import { ToolsConnection, ToolSendReport } from './ToolsConnection.tsx';
 import { Tooltip } from './Tooltip.tsx';
 import { configToUrl } from './urlState.ts';
 import type { InstantMoment } from './utils/date/InstantMoment.ts';
-import { AlertLabel, LeadLabel } from './WireItemLabel.tsx';
+import {
+	AlertLabel,
+	LeadLabel,
+	MediaDirectItemLabel,
+} from './WireItemLabel.tsx';
 
 function TitleContentForItem({
 	slug,
@@ -51,6 +55,7 @@ function TitleContentForItem({
 	wordCount,
 	isAlert,
 	isLead,
+	isMediaDirectItem,
 }: {
 	slug?: string;
 	subhead?: string;
@@ -60,6 +65,7 @@ function TitleContentForItem({
 	wordCount: number;
 	isAlert: boolean;
 	isLead: boolean;
+	isMediaDirectItem: boolean;
 }) {
 	const theme = useEuiTheme();
 	const MAX_SUBHEAD_LENGTH = 250;
@@ -160,6 +166,7 @@ function TitleContentForItem({
 					`}
 				>
 					<SupplierBadge supplier={supplier} />
+					{isMediaDirectItem && <MediaDirectItemLabel />}
 					{isAlert && <AlertLabel outlined={true} />}
 					{isLead && <LeadLabel outlined={true} />}
 				</div>
@@ -734,6 +741,7 @@ export const WireDetail = ({
 				wordCount={wordCount}
 				isAlert={wire.isAlert}
 				isLead={wire.isLead}
+				isMediaDirectItem={wire.isMediaDirectItem}
 			/>
 			<EuiSpacer size="s" />
 			{isShowingJson ? (

--- a/newswires/client/src/WireItemLabel.tsx
+++ b/newswires/client/src/WireItemLabel.tsx
@@ -54,6 +54,27 @@ export const AlertLabel = ({
 	);
 };
 
+export const MediaDirectItemLabel = ({
+	hoverParentClassName,
+}: {
+	hoverParentClassName?: string;
+}) => {
+	const { euiTheme } = useEuiTheme();
+	const leadLabelTheme = {
+		backgroundColour: euiTheme.colors.backgroundBaseSubdued,
+		textColour: euiTheme.colors.textSubdued,
+		borderColour: euiTheme.colors.textSubdued,
+	};
+	return (
+		<WireItemLabel
+			label={'MD'}
+			hoverParentClassName={hoverParentClassName}
+			theme={leadLabelTheme}
+			outlined={true}
+		/>
+	);
+};
+
 export const WireItemLabel = ({
 	label,
 	theme: { borderColour, backgroundColour, textColour },

--- a/newswires/client/src/WireItemList.stories.tsx
+++ b/newswires/client/src/WireItemList.stories.tsx
@@ -291,6 +291,27 @@ export const WithDataFormatting: Story = {
 	},
 };
 
+export const WithDataFormattingAndMediaDirectItemBadge: Story = {
+	args: {
+		wires: [
+			{
+				...sampleItemData,
+				hasDataFormatting: true,
+				isMediaDirectItem: true,
+			},
+			{
+				...sampleItemData,
+				hasDataFormatting: true,
+				isMediaDirectItem: true,
+				id: 67890,
+			},
+		],
+		totalCount: 1,
+		showCollectionMetadata: false,
+		showSecondaryFeedContent: false,
+	},
+};
+
 export const WithLongTitleSlugAndSubheading: Story = {
 	args: {
 		wires: [

--- a/newswires/client/src/WireItemList.stories.tsx
+++ b/newswires/client/src/WireItemList.stories.tsx
@@ -52,6 +52,7 @@ const sampleItemData: WireData = {
 	collections: [],
 	isAlert: false,
 	isLead: false,
+	isMediaDirectItem: false,
 	ingestedAtMoment: new InstantMoment(moment(now.toISOString())),
 };
 

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -21,7 +21,11 @@ import { Link } from './Link.tsx';
 import type { WireData } from './sharedTypes.ts';
 import { SupplierBadge } from './SupplierBadge.tsx';
 import { ToolSendReport } from './ToolsConnection.tsx';
-import { AlertLabel, LeadLabel } from './WireItemLabel.tsx';
+import {
+	AlertLabel,
+	LeadLabel,
+	MediaDirectItemLabel,
+} from './WireItemLabel.tsx';
 
 export const WireItemList = ({
 	wires,
@@ -201,6 +205,7 @@ const WirePreviewCard = ({
 		hasDataFormatting,
 		isAlert,
 		isLead,
+		isMediaDirectItem,
 	} = wire;
 
 	const ref = useRef<HTMLDivElement>(null);
@@ -386,8 +391,16 @@ const WirePreviewCard = ({
 						grid-area: badges;
 						justify-self: end;
 						align-self: flex-start;
+						display: flex;
+						gap: 0.3rem;
+						align-items: center;
 					`}
 				>
+					{isMediaDirectItem && (
+						<MediaDirectItemLabel
+							hoverParentClassName={classNameForStylingLabelsOnCardHover}
+						/>
+					)}
 					{hasDataFormatting && (
 						<EuiIcon type="visTable" size="m" title="Has data formatting" />
 					)}

--- a/newswires/client/src/context/transformQueryResponse.ts
+++ b/newswires/client/src/context/transformQueryResponse.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import type { SupplierInfo, WireData, WireDataFromAPI } from '../sharedTypes';
 import { supplierData, UNKNOWN_SUPPLIER } from '../suppliers';
-import { isAlert, isLead } from '../utils/contentHelpers';
+import { isAlert, isLead, isMediaDirectItem } from '../utils/contentHelpers';
 import { InstantMoment } from '../utils/date/InstantMoment';
 
 function enhanceSupplier(supplier: string): SupplierInfo {
@@ -16,5 +16,6 @@ export function transformWireItemQueryResult(data: WireDataFromAPI): WireData {
 		ingestedAtMoment: new InstantMoment(moment(data.ingestedAt)),
 		supplier: enhanceSupplier(data.supplier),
 		hasDataFormatting: data.content.composerCompatible === false, // if composerCompatible is missing or true, we assume true
+		isMediaDirectItem: isMediaDirectItem(data),
 	};
 }

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -143,6 +143,7 @@ export type WireData = Omit<WireDataFromAPI, 'supplier'> & {
 	ingestedAtMoment: InstantMoment;
 	isAlert: boolean;
 	isLead: boolean;
+	isMediaDirectItem: boolean;
 };
 
 export type WiresQueryData = {

--- a/newswires/client/src/tests/fixtures/wireData.ts
+++ b/newswires/client/src/tests/fixtures/wireData.ts
@@ -51,5 +51,6 @@ export const sampleWireData: WireData = {
 	hasDataFormatting: false,
 	isAlert: false,
 	isLead: false,
+	isMediaDirectItem: false,
 	ingestedAtMoment: new InstantMoment(moment(sampleWireResponse.ingestedAt)),
 };

--- a/newswires/client/src/utils/contentHelpers.ts
+++ b/newswires/client/src/utils/contentHelpers.ts
@@ -1,7 +1,19 @@
-import type { WireData } from '../sharedTypes.ts';
+import type { WireData, WireDataFromAPI } from '../sharedTypes.ts';
 
 export const isAlert = (content: WireData['content']) =>
 	content.type === 'text' && content.profile === 'alert';
 
 export const isLead = (content: WireData['content']) =>
 	content.type === 'composite' && content.profile === 'story';
+
+const mediaDirectSourceFeeds = [
+	'PA',
+	'PA PA RACING DATA',
+	'PA DATA FORMATTING',
+	'PA PA SPORT DATA',
+];
+
+export const isMediaDirectItem = (wireData: WireDataFromAPI) => {
+	const { guSourceFeed } = wireData;
+	return mediaDirectSourceFeeds.includes(guSourceFeed);
+};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

Co-authored-by: Holly Knox <168672047+hk-15@users.noreply.github.com>

## What does this change?

Add a 'MD' badge to stories that have come from Media Direct (legacy PA delivery source), to help us identify these stories as they're being phased out.

The code follows the pattern set for other badges (`lead` and `alert`): enhance the wire item in the client on ingestion to work out if `isMediaDirectItem`, then use this in subsequent rendering code.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Run storybook and check out:
    - [x] http://localhost:6006/?path=/story/components-wireitemlist--with-data-formatting-and-media-direct-item-badge
    - [x] http://localhost:6006/?path=/story/components-item--with-multiple-labels
- [x] Run app locally and verify that badges appear only on media direct stories 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<img width="823" height="337" alt="image" src="https://github.com/user-attachments/assets/1b1fcf82-d099-4bdc-aecc-a74895638fe6" />


<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD