### PR TITLE
Bump undici 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20504,9 +20504,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.24.4",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-			"integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+			"version": "7.28.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+			"integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
 	},
 	"overrides": {
 		"fast-xml-parser": "5.5.8",
-		"undici": "7.24.4"
+		"undici": "7.28.0"
 	},
 	"dependencies": {
 		"@aws-sdk/client-s3": "3.995.0",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Following the same pattern as https://github.com/guardian/newswires/pull/742, we need to override the undici dependency that's pulled in by mailauth, to address a vulnerability alert.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD