### PR TITLE
Fix badge alignment and Storybook config

### DIFF
--- a/newswires/client/.storybook/preview.tsx
+++ b/newswires/client/.storybook/preview.tsx
@@ -1,4 +1,5 @@
 import type { Preview } from '@storybook/react-vite';
+import { GlobalStyles } from '../src/GlobalStyles';
 
 const preview: Preview = {
 	parameters: {
@@ -9,6 +10,15 @@ const preview: Preview = {
 			},
 		},
 	},
+	decorators: [
+		(Story) => (
+			<>
+				{' '}
+				<GlobalStyles />
+				<Story />
+			</>
+		),
+	],
 };
 
 export default preview;

--- a/newswires/client/src/App.tsx
+++ b/newswires/client/src/App.tsx
@@ -15,7 +15,7 @@ import {
 	EuiSwitch,
 	EuiText,
 } from '@elastic/eui';
-import { css, Global } from '@emotion/react';
+import { css } from '@emotion/react';
 import { useEffect, useState } from 'react';
 import { z } from 'zod/v4';
 import { STAGE } from './app-configuration.ts';
@@ -27,7 +27,7 @@ import {
 import { useSearch } from './context/SearchContext.tsx';
 import { isRestricted } from './dateHelpers.ts';
 import { DefaultLayout } from './DefaultLayout.tsx';
-import { fontStyles } from './fontStyles.ts';
+import { GlobalStyles } from './GlobalStyles.tsx';
 import { presetLabel } from './presets.ts';
 import { useSettingsSwitches } from './SettingsSwitches.tsx';
 import { TelemetryPixel } from './TelemetryPixel.tsx';
@@ -87,7 +87,7 @@ export function App() {
 
 	return (
 		<>
-			<Global styles={fontStyles} />
+			<GlobalStyles />
 			<div style={{ position: 'absolute' }}>
 				<TelemetryPixel stage={STAGE} />
 			</div>

--- a/newswires/client/src/GlobalStyles.tsx
+++ b/newswires/client/src/GlobalStyles.tsx
@@ -1,0 +1,8 @@
+import { Global } from '@emotion/react';
+import { fontStyles } from './fontStyles';
+
+/** Exporting this so that we have a single source of truth for global styles
+ * which can be shared by both the app and storybook. */
+export function GlobalStyles() {
+	return <Global styles={fontStyles} />;
+}

--- a/newswires/client/src/fontStyles.ts
+++ b/newswires/client/src/fontStyles.ts
@@ -83,7 +83,6 @@ export const fontStyles = css`
 		margin: 0;
 		font-family: var(--euiFontFamily);
 		font-size: 1.1rem;
-		line-height: 1.5rem;
 	}
 
 	button {


### PR DESCRIPTION
I was puzzled why the alignment of badges in the WireItemList seemed to be as intended in the Storybook, but not in the app. The Storybook stories weren't receiving the global font styling that we apply to the app.

This PR:

1. Adds the same global styles to all Storybook stories as we add to the app, to ensure a more consistent testing environment
2. Removes the global line-height rule which seemed to be responsible for the unexpected alignment in WireItemList

|Before|After|
|-|-|
|<img width="158" height="35" alt="image" src="https://github.com/user-attachments/assets/93fc47c0-ed62-4001-8e72-db48e64bb33d" />|<img width="159" height="32" alt="image" src="https://github.com/user-attachments/assets/e748c3a5-2f50-4372-95cf-f09a3fb4b531" />|