### PR TITLE
Remove uuid dependency in favour of node's crypto.randomUUID

### DIFF
--- a/newswires/client/package.json
+++ b/newswires/client/package.json
@@ -29,7 +29,6 @@
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
 		"sanitize-html": "^2.17.4",
-		"uuid": "11.1.0",
 		"zod": "4.0.5"
 	},
 	"devDependencies": {

--- a/newswires/client/src/context/fetchResults/generateRequestId.ts
+++ b/newswires/client/src/context/fetchResults/generateRequestId.ts
@@ -1,8 +1,6 @@
-import { v4 as uuidv4 } from 'uuid';
-
-/** Just a simple wrapper around uuidv4 to make it easier to mock in tests.
+/** Just a simple wrapper around node's uuid implementation to make it easier to mock in tests.
  * Avoids the test setup needing to know about the internal implementation of fetchResults.
  */
 export function generateRequestId(): string {
-	return uuidv4();
+	return crypto.randomUUID();
 }

--- a/newswires/client/src/telemetry.ts
+++ b/newswires/client/src/telemetry.ts
@@ -1,6 +1,5 @@
 import type { IUserTelemetryEvent } from '@guardian/user-telemetry-client';
 import { UserTelemetryEventSender } from '@guardian/user-telemetry-client';
-import { v4 as uuidv4 } from 'uuid';
 import { z } from 'zod/v4';
 import { loadOrSetInLocalStorage } from './context/localStorage';
 
@@ -49,7 +48,7 @@ export const createTelemetryEventSender = ({
 		const browserUUID = loadOrSetInLocalStorage(
 			'browserUUID',
 			z.string(),
-			uuidv4(),
+			crypto.randomUUID(),
 		);
 		const isDevUser = sendTelemetryAsDev;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2324,7 +2324,6 @@
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
 				"sanitize-html": "^2.17.4",
-				"uuid": "11.1.0",
 				"zod": "4.0.5"
 			},
 			"devDependencies": {
@@ -20827,19 +20826,6 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-			}
-		},
-		"node_modules/uuid": {
-			"version": "11.1.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-			"integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
-			"funding": [
-				"https://github.com/sponsors/broofa",
-				"https://github.com/sponsors/ctavan"
-			],
-			"license": "MIT",
-			"bin": {
-				"uuid": "dist/esm/bin/uuid"
 			}
 		},
 		"node_modules/v8-compile-cache-lib": {


### PR DESCRIPTION
We aren't using it for anything sensitive and the uuid package has some breaking changes coming up (converting to ESM-only) that don't play well with our existing Jest setup.

