### PR TITLE
Always use 'plain not' query variant unless explicitly overridden

### DIFF
--- a/newswires/app/controllers/QueryController.scala
+++ b/newswires/app/controllers/QueryController.scala
@@ -16,7 +16,6 @@ import play.api.{Configuration, Logging}
 import service.FeatureSwitchProvider
 
 import java.time.Instant
-import scala.util.Random
 
 class QueryController(
     val controllerComponents: ControllerComponents,
@@ -96,10 +95,8 @@ class QueryController(
       )
 
       val queryVariant = request.getQueryString("variant") match {
-        case Some("not_exists")        => NotExists
-        case Some("plain_not")         => PlainNot
-        case _ if Random.nextBoolean() => NotExists
-        case _                         => PlainNot
+        case Some("not_exists") => NotExists
+        case _                  => PlainNot
       }
 
       val queryResponse = FingerpostWireEntry.query(


### PR DESCRIPTION
As it says on the tin. We've got a good amount of data on the a/b comparison between the two variants in terms of query speed.

The intention here is to check what the effect is of using *only* this query variant, on the CPU usage of the database. The hypothesis is that this variant should have a lighter CPU footprint, but we can't really tell when both queries are being run 50% of the time.