### PR TITLE
Remove Media Direct exclusions from search presets

### DIFF
--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -3,7 +3,7 @@ package conf
 import conf.SearchField.{BodyText, Headline, Slug}
 import conf.SearchTerm.SingleField
 import conf.Suppliers._
-import models.{FilterParams, SearchParams}
+import models.FilterParams
 
 // Increase max line length to improve readability of search presets
 // scalafmt: { maxColumn = 120 }
@@ -19,9 +19,7 @@ object SearchPreset {
       keywordExcl: List[String] = Nil,
       hasDataFormatting: Option[Boolean] = None,
       preComputedCategories: List[String] = Nil,
-      preComputedCategoriesExcl: List[String] = Nil,
-      guSourceFeeds: List[String] = Nil,
-      guSourceFeedsExcl: List[String] = Nil
+      preComputedCategoriesExcl: List[String] = Nil
   ): FilterParams =
     FilterParams(
       searchTerms = searchTerms,
@@ -35,8 +33,8 @@ object SearchPreset {
       preComputedCategories = preComputedCategories,
       preComputedCategoriesExcl = preComputedCategoriesExcl,
       collectionId = None,
-      guSourceFeeds = guSourceFeeds,
-      guSourceFeedsExcl = guSourceFeedsExcl,
+      guSourceFeeds = Nil,
+      guSourceFeedsExcl = Nil,
       eventCode = None
     )
 }
@@ -394,8 +392,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("-RUGBY -RUGBYU -RUGBYL", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.SoccerScores.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.SoccerScores.PA, SOME))
     ),
     SearchPreset(PA, searchTerms = Some(SingleTerm(SingleField("\"SOCCER TABULATED RESULTS\"", Slug)))),
     SearchPreset(
@@ -420,8 +417,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = None,
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.SoccerTables.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.SoccerTables.PA, SOME))
     )
   )
   // SoccerTablesDataFormats
@@ -557,8 +553,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("BASKETBALL", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME))
     ),
     SearchPreset(
       AP,
@@ -624,20 +619,17 @@ object SearchPresets {
     ),
     SearchPreset(
       PA,
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.CricketScores.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.CricketScores.PA, SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("fixtures OR fixture", Headline))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:SCR"), SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:SCR"), SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("Summaries", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:SCR"), SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:SCR"), SOME))
     ),
     SearchPreset(
       AP,
@@ -660,8 +652,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("RUGBYL -Scorer", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
     ),
     SearchPreset(
       AFP,
@@ -671,8 +662,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("RUGBYL -SOCCER Summaries", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME))
     ),
     SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyLeague.AAP, SOME))),
     SearchPreset(
@@ -692,14 +682,12 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("\"RUGBY UNION\" OR RUGBYU -SOCCER Summaries", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("\"RUGBY UNION\" OR RUGBYU -Scorer", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:SFF"), SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:SFF"), SOME))
     ),
     SearchPreset(
       AFP,
@@ -719,22 +707,19 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("-SOCCER -Summaries", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("RUGBY", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:RFC"), SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RFC"), SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(
         SingleTerm(SingleField("RUGBYU Scorer OR RUGBYL Scorer", Slug))
       ),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
     ),
     SearchPreset(
       AFP,
@@ -791,8 +776,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("TENNIS -\"ATP Challenger\"", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME))
     ),
     SearchPreset(
       AFP,
@@ -811,8 +795,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("CYCLING", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
     ),
     SearchPreset(
       AFP,
@@ -833,8 +816,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("auto OR MOTO", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
     ),
     SearchPreset(
       AFP,
@@ -888,8 +870,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("GOLF", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME))
     ),
     SearchPreset(
       AP,
@@ -950,8 +931,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("ICEHOCKEY", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
     ),
     SearchPreset(
       AFP,

--- a/newswires/client/src/Item.stories.tsx
+++ b/newswires/client/src/Item.stories.tsx
@@ -47,7 +47,6 @@ const sampleItemData: WireData = {
 	collections: [],
 	isAlert: false,
 	isLead: false,
-	isMediaDirectItem: false,
 	ingestedAtMoment: new InstantMoment(moment('2025-02-26T09:58:22.000Z')),
 };
 
@@ -159,7 +158,6 @@ export const WithMultipleLabels: Story = {
 			...sampleItemData,
 			isAlert: true,
 			isLead: true,
-			isMediaDirectItem: true,
 			content: {
 				...sampleItemData.content,
 				slug: 'SAMPLE-WIRE-WITH-EXTRA-LONG-HEADLINE AND-SUBHEAD-With-no-breaks-to-test-overflow-handling-in-the-UI',

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -42,7 +42,6 @@ import type { InstantMoment } from './utils/date/InstantMoment.ts';
 import {
 	AlertLabel,
 	LeadLabel,
-	MediaDirectItemLabel,
 	SupplierLabel,
 } from './WireItemLabel.tsx';
 
@@ -55,7 +54,6 @@ function TitleContentForItem({
 	wordCount,
 	isAlert,
 	isLead,
-	isMediaDirectItem,
 }: {
 	slug?: string;
 	subhead?: string;
@@ -65,7 +63,6 @@ function TitleContentForItem({
 	wordCount: number;
 	isAlert: boolean;
 	isLead: boolean;
-	isMediaDirectItem: boolean;
 }) {
 	const theme = useEuiTheme();
 	const MAX_SUBHEAD_LENGTH = 250;
@@ -170,7 +167,6 @@ function TitleContentForItem({
 						isPrimary={true}
 						isCondensed={false}
 					/>
-					{isMediaDirectItem && <MediaDirectItemLabel />}
 					{isAlert && <AlertLabel outlined={true} />}
 					{isLead && <LeadLabel outlined={true} />}
 				</div>
@@ -745,7 +741,6 @@ export const WireDetail = ({
 				wordCount={wordCount}
 				isAlert={wire.isAlert}
 				isLead={wire.isLead}
-				isMediaDirectItem={wire.isMediaDirectItem}
 			/>
 			<EuiSpacer size="s" />
 			{isShowingJson ? (

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -39,11 +39,7 @@ import { ToolsConnection, ToolSendReport } from './ToolsConnection.tsx';
 import { Tooltip } from './Tooltip.tsx';
 import { configToUrl } from './urlState.ts';
 import type { InstantMoment } from './utils/date/InstantMoment.ts';
-import {
-	AlertLabel,
-	LeadLabel,
-	SupplierLabel,
-} from './WireItemLabel.tsx';
+import { AlertLabel, LeadLabel, SupplierLabel } from './WireItemLabel.tsx';
 
 function TitleContentForItem({
 	slug,

--- a/newswires/client/src/WireItemLabel.tsx
+++ b/newswires/client/src/WireItemLabel.tsx
@@ -56,27 +56,6 @@ export const AlertLabel = ({
 	);
 };
 
-export const MediaDirectItemLabel = ({
-	hoverParentClassName,
-}: {
-	hoverParentClassName?: string;
-}) => {
-	const { euiTheme } = useEuiTheme();
-	const leadLabelTheme = {
-		backgroundColour: euiTheme.colors.backgroundBaseSubdued,
-		textColour: euiTheme.colors.textSubdued,
-		borderColour: euiTheme.colors.textSubdued,
-	};
-	return (
-		<WireItemLabel
-			label={'MD'}
-			hoverParentClassName={hoverParentClassName}
-			theme={leadLabelTheme}
-			outlined={true}
-		/>
-	);
-};
-
 export const SupplierLabel = ({
 	supplier,
 	isPrimary,

--- a/newswires/client/src/WireItemList.stories.tsx
+++ b/newswires/client/src/WireItemList.stories.tsx
@@ -51,7 +51,6 @@ const sampleItemData: WireData = {
 	collections: [],
 	isAlert: false,
 	isLead: false,
-	isMediaDirectItem: false,
 	ingestedAtMoment: new InstantMoment(moment(now.toISOString())),
 };
 
@@ -281,27 +280,6 @@ export const WithDataFormatting: Story = {
 			{
 				...sampleItemData,
 				hasDataFormatting: true,
-				id: 67890,
-			},
-		],
-		totalCount: 1,
-		showCollectionMetadata: false,
-		showSecondaryFeedContent: false,
-	},
-};
-
-export const WithDataFormattingAndMediaDirectItemBadge: Story = {
-	args: {
-		wires: [
-			{
-				...sampleItemData,
-				hasDataFormatting: true,
-				isMediaDirectItem: true,
-			},
-			{
-				...sampleItemData,
-				hasDataFormatting: true,
-				isMediaDirectItem: true,
 				id: 67890,
 			},
 		],

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -23,7 +23,6 @@ import { ToolSendReport } from './ToolsConnection.tsx';
 import {
 	AlertLabel,
 	LeadLabel,
-	MediaDirectItemLabel,
 	SupplierLabel,
 } from './WireItemLabel.tsx';
 
@@ -205,7 +204,6 @@ const WirePreviewCard = ({
 		hasDataFormatting,
 		isAlert,
 		isLead,
-		isMediaDirectItem,
 	} = wire;
 
 	const ref = useRef<HTMLDivElement>(null);
@@ -400,11 +398,6 @@ const WirePreviewCard = ({
 						justify-content: flex-end;
 					`}
 				>
-					{isMediaDirectItem && (
-						<MediaDirectItemLabel
-							hoverParentClassName={classNameForStylingLabelsOnCardHover}
-						/>
-					)}
 					{hasDataFormatting && (
 						<EuiIcon type="visTable" size="m" title="Has data formatting" />
 					)}

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -20,11 +20,7 @@ import { CollectionsIcon } from './icons/CollectionsIcon.tsx';
 import { Link } from './Link.tsx';
 import type { WireData } from './sharedTypes.ts';
 import { ToolSendReport } from './ToolsConnection.tsx';
-import {
-	AlertLabel,
-	LeadLabel,
-	SupplierLabel,
-} from './WireItemLabel.tsx';
+import { AlertLabel, LeadLabel, SupplierLabel } from './WireItemLabel.tsx';
 
 export const WireItemList = ({
 	wires,

--- a/newswires/client/src/context/transformQueryResponse.ts
+++ b/newswires/client/src/context/transformQueryResponse.ts
@@ -1,7 +1,7 @@
 import moment from 'moment';
 import type { SupplierInfo, WireData, WireDataFromAPI } from '../sharedTypes';
 import { supplierData, UNKNOWN_SUPPLIER } from '../suppliers';
-import { isAlert, isLead, isMediaDirectItem } from '../utils/contentHelpers';
+import { isAlert, isLead } from '../utils/contentHelpers';
 import { InstantMoment } from '../utils/date/InstantMoment';
 
 function enhanceSupplier(supplier: string): SupplierInfo {
@@ -16,6 +16,5 @@ export function transformWireItemQueryResult(data: WireDataFromAPI): WireData {
 		ingestedAtMoment: new InstantMoment(moment(data.ingestedAt)),
 		supplier: enhanceSupplier(data.supplier),
 		hasDataFormatting: data.content.composerCompatible === false, // if composerCompatible is missing or true, we assume true
-		isMediaDirectItem: isMediaDirectItem(data),
 	};
 }

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -143,7 +143,6 @@ export type WireData = Omit<WireDataFromAPI, 'supplier'> & {
 	ingestedAtMoment: InstantMoment;
 	isAlert: boolean;
 	isLead: boolean;
-	isMediaDirectItem: boolean;
 };
 
 export type WiresQueryData = {

--- a/newswires/client/src/tests/fixtures/wireData.ts
+++ b/newswires/client/src/tests/fixtures/wireData.ts
@@ -51,6 +51,5 @@ export const sampleWireData: WireData = {
 	hasDataFormatting: false,
 	isAlert: false,
 	isLead: false,
-	isMediaDirectItem: false,
 	ingestedAtMoment: new InstantMoment(moment(sampleWireResponse.ingestedAt)),
 };

--- a/newswires/client/src/utils/contentHelpers.ts
+++ b/newswires/client/src/utils/contentHelpers.ts
@@ -1,19 +1,7 @@
-import type { WireData, WireDataFromAPI } from '../sharedTypes.ts';
+import type { WireData } from '../sharedTypes.ts';
 
 export const isAlert = (content: WireData['content']) =>
 	content.type === 'text' && content.profile === 'alert';
 
 export const isLead = (content: WireData['content']) =>
 	content.type === 'composite' && content.profile === 'story';
-
-const mediaDirectSourceFeeds = [
-	'PA',
-	'PA PA RACING DATA',
-	'PA DATA FORMATTING',
-	'PA PA SPORT DATA',
-];
-
-export const isMediaDirectItem = (wireData: WireDataFromAPI) => {
-	const { guSourceFeed } = wireData;
-	return mediaDirectSourceFeeds.includes(guSourceFeed);
-};


### PR DESCRIPTION
## What does this change?

Now that PA have phased out Media Direct and we have stopped receiving stories from this source, we need to clean up source feed logic that is no longer needed.

This PR reverts changes made in https://github.com/guardian/newswires/pull/905, as well as small changes in https://github.com/guardian/newswires/pull/916 and https://github.com/guardian/newswires/pull/923, all of which added exclusions to search presets to filter out Media Direct stories.

## How to test

Go to Cricket Scores preset, change date range to end at 10pm on 25 June and some MD stories should now be visible in the preset. This can be verified by checking the JSON of the top item, in which "guSourceFeed": "PA DATA FORMATTING" is present.