### PR TITLE
Ensure ticker can be opened from the side nav for AAP and Minor Agencies

### DIFF
--- a/newswires/client/src/SideNav/SideNav.tsx
+++ b/newswires/client/src/SideNav/SideNav.tsx
@@ -103,6 +103,7 @@ export const SideNav = ({
 	const suppliers = useMemo(
 		() => [
 			{
+				name: "",
 				label: 'All',
 				isActive:
 					activeSuppliers.length === 0 ||
@@ -114,6 +115,7 @@ export const SideNav = ({
 				colour: 'black',
 			},
 			...recognisedSuppliers.map(({ name, label, colour }) => ({
+				name: name,
 				label: label === 'Minor' ? 'Minor agencies' : label,
 				isActive:
 					activeSuppliers.includes(name) || activeSuppliers.length === 0,
@@ -128,8 +130,8 @@ export const SideNav = ({
 	);
 
 	const supplierItems = suppliers.map(
-		({ label, colour, isActive, onClick }) => ({
-			id: label,
+		({ name, label, colour, isActive, onClick }) => ({
+			id: name,
 			label,
 			onClick,
 			isActive,

--- a/newswires/client/src/SideNav/SideNav.tsx
+++ b/newswires/client/src/SideNav/SideNav.tsx
@@ -103,7 +103,6 @@ export const SideNav = ({
 	const suppliers = useMemo(
 		() => [
 			{
-				name: "",
 				label: 'All',
 				isActive:
 					activeSuppliers.length === 0 ||
@@ -115,7 +114,6 @@ export const SideNav = ({
 				colour: 'black',
 			},
 			...recognisedSuppliers.map(({ name, label, colour }) => ({
-				name: name,
 				label: label === 'Minor' ? 'Minor agencies' : label,
 				isActive:
 					activeSuppliers.includes(name) || activeSuppliers.length === 0,
@@ -130,12 +128,13 @@ export const SideNav = ({
 	);
 
 	const supplierItems = suppliers.map(
-		({ name, label, colour, isActive, onClick }) => ({
-			id: name,
+		({ label, colour, isActive, onClick, onTickerClick }) => ({
+			id: label,
 			label,
 			onClick,
 			isActive,
 			colour,
+			onTickerClick,
 		}),
 	);
 
@@ -241,12 +240,7 @@ export const SideNav = ({
 									isActive={item.isActive}
 									isTopLevel={true}
 									handleButtonClick={item.onClick}
-									handleSecondaryActionClick={() =>
-										openTicker({
-											...config.query,
-											supplier: item.label === 'All' ? [] : [item.id],
-										})
-									}
+									handleSecondaryActionClick={item.onTickerClick}
 									arrowSide={undefined}
 									colour={item.colour}
 								/>


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

When a user opened a ticker from the side nav for AAP, it returned no search results because the supplier label (which contains parentheses and a special character) was being used for the search.

This PR fixes the problem by ensuring that the supplier name is used for the search when the ticker is opened. This fix will also ensure that the Minor Agencies ticker opens correctly.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

For AAP and Minor Agencies: verify that opening a ticker using the side nav yields the same result as opening one via the `New Ticker` button in the top right corner. Test opening tickers for all suppliers and combinations of a few suppliers to check that no existing functionality has been affected.