### PR TITLE
ADRs for post-ingestion enhancements and for preset definitions

### DIFF
--- a/docs/adrs/03-post-ingestion-enhancement.md
+++ b/docs/adrs/03-post-ingestion-enhancement.md
@@ -34,7 +34,7 @@ What about the user who has P2 open?
     1. At the top, in which case it will potentially be out of chronological order with other items (sorted by ingestion time).
     2. In its chronological place, in which case it might not be at the top of the list, or even visible in the user's viewport at the time it loads.
 
-Neither (2.1) nor (2.2) feels ideal, and either option would also introduce a difference between the experience of P1 and P2 which would be impossible for end-users to diagnose.
+Neither (2.i) nor (2.ii) feels ideal, and either option would also introduce a difference between the experience of P1 and P2 which would be impossible for end-users to diagnose.
 
 ## Decision
 

--- a/docs/adrs/03-post-ingestion-enhancement.md
+++ b/docs/adrs/03-post-ingestion-enhancement.md
@@ -31,10 +31,10 @@ What about the user who has P2 open?
 
 1. We could just say they don't get to see it in their feed, although it will naturally show if they freshly load P2 after T2, but this seems like poor service.
 2. We could load S into their feed at T2, but then where should we place it in their feed?
-    i. At the top, in which case it will potentially be out of chronological order with other items (sorted by ingestion time).
-    ii. In its chronological place, in which case it might not be at the top of the list, or even visible in the user's viewport at the time it loads.
+    1. At the top, in which case it will potentially be out of chronological order with other items (sorted by ingestion time).
+    2. In its chronological place, in which case it might not be at the top of the list, or even visible in the user's viewport at the time it loads.
 
-Neither (2.i) nor (2.ii) feels ideal, and either option would also introduce a difference between the experience of P1 and P2 which would be impossible for end-users to diagnose.
+Neither (2.1) nor (2.2) feels ideal, and either option would also introduce a difference between the experience of P1 and P2 which would be impossible for end-users to diagnose.
 
 ## Decision
 

--- a/docs/adrs/03-post-ingestion-enhancement.md
+++ b/docs/adrs/03-post-ingestion-enhancement.md
@@ -4,7 +4,7 @@
 
 One advantage of having our own persistent storage for wire items (see [ADR 01](./01-newswires-overview.md)) is that it gives us more opportunities to enhance the metadata that's available for a given wire item. Example use-cases include:
 
-- Mapping Fingerpost's 'source feed' field [to our 'supplier' field](https://github.com/guardian/newswires/blob/9ede2e190239f087d91c7539ab6f983f1f1a1fd3/ingestion-lambda/src/processContentObject.ts#L254)
+- Mapping Fingerpost's 'source feed' field [to our 'supplier' field](https://github.com/guardian/newswires/blob/2c9a5e2c735f4455195b8d2fdd290bb18a89e6ca/ingestion-lambda/src/processContentObject.ts#L254)
 - Inferring whether a story is pertinent to the UK desk (https://github.com/guardian/newswires/pull/235)
 - Adding a TS vector index to enable better full text search
 

--- a/docs/adrs/03-post-ingestion-enhancement.md
+++ b/docs/adrs/03-post-ingestion-enhancement.md
@@ -1,4 +1,4 @@
-# ADR 02: Post-ingestion enhancement of wire items
+# ADR 03: Post-ingestion enhancement of wire items
 
 ## Context
 
@@ -10,7 +10,7 @@ One advantage of having our own persistent storage for wire items (see [ADR 01](
 
 Any such enhancement needs to either:
 
-1. blocks the story from being initially persisted in our database, or
+1. block the story from being initially persisted in our database, or
 2. take place in a non-blocking way, either asynchronously or triggered after ingestion
 
 ## Options
@@ -38,6 +38,6 @@ Neither (b.i) nor (b.ii) feels ideal, and either option would also introduce a d
 
 ## Decision
 
-We have decided not to do asynchronous or post-ingestion enhancements of wire items if the enhancement concerns attributes which we user for constructing live feeds. Given that, as per [the ADR on Filter and Search](./02-filter-and-search.md), we are aiming to model everything via the idea of a unified filter/search view presented to the user, this effectively means that we aren't doing asynchronous enhancement at the moment. However, there's no reason in principle why we couldn't add asynchronous enhancement in the future if we add other discovery/browsing features ('trending topics' might be a good example).
+We have decided not to do asynchronous or post-ingestion enhancements of wire items if the enhancement concerns attributes which we use for constructing live feeds. Given that, as per [the ADR on Filter and Search](./02-filter-and-search.md), we are aiming to model everything via the idea of a unified filter/search view presented to the user, this effectively means that we aren't doing asynchronous enhancement at the moment. However, there's no reason in principle why we couldn't add asynchronous enhancement in the future if we add other discovery/browsing features ('trending topics' might be a good example).
 
 At the same time, we also want to limit the amount of pre-ingestion enhancement that we're doing, because it blocks ingestion. As things stand, this is left to judgement rather than firm rules, as we don't have an SLO governing time to ingestion.

--- a/docs/adrs/03-post-ingestion-enhancement.md
+++ b/docs/adrs/03-post-ingestion-enhancement.md
@@ -1,0 +1,43 @@
+# ADR 02: Post-ingestion enhancement of wire items
+
+## Context
+
+One advantage of having our own persistent storage for wire items (see [ADR 01](./01-newswires-overview.md)) is that it gives us more opportunities to enhance the metadata that's available for a given wire item. Example use-cases include:
+
+- Mapping Fingerpost's 'source feed' field [to our 'supplier' field](https://github.com/guardian/newswires/blob/9ede2e190239f087d91c7539ab6f983f1f1a1fd3/ingestion-lambda/src/processContentObject.ts#L254)
+- Inferring whether a story is pertinent to the UK desk (https://github.com/guardian/newswires/pull/235)
+- Adding a TS vector index to enable better full text search
+
+Any such enhancement needs to either:
+
+1. blocks the story from being initially persisted in our database, or
+2. take place in a non-blocking way, either asynchronously or triggered after ingestion
+
+## Options
+
+### Enhancement blocks ingestion
+
+If enhancement steps block ingestion, then it follows that ingestion will be delayed by the amount of time it takes to run enhancements. Not all stories are consumed 'live', but our user research has shown clearly that users sometimes monitor the wires from moment to moment to receive new updates on a story which might affect the filing of a story to the site/app. It is therefore important to minimise the amount of blocking in our ingestion pipeline as a whole, including enhancement.
+
+### Asynchronous or post-ingestion enhancement
+
+If we apply enhancements asynchronously, or post-ingestion, we can spend more time on the computation without blocking ingestion. A possible example would be running more complex natural language processing to supplement our categorisation of stories.
+
+Post-ingestion enhancement introduces a significant complication, however. Imagine that the enhancement of a story S affects how S is categorised by preset or user-defined filters. On ingestion at time T1, it fits the criteria for preset P1, and then some time later at T2 an enhancement is added which means it also fits the criteria for P2. Now imagine that users are watching feeds of P1 and P2.
+
+The user who has P1 open from T0 to T2 will see story S show up just after T1.
+
+What about the user who has P2 open?
+
+a. We could just say they don't get to see it in their feed, although it will naturally show if they freshly load P2 after T2, but this seems like poor service.
+b. We could load S into their feed at T2, but then where should we place it in their feed?
+i. At the top, in which case it will potentially be out of chronological order with other items (sorted by ingestion time).
+ii. In its chronological place, in which case it might not be at the top of the list, or even visible in the user's viewport at the time it loads.
+
+Neither (b.i) nor (b.ii) feels ideal, and either option would also introduce a difference between the experience of P1 and P2 which would be impossible for end-users to diagnose.
+
+## Decision
+
+We have decided not to do asynchronous or post-ingestion enhancements of wire items if the enhancement concerns attributes which we user for constructing live feeds. Given that, as per [the ADR on Filter and Search](./02-filter-and-search.md), we are aiming to model everything via the idea of a unified filter/search view presented to the user, this effectively means that we aren't doing asynchronous enhancement at the moment. However, there's no reason in principle why we couldn't add asynchronous enhancement in the future if we add other discovery/browsing features ('trending topics' might be a good example).
+
+At the same time, we also want to limit the amount of pre-ingestion enhancement that we're doing, because it blocks ingestion. As things stand, this is left to judgement rather than firm rules, as we don't have an SLO governing time to ingestion.

--- a/docs/adrs/03-post-ingestion-enhancement.md
+++ b/docs/adrs/03-post-ingestion-enhancement.md
@@ -29,12 +29,12 @@ The user who has P1 open from T0 to T2 will see story S show up just after T1.
 
 What about the user who has P2 open?
 
-a. We could just say they don't get to see it in their feed, although it will naturally show if they freshly load P2 after T2, but this seems like poor service.
-b. We could load S into their feed at T2, but then where should we place it in their feed?
-i. At the top, in which case it will potentially be out of chronological order with other items (sorted by ingestion time).
-ii. In its chronological place, in which case it might not be at the top of the list, or even visible in the user's viewport at the time it loads.
+1. We could just say they don't get to see it in their feed, although it will naturally show if they freshly load P2 after T2, but this seems like poor service.
+2. We could load S into their feed at T2, but then where should we place it in their feed?
+    i. At the top, in which case it will potentially be out of chronological order with other items (sorted by ingestion time).
+    ii. In its chronological place, in which case it might not be at the top of the list, or even visible in the user's viewport at the time it loads.
 
-Neither (b.i) nor (b.ii) feels ideal, and either option would also introduce a difference between the experience of P1 and P2 which would be impossible for end-users to diagnose.
+Neither (2.i) nor (2.ii) feels ideal, and either option would also introduce a difference between the experience of P1 and P2 which would be impossible for end-users to diagnose.
 
 ## Decision
 

--- a/docs/adrs/04-precomputation-of-presets.md
+++ b/docs/adrs/04-precomputation-of-presets.md
@@ -1,4 +1,4 @@
-# Precomputation of search presets
+# ADR 04: Precomputation of search presets
 
 ## Context
 
@@ -6,7 +6,7 @@ As described in the ADR on [Filter and Search](./02-filter-and-search.md), all v
 
 In order to create a more familiar and easily adoptable experience for users, we plan to recreate many of the lists/feeds that were provided by the Fingerpost UI (e.g. 'UK News', 'Cricket scores'). Under the hood, these will be saved searches which can be combined with other user-defined filters and search terms. We've sometimes referred to these internally as 'buckets', but in the UI we've gone for 'presets'.
 
-The searches underlying the familiar presets are often very complex (as they were in the Fingerpost implementation) because different agencies provide different metadata and none of them map precisely onto the categories our users are interested in.As an example, we might need to add inclusions and exclusions based on category code and 'slug' text. For example, in order to differentiate Rugby League from Rugby Union, and to differentiate rugby _stories_ from rugby _results_, we need to look for `"RUGBYL" / "RUGBYU" / "RUGBY UNION"` in the slug, and exclude any of a number of category codes which are applied to results only:
+The searches underlying the familiar presets are often very complex (as they were in the Fingerpost implementation) because different agencies provide different metadata and none of them map precisely onto the categories our users are interested in. As an example, we might need to add inclusions and exclusions based on category code and 'slug' text. For example, in order to differentiate Rugby League from Rugby Union, and to differentiate rugby _stories_ from rugby _results_, we need to look for `"RUGBYL" / "RUGBYU" / "RUGBY UNION"` in the slug, and exclude any of a number of category codes which are applied to results only:
 
 ```
 "paCat:RRG",
@@ -60,7 +60,7 @@ ORDER BY i.first_created DESC
 LIMIT 100;
 ```
 
-There are good reasons to think that this would be quicker to execute at query time than the complex queries we currently have. If it worked as expected, then it would also unlock the possibility of combining presets in a given user query (e.g. "all sports stories that aren't in the cricket presets").
+There are good reasons to think that this would be quicker to execute at query time than the complex queries we currently have. If it worked as expected, then it would also unlock the possibility of combining presets in a given user query (e.g. 'all sports stories that aren't in the cricket presets').
 
 ### Keep the preset logic in the SQL query
 

--- a/docs/adrs/04-precomputation-of-presets.md
+++ b/docs/adrs/04-precomputation-of-presets.md
@@ -1,0 +1,85 @@
+# Precomputation of search presets
+
+## Context
+
+As described in the ADR on [Filter and Search](./02-filter-and-search.md), all views in Newswires will initially be implemented via a single combined search/filter mechanism. We are using Postgres for storage, which supports combining e.g. category code conditions and full text search in a single query.
+
+In order to create a more familiar and easily adoptable experience for users, we plan to recreate many of the lists/feeds that were provided by the Fingerpost UI (e.g. 'UK News', 'Cricket scores'). Under the hood, these will be saved searches which can be combined with other user-defined filters and search terms. We've sometimes referred to these internally as 'buckets', but in the UI we've gone for 'presets'.
+
+The searches underlying the familiar presets are often very complex (as they were in the Fingerpost implementation) because different agencies provide different metadata and none of them map precisely onto the categories our users are interested in.As an example, we might need to add inclusions and exclusions based on category code and 'slug' text. For example, in order to differentiate Rugby League from Rugby Union, and to differentiate rugby _stories_ from rugby _results_, we need to look for `"RUGBYL" / "RUGBYU" / "RUGBY UNION"` in the slug, and exclude any of a number of category codes which are applied to results only:
+
+```
+"paCat:RRG",
+"paCat:RRE",
+"paCat:RRI",
+"paCat:RRL",
+"paCat:RRF",
+"paCat:RRU",
+"paCat:RDJ",
+"paCat:SDF",
+"paCat:SDT",
+"paCat:SFU",
+"paCat:STE",
+"paCat:SSD",
+"paCat:STF",
+"paCat:SSF"
+```
+
+Conditions are also typically different for each agency within a preset. So preset queries can get very complex. Postgres supports these complex queries, but running them at request time can be relatively slow (generally still <1s, but in some cases it can be multiple seconds to retrieve only one page of results).
+
+We started off by implementing the presets in the SQL queries that we run in response to each user request, but at various points we have noticed slowness and considered options for some kind of precomputation. It's worth noting that it's in the initial load that we tend to see slower performance; querying for updates once the initial page has loaded tends to perform fine because we're looking for 'stories since (recent) time T' at that point.
+
+## Options
+
+### Materialised view
+
+Postgres allows for the creation of 'materialised views', which are essentially the cached outputs of queries, which can in turn be used in further queries. Creating a materialised view of a preset and then searching/filtering within it would work for our use-case on a logical level. It is also very likely to improve performance.
+
+The drawback here is that the data in the materialised view will become stale after creation until it's refreshed. Users will often be watching a feed 'live' to monitor for updates, so we want to minimise the chance of serving stale data or introducing a lag between ingestion and visibility of a story.[^1] Importantly, while initial page load could be sped up using an MV, any delay due to staleness would affect update queries as well as initial queries.
+
+We'd also potentially have the problem that a story might show up in multiple presets, but at different times depending on the refresh schedule for the relevant MV. It's possible that these problems with an MV are solveable with the right structure and refresh conditions, but from our understanding it is not trivial to balance performance and staleness using an MV when there are regular writes.
+
+### Precompute preset membership and persist it in the database
+
+For each preset we have accumulated a set of conditions for membership, based on data which is available at ingestion time. Given this, we could compute which preset(s) a given story belongs to at ingestion time, and persist this in the database, e.g. via a many-to-many relation table:
+
+| item_id (fk to item.id) | preset_id (fk to preset table.id) |
+| ----------------------- | --------------------------------- |
+| 1                       | 1                                 |
+| 1                       | 5                                 |
+| 2                       | 5                                 |
+
+This would make the SQL query to fetch items belonging to a given preset much more straightforward, e.g.:
+
+```sql
+SELECT i.headline
+FROM item i
+JOIN item_presets ip ON ip.item_id = i.id
+WHERE ip.preset_id = $1
+ORDER BY i.first_created DESC
+LIMIT 100;
+```
+
+There are good reasons to think that this would be quicker to execute at query time than the complex queries we currently have. If it worked as expected, then it would also unlock the possibility of combining presets in a given user query (e.g. "all sports stories that aren't in the cricket presets").
+
+### Keep the preset logic in the SQL query
+
+Currently, we have most of our preset logic in the SQL queries. Executing these at query time can be slower, but it does provide benefits.
+
+The main benefits are:
+
+1. SQL provides a robust, declarative paradigm for expressing inclusion and exclusion criteria.
+2. Changes in the query can be tested immediately, across the corpus of existing ingested stories. This makes it easier to iterate on preset criteria and compare with `main` across a large sample.
+3. If we fix a problem with a preset definition (e.g. American tennis scores showing up in UK News), it will automatically be applied retrospectively to items that have already been ingested, without us needing to go back and edit existing database entries.
+
+## Decision
+
+While there are some performance issues with defining the presets via SQL, it has the big advantage of being, as it were, 'stateless' in the sense of points (2) and (3) in the section above. This means that changes to the preset definitions can be tested and applied easily and safely, without the mutation of any stored data.
+
+Whilst there's still a need to iterate on the definition of the presets, it makes sense to apply the logic largely at query time. We can still take advantage of precomputation [for some preset-relevant conditions](https://github.com/guardian/newswires/pull/496) as and when we need to for performance reasons.
+
+The balance between flexibility and performance might change over time. If it does, then precomputation seems like the best fit, although we should be conscious that translating the declarative SQL definitions into a logically equivalent decision method in the ingestion code is unlikely to be trivial.
+
+<!-- footnotes -->
+
+[^1]: See ADR on [post-ingestment enhancement](03-post-ingestion-enhancement.md) for more on this.


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Add retrospective ADRs to capture decisions we've made about how to approach post-ingestion enhancement of story metadata, and pre-computation of search presets.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- Do they make sense?
- Do they seem accurate reflections of the decisions we've taken, and the reasons for these decisions?

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD