### PR TITLE
Include PA election coverage in UK feed by default

### DIFF
--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -191,7 +191,7 @@ object SearchPresets {
   private val AllUk = List(
     SearchPreset(
       PA,
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.UK.PA, SOME))
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.UK.PA ++ CategoryCodes.Elections.PA, SOME))
     ), // We aren't excluding CategoryCodes.World.PA because PA's still fairly UK-focused, and UK eds are used to seeing all non-sport, non-business PA content in the UK feed
     SearchPreset(MINOR_AGENCIES, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.UK.MINOR_AGENCIES, SOME)))
   )


### PR DESCRIPTION
During big elections, we might not want to show election results in the main UK feed, as it would create a lot of noise. However, in between bigger elections we probably do want to show it in the UK feed (unless we decide to make the 'UK Election' preset a permanent fixture in the UI)