### PR TITLE
Remove unused lint-staged package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,6 @@
 				"eslint-plugin-prettier": "5.5.5",
 				"husky": "^9.1.7",
 				"lage": "^2.14.15",
-				"lint-staged": "16.1.2",
 				"prettier": "3.8.1",
 				"tsx": "^4.20.3",
 				"typescript": "5.9.3",
@@ -9616,19 +9615,6 @@
 				"balanced-match": "^1.0.0"
 			}
 		},
-		"node_modules/braces": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-			"integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fill-range": "^7.1.1"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/browserslist": {
 			"version": "4.25.1",
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
@@ -9895,107 +9881,6 @@
 			"resolved": "cleanup-lambda",
 			"link": true
 		},
-		"node_modules/cli-cursor": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
-			"integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"restore-cursor": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cli-truncate": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
-			"integrity": "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"slice-ansi": "^5.0.0",
-				"string-width": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cli-truncate/node_modules/ansi-styles": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/cli-truncate/node_modules/emoji-regex": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-			"integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/cli-truncate/node_modules/is-fullwidth-code-point": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-4.0.0.tgz",
-			"integrity": "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/cli-truncate/node_modules/slice-ansi": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-5.0.0.tgz",
-			"integrity": "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^6.0.0",
-				"is-fullwidth-code-point": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
-			}
-		},
-		"node_modules/cli-truncate/node_modules/string-width": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^10.3.0",
-				"get-east-asian-width": "^1.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/cliui": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -10087,13 +9972,6 @@
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"license": "MIT"
 		},
-		"node_modules/colorette": {
-			"version": "2.0.20",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
-			"integrity": "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/comma-separated-tokens": {
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
@@ -10102,16 +9980,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/wooorm"
-			}
-		},
-		"node_modules/commander": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
-			"integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=20"
 			}
 		},
 		"node_modules/comment-parser": {
@@ -10670,19 +10538,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
-		"node_modules/environment": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
-			"integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/error-ex": {
@@ -11525,13 +11380,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/eventemitter3": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-			"integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/expect-type": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -11653,19 +11501,6 @@
 			},
 			"engines": {
 				"node": ">= 10"
-			}
-		},
-		"node_modules/fill-range": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-			"integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"to-regex-range": "^5.0.1"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/find-root": {
@@ -11827,19 +11662,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": "6.* || 8.* || >= 10.*"
-			}
-		},
-		"node_modules/get-east-asian-width": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.3.0.tgz",
-			"integrity": "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/get-intrinsic": {
@@ -13024,16 +12846,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/is-number": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.12.0"
-			}
-		},
 		"node_modules/is-number-object": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
@@ -13550,19 +13362,6 @@
 			"integrity": "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow==",
 			"license": "MIT"
 		},
-		"node_modules/lilconfig": {
-			"version": "3.1.3",
-			"resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
-			"integrity": "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/antonk52"
-			}
-		},
 		"node_modules/lines-and-columns": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
@@ -13588,121 +13387,6 @@
 				"uc.micro": "^2.0.0"
 			}
 		},
-		"node_modules/lint-staged": {
-			"version": "16.1.2",
-			"resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.1.2.tgz",
-			"integrity": "sha512-sQKw2Si2g9KUZNY3XNvRuDq4UJqpHwF0/FQzZR2M7I5MvtpWvibikCjUVJzZdGE0ByurEl3KQNvsGetd1ty1/Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^5.4.1",
-				"commander": "^14.0.0",
-				"debug": "^4.4.1",
-				"lilconfig": "^3.1.3",
-				"listr2": "^8.3.3",
-				"micromatch": "^4.0.8",
-				"nano-spawn": "^1.0.2",
-				"pidtree": "^0.6.0",
-				"string-argv": "^0.3.2",
-				"yaml": "^2.8.0"
-			},
-			"bin": {
-				"lint-staged": "bin/lint-staged.js"
-			},
-			"engines": {
-				"node": ">=20.17"
-			},
-			"funding": {
-				"url": "https://opencollective.com/lint-staged"
-			}
-		},
-		"node_modules/lint-staged/node_modules/chalk": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-5.5.0.tgz",
-			"integrity": "sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^12.17.0 || ^14.13 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/listr2": {
-			"version": "8.3.3",
-			"resolved": "https://registry.npmjs.org/listr2/-/listr2-8.3.3.tgz",
-			"integrity": "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cli-truncate": "^4.0.0",
-				"colorette": "^2.0.20",
-				"eventemitter3": "^5.0.1",
-				"log-update": "^6.1.0",
-				"rfdc": "^1.4.1",
-				"wrap-ansi": "^9.0.0"
-			},
-			"engines": {
-				"node": ">=18.0.0"
-			}
-		},
-		"node_modules/listr2/node_modules/ansi-styles": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/listr2/node_modules/emoji-regex": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-			"integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/listr2/node_modules/string-width": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^10.3.0",
-				"get-east-asian-width": "^1.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/listr2/node_modules/wrap-ansi": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
-			"integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^6.2.1",
-				"string-width": "^7.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
 		"node_modules/lodash": {
 			"version": "4.18.1",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
@@ -13715,131 +13399,6 @@
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/log-update": {
-			"version": "6.1.0",
-			"resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
-			"integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-escapes": "^7.0.0",
-				"cli-cursor": "^5.0.0",
-				"slice-ansi": "^7.1.0",
-				"strip-ansi": "^7.1.0",
-				"wrap-ansi": "^9.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/log-update/node_modules/ansi-escapes": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.0.0.tgz",
-			"integrity": "sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"environment": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/log-update/node_modules/ansi-styles": {
-			"version": "6.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
-			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
-			}
-		},
-		"node_modules/log-update/node_modules/emoji-regex": {
-			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.4.0.tgz",
-			"integrity": "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/log-update/node_modules/is-fullwidth-code-point": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.0.0.tgz",
-			"integrity": "sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"get-east-asian-width": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/log-update/node_modules/slice-ansi": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.0.tgz",
-			"integrity": "sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^6.2.1",
-				"is-fullwidth-code-point": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/slice-ansi?sponsor=1"
-			}
-		},
-		"node_modules/log-update/node_modules/string-width": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
-			"integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"emoji-regex": "^10.3.0",
-				"get-east-asian-width": "^1.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/log-update/node_modules/wrap-ansi": {
-			"version": "9.0.0",
-			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.0.tgz",
-			"integrity": "sha512-G8ura3S+3Z2G+mkgNRq8dqaFZAuxfsxpBB8OCTGRTCtp+l/v9nbFNmCUP1BZMts3G1142MsZfn6eeUKrr4PD1Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^6.2.1",
-				"string-width": "^7.0.0",
-				"strip-ansi": "^7.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
 		},
 		"node_modules/loose-envify": {
 			"version": "1.4.0",
@@ -14087,46 +13646,6 @@
 			"integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
 			"license": "MIT"
 		},
-		"node_modules/micromatch": {
-			"version": "4.0.8",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-			"integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"braces": "^3.0.3",
-				"picomatch": "^2.3.1"
-			},
-			"engines": {
-				"node": ">=8.6"
-			}
-		},
-		"node_modules/micromatch/node_modules/picomatch": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/mimic-function": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
-			"integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/min-indent": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
@@ -14189,19 +13708,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
-		},
-		"node_modules/nano-spawn": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/nano-spawn/-/nano-spawn-1.0.2.tgz",
-			"integrity": "sha512-21t+ozMQDAL/UGgQVBbZ/xXvNO10++ZPuTmKRO8k9V3AClVRht49ahtDjfY8l1q6nSHOrE5ASfthzH3ol6R/hg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=20.17"
-			},
-			"funding": {
-				"url": "https://github.com/sindresorhus/nano-spawn?sponsor=1"
-			}
 		},
 		"node_modules/nanoid": {
 			"version": "3.3.11",
@@ -14788,19 +14294,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
-			}
-		},
-		"node_modules/pidtree": {
-			"version": "0.6.0",
-			"resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.6.0.tgz",
-			"integrity": "sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==",
-			"dev": true,
-			"license": "MIT",
-			"bin": {
-				"pidtree": "bin/pidtree.js"
-			},
-			"engines": {
-				"node": ">=0.10"
 			}
 		},
 		"node_modules/poller-lambdas": {
@@ -15904,46 +15397,6 @@
 				"url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
 			}
 		},
-		"node_modules/restore-cursor": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
-			"integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"onetime": "^7.0.0",
-				"signal-exit": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/restore-cursor/node_modules/onetime": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-			"integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mimic-function": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/rfdc": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
-			"integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/rollup": {
 			"version": "4.46.2",
 			"resolved": "https://registry.npmjs.org/rollup/-/rollup-4.46.2.tgz",
@@ -16285,19 +15738,6 @@
 			"dev": true,
 			"license": "ISC"
 		},
-		"node_modules/signal-exit": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=14"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
@@ -16415,16 +15855,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/string-argv": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
-			"integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.6.19"
 			}
 		},
 		"node_modules/string.prototype.includes": {
@@ -16820,19 +16250,6 @@
 			"license": "MIT",
 			"optional": true,
 			"peer": true
-		},
-		"node_modules/to-regex-range": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-number": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=8.0"
-			}
 		},
 		"node_modules/tough-cookie": {
 			"version": "5.1.2",
@@ -18257,6 +17674,8 @@
 			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
 			"dev": true,
 			"license": "ISC",
+			"optional": true,
+			"peer": true,
 			"bin": {
 				"yaml": "bin.mjs"
 			},

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
 		"eslint-plugin-prettier": "5.5.5",
 		"husky": "^9.1.7",
 		"lage": "^2.14.15",
-		"lint-staged": "16.1.2",
 		"prettier": "3.8.1",
 		"tsx": "^4.20.3",
 		"typescript": "5.9.3",
@@ -51,9 +50,6 @@
 		"vitest": "4.1.9"
 	},
 	"prettier": "@guardian/prettier",
-	"lint-staged": {
-		"*.{js,jsx,ts,tsx}": "vitest related --run --passWithNoTests"
-	},
 	"overrides": {
 		"eslint": "9.39.1",
 		"fast-xml-parser": "5.5.8",


### PR DESCRIPTION
As far as I can see, we aren't using this package anywhere, so let's drop it unless we want to start using it. We're already running more comprehensive checks on commit, though, so this seems redundant..?