### PR TITLE
Show S3 writes in diagram, and add dot-copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,12 @@ CI-style workspace commands can also be run by appending `:ci` to any of the abo
 ### High-level architecture
 
 ```mermaid
-graph TB
+graph LR
     %% External Sources
     Reuters[Reuters Feed]
     AP[AP Feed]
     Fingerpost[Fingerpost Feed]
+    Correspondents[Correspondents aka 'dot-copy']
     Users[Users]
 
     subgraph AWS["AWS 'editorial-feeds'"]
@@ -161,13 +162,19 @@ graph TB
             FingerpostSNS[Fingerpost SNS]
             FingerpostQueueingLambda[Fingerpost Queueing Lambda]
             SourceQ[/Source Queue/]
+            SES[SES]
 
             %% Ingestion flows
             ReutersPoller --> SourceQ
+            ReutersPoller --> FeedsBucket
             APPoller --> SourceQ
+            APPoller --> FeedsBucket
             FingerpostQueueingLambda --> SourceQ
+            FingerpostQueueingLambda --> FeedsBucket
             SourceQ --> Ingestion
-            Ingestion --> FeedsBucket
+            FeedsBucket <-- reads --> Ingestion
+            SES --> FeedsBucket
+            SES --> SourceQ
         end
 
         subgraph ReadPath["User-facing app"]
@@ -195,6 +202,7 @@ graph TB
     AP <-- "long polling" --> APPoller
     Fingerpost -- pushes --> FingerpostSNS
     FingerpostSNS --> FingerpostQueueingLambda
+    Correspondents -- send email --> SES
     Users --> ALB
 
     %% Styling

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ graph LR
     Reuters[Reuters Feed]
     AP[AP Feed]
     Fingerpost[Fingerpost Feed]
-    Correspondents[Correspondents ('dot-copy')]
+    Correspondents["Correspondents ('dot-copy')"]
     Users[Users]
 
     subgraph AWS["AWS 'editorial-feeds'"]

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ graph LR
     Reuters[Reuters Feed]
     AP[AP Feed]
     Fingerpost[Fingerpost Feed]
-    Correspondents[Correspondents aka 'dot-copy']
+    Correspondents[Correspondents ('dot-copy')]
     Users[Users]
 
     subgraph AWS["AWS 'editorial-feeds'"]
@@ -193,7 +193,7 @@ graph LR
 
         %% Shared Resource Flows
         Ingestion --> DB
-        ASG -- "read-only access" --> DB
+        ASG -- "reads" --> DB
         Cleanup -- "delete old stories on a schedule" --> DB
     end
 

--- a/fingerpost-queueing-lambda/README.md
+++ b/fingerpost-queueing-lambda/README.md
@@ -1,3 +1,3 @@
 # Fingerpost Queueing Lambda
 
-A Lambda function that's invoked by incoming items on the Fingerpost SNS topic, and is responsible for adding them to the 'source queue' for the Ingestion Lambda.
+A Lambda function that's invoked by incoming items on the Fingerpost SNS topic, and is responsible for persisting them to S3 and then adding them to the 'source queue' for the Ingestion Lambda.


### PR DESCRIPTION
We haven't updated the diagram for a while, so it was missing the fact that the ingestion lambda now *reads* from S3, and upstream sources write to it. It was also missing the 'dot-copy' feed via SES.