### PR TITLE
Filter out media direct stories from the cricket scores preset

### DIFF
--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -622,16 +622,22 @@ object SearchPresets {
       searchTerms = Some(SingleTerm(SingleField("(OPTA)", BodyText))),
       categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Cricket.REUTERS, SOME))
     ),
-    SearchPreset(PA, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.CricketScores.PA, SOME))),
+    SearchPreset(
+      PA,
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.CricketScores.PA, SOME)),
+      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+    ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("fixtures OR fixture", Headline))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:SCR"), SOME))
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:SCR"), SOME)),
+      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("Summaries", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:SCR"), SOME))
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:SCR"), SOME)),
+      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
     ),
     SearchPreset(
       AP,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Filter out stories received via Media Direct from the Cricket Scores preset.

See https://github.com/guardian/newswires/pull/905 for more context.

## How to test

Checked on this branch that MD stories are not visible in the Cricket Scores preset, but are still accessible.
