### PR TITLE
Hide media direct content from the golf scores preset

### DIFF
--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -882,7 +882,8 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("GOLF", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME))
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME)),
+      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
     ),
     SearchPreset(
       AP,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The issue with missing content for this preset has been resolved. So this hides the media direct content from 'Golf Scores' preset ahead of the old feed being removed at the end of the month.\

For more context, see https://github.com/guardian/newswires/pull/905.

## How to test

Checked on this branch that media direct stories are no longer appearing in the preset.
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
