### PR TITLE
Remove media direct badge from frontend

### DIFF
--- a/newswires/client/src/Item.stories.tsx
+++ b/newswires/client/src/Item.stories.tsx
@@ -47,7 +47,6 @@ const sampleItemData: WireData = {
 	collections: [],
 	isAlert: false,
 	isLead: false,
-	isMediaDirectItem: false,
 	ingestedAtMoment: new InstantMoment(moment('2025-02-26T09:58:22.000Z')),
 };
 
@@ -159,7 +158,6 @@ export const WithMultipleLabels: Story = {
 			...sampleItemData,
 			isAlert: true,
 			isLead: true,
-			isMediaDirectItem: true,
 			content: {
 				...sampleItemData.content,
 				slug: 'SAMPLE-WIRE-WITH-EXTRA-LONG-HEADLINE AND-SUBHEAD-With-no-breaks-to-test-overflow-handling-in-the-UI',

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -42,7 +42,6 @@ import type { InstantMoment } from './utils/date/InstantMoment.ts';
 import {
 	AlertLabel,
 	LeadLabel,
-	MediaDirectItemLabel,
 	SupplierLabel,
 } from './WireItemLabel.tsx';
 
@@ -55,7 +54,6 @@ function TitleContentForItem({
 	wordCount,
 	isAlert,
 	isLead,
-	isMediaDirectItem,
 }: {
 	slug?: string;
 	subhead?: string;
@@ -65,7 +63,6 @@ function TitleContentForItem({
 	wordCount: number;
 	isAlert: boolean;
 	isLead: boolean;
-	isMediaDirectItem: boolean;
 }) {
 	const theme = useEuiTheme();
 	const MAX_SUBHEAD_LENGTH = 250;
@@ -170,7 +167,6 @@ function TitleContentForItem({
 						isPrimary={true}
 						isCondensed={false}
 					/>
-					{isMediaDirectItem && <MediaDirectItemLabel />}
 					{isAlert && <AlertLabel outlined={true} />}
 					{isLead && <LeadLabel outlined={true} />}
 				</div>
@@ -745,7 +741,6 @@ export const WireDetail = ({
 				wordCount={wordCount}
 				isAlert={wire.isAlert}
 				isLead={wire.isLead}
-				isMediaDirectItem={wire.isMediaDirectItem}
 			/>
 			<EuiSpacer size="s" />
 			{isShowingJson ? (

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -39,11 +39,7 @@ import { ToolsConnection, ToolSendReport } from './ToolsConnection.tsx';
 import { Tooltip } from './Tooltip.tsx';
 import { configToUrl } from './urlState.ts';
 import type { InstantMoment } from './utils/date/InstantMoment.ts';
-import {
-	AlertLabel,
-	LeadLabel,
-	SupplierLabel,
-} from './WireItemLabel.tsx';
+import { AlertLabel, LeadLabel, SupplierLabel } from './WireItemLabel.tsx';
 
 function TitleContentForItem({
 	slug,

--- a/newswires/client/src/WireItemLabel.tsx
+++ b/newswires/client/src/WireItemLabel.tsx
@@ -56,27 +56,6 @@ export const AlertLabel = ({
 	);
 };
 
-export const MediaDirectItemLabel = ({
-	hoverParentClassName,
-}: {
-	hoverParentClassName?: string;
-}) => {
-	const { euiTheme } = useEuiTheme();
-	const leadLabelTheme = {
-		backgroundColour: euiTheme.colors.backgroundBaseSubdued,
-		textColour: euiTheme.colors.textSubdued,
-		borderColour: euiTheme.colors.textSubdued,
-	};
-	return (
-		<WireItemLabel
-			label={'MD'}
-			hoverParentClassName={hoverParentClassName}
-			theme={leadLabelTheme}
-			outlined={true}
-		/>
-	);
-};
-
 export const SupplierLabel = ({
 	supplier,
 	isPrimary,

--- a/newswires/client/src/WireItemList.stories.tsx
+++ b/newswires/client/src/WireItemList.stories.tsx
@@ -51,7 +51,6 @@ const sampleItemData: WireData = {
 	collections: [],
 	isAlert: false,
 	isLead: false,
-	isMediaDirectItem: false,
 	ingestedAtMoment: new InstantMoment(moment(now.toISOString())),
 };
 
@@ -281,27 +280,6 @@ export const WithDataFormatting: Story = {
 			{
 				...sampleItemData,
 				hasDataFormatting: true,
-				id: 67890,
-			},
-		],
-		totalCount: 1,
-		showCollectionMetadata: false,
-		showSecondaryFeedContent: false,
-	},
-};
-
-export const WithDataFormattingAndMediaDirectItemBadge: Story = {
-	args: {
-		wires: [
-			{
-				...sampleItemData,
-				hasDataFormatting: true,
-				isMediaDirectItem: true,
-			},
-			{
-				...sampleItemData,
-				hasDataFormatting: true,
-				isMediaDirectItem: true,
 				id: 67890,
 			},
 		],

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -23,7 +23,6 @@ import { ToolSendReport } from './ToolsConnection.tsx';
 import {
 	AlertLabel,
 	LeadLabel,
-	MediaDirectItemLabel,
 	SupplierLabel,
 } from './WireItemLabel.tsx';
 
@@ -205,7 +204,6 @@ const WirePreviewCard = ({
 		hasDataFormatting,
 		isAlert,
 		isLead,
-		isMediaDirectItem,
 	} = wire;
 
 	const ref = useRef<HTMLDivElement>(null);
@@ -400,11 +398,6 @@ const WirePreviewCard = ({
 						justify-content: flex-end;
 					`}
 				>
-					{isMediaDirectItem && (
-						<MediaDirectItemLabel
-							hoverParentClassName={classNameForStylingLabelsOnCardHover}
-						/>
-					)}
 					{hasDataFormatting && (
 						<EuiIcon type="visTable" size="m" title="Has data formatting" />
 					)}

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -20,11 +20,7 @@ import { CollectionsIcon } from './icons/CollectionsIcon.tsx';
 import { Link } from './Link.tsx';
 import type { WireData } from './sharedTypes.ts';
 import { ToolSendReport } from './ToolsConnection.tsx';
-import {
-	AlertLabel,
-	LeadLabel,
-	SupplierLabel,
-} from './WireItemLabel.tsx';
+import { AlertLabel, LeadLabel, SupplierLabel } from './WireItemLabel.tsx';
 
 export const WireItemList = ({
 	wires,

--- a/newswires/client/src/context/transformQueryResponse.ts
+++ b/newswires/client/src/context/transformQueryResponse.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import type { SupplierInfo, WireData, WireDataFromAPI } from '../sharedTypes';
 import { supplierData, UNKNOWN_SUPPLIER } from '../suppliers';
-import { isAlert, isLead, isMediaDirectItem } from '../utils/contentHelpers';
+import { isAlert, isLead } from '../utils/contentHelpers';
 import { InstantMoment } from '../utils/date/InstantMoment';
 
 function enhanceSupplier(supplier: string): SupplierInfo {
@@ -16,6 +16,5 @@ export function transformWireItemQueryResult(data: WireDataFromAPI): WireData {
 		ingestedAtMoment: new InstantMoment(moment(data.ingestedAt)),
 		supplier: enhanceSupplier(data.supplier),
 		hasDataFormatting: data.content.composerCompatible === false, // if composerCompatible is missing or true, we assume true
-		isMediaDirectItem: isMediaDirectItem(data),
 	};
 }

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -143,7 +143,6 @@ export type WireData = Omit<WireDataFromAPI, 'supplier'> & {
 	ingestedAtMoment: InstantMoment;
 	isAlert: boolean;
 	isLead: boolean;
-	isMediaDirectItem: boolean;
 };
 
 export type WiresQueryData = {

--- a/newswires/client/src/tests/fixtures/wireData.ts
+++ b/newswires/client/src/tests/fixtures/wireData.ts
@@ -51,6 +51,5 @@ export const sampleWireData: WireData = {
 	hasDataFormatting: false,
 	isAlert: false,
 	isLead: false,
-	isMediaDirectItem: false,
 	ingestedAtMoment: new InstantMoment(moment(sampleWireResponse.ingestedAt)),
 };

--- a/newswires/client/src/utils/contentHelpers.ts
+++ b/newswires/client/src/utils/contentHelpers.ts
@@ -1,19 +1,7 @@
-import type { WireData, WireDataFromAPI } from '../sharedTypes.ts';
+import type { WireData } from '../sharedTypes.ts';
 
 export const isAlert = (content: WireData['content']) =>
 	content.type === 'text' && content.profile === 'alert';
 
 export const isLead = (content: WireData['content']) =>
 	content.type === 'composite' && content.profile === 'story';
-
-const mediaDirectSourceFeeds = [
-	'PA',
-	'PA PA RACING DATA',
-	'PA DATA FORMATTING',
-	'PA PA SPORT DATA',
-];
-
-export const isMediaDirectItem = (wireData: WireDataFromAPI) => {
-	const { guSourceFeed } = wireData;
-	return mediaDirectSourceFeeds.includes(guSourceFeed);
-};


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Now that PA have phased out Media Direct and we have stopped receiving stories from this source, we need to clean up source feed logic that is no longer needed.

This reverts all changes made in https://github.com/guardian/newswires/pull/906 (enhance the wire item in the client on ingestion to work out if isMediaDirectItem, and add MD badge to stories).

PR https://github.com/guardian/newswires/pull/906 added a story to storybook for items with multiple labels, which I have retained because it is still helpful.

## How to test

- [x] Run storybook and check out: http://localhost:6006/?path=/story/components-item--with-multiple-labels
- [x] Run app locally and verify that no MD badges appear and remaining badges are displaying correctly
