### PR TITLE
Remove media direct exclusions from search presets

### DIFF
--- a/newswires/app/conf/SearchPresets.scala
+++ b/newswires/app/conf/SearchPresets.scala
@@ -3,7 +3,7 @@ package conf
 import conf.SearchField.{BodyText, Headline, Slug}
 import conf.SearchTerm.SingleField
 import conf.Suppliers._
-import models.{FilterParams, SearchParams}
+import models.FilterParams
 
 // Increase max line length to improve readability of search presets
 // scalafmt: { maxColumn = 120 }
@@ -19,9 +19,7 @@ object SearchPreset {
       keywordExcl: List[String] = Nil,
       hasDataFormatting: Option[Boolean] = None,
       preComputedCategories: List[String] = Nil,
-      preComputedCategoriesExcl: List[String] = Nil,
-      guSourceFeeds: List[String] = Nil,
-      guSourceFeedsExcl: List[String] = Nil
+      preComputedCategoriesExcl: List[String] = Nil
   ): FilterParams =
     FilterParams(
       searchTerms = searchTerms,
@@ -35,8 +33,8 @@ object SearchPreset {
       preComputedCategories = preComputedCategories,
       preComputedCategoriesExcl = preComputedCategoriesExcl,
       collectionId = None,
-      guSourceFeeds = guSourceFeeds,
-      guSourceFeedsExcl = guSourceFeedsExcl,
+      guSourceFeeds = Nil,
+      guSourceFeedsExcl = Nil,
       eventCode = None
     )
 }
@@ -394,8 +392,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("-RUGBY -RUGBYU -RUGBYL", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.SoccerScores.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.SoccerScores.PA, SOME))
     ),
     SearchPreset(PA, searchTerms = Some(SingleTerm(SingleField("\"SOCCER TABULATED RESULTS\"", Slug)))),
     SearchPreset(
@@ -420,8 +417,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = None,
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.SoccerTables.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.SoccerTables.PA, SOME))
     )
   )
   // SoccerTablesDataFormats
@@ -557,8 +553,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("BASKETBALL", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME))
     ),
     SearchPreset(
       AP,
@@ -624,20 +619,17 @@ object SearchPresets {
     ),
     SearchPreset(
       PA,
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.CricketScores.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.CricketScores.PA, SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("fixtures OR fixture", Headline))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:SCR"), SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:SCR"), SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("Summaries", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:SCR"), SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:SCR"), SOME))
     ),
     SearchPreset(
       AP,
@@ -660,8 +652,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("RUGBYL -Scorer", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
     ),
     SearchPreset(
       AFP,
@@ -671,8 +662,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("RUGBYL -SOCCER Summaries", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME))
     ),
     SearchPreset(AAP, categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyLeague.AAP, SOME))),
     SearchPreset(
@@ -692,14 +682,12 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("\"RUGBY UNION\" OR RUGBYU -SOCCER Summaries", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("\"RUGBY UNION\" OR RUGBYU -Scorer", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:SFF"), SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA ::: List("paCat:SFF"), SOME))
     ),
     SearchPreset(
       AFP,
@@ -719,22 +707,19 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("-SOCCER -Summaries", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.RugbyScores.PA, SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("RUGBY", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:RFC"), SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RFC"), SOME))
     ),
     SearchPreset(
       PA,
       searchTerms = Some(
         SingleTerm(SingleField("RUGBYU Scorer OR RUGBYL Scorer", Slug))
       ),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
     ),
     SearchPreset(
       AFP,
@@ -791,8 +776,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("TENNIS -\"ATP Challenger\"", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME))
     ),
     SearchPreset(
       AFP,
@@ -811,8 +795,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("CYCLING", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
     ),
     SearchPreset(
       AFP,
@@ -833,8 +816,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("auto OR MOTO", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
     ),
     SearchPreset(
       AFP,
@@ -888,8 +870,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("GOLF", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(List("paCat:RSR"), SOME))
     ),
     SearchPreset(
       AP,
@@ -950,8 +931,7 @@ object SearchPresets {
     SearchPreset(
       PA,
       searchTerms = Some(SingleTerm(SingleField("ICEHOCKEY", Slug))),
-      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME)),
-      guSourceFeedsExcl = SearchParams.mediaDirectSourceFeeds
+      categoryCodes = Some(CategoryCodesCondition(CategoryCodes.Sport.PA, SOME))
     ),
     SearchPreset(
       AFP,


### PR DESCRIPTION
## What does this change?
Now that PA have phased out Media Direct and we have stopped receiving stories from this source, we need to clean up source feed logic that is no longer needed.

This PR reverts changes made in https://github.com/guardian/newswires/pull/905, as well as small changes in https://github.com/guardian/newswires/pull/916 and https://github.com/guardian/newswires/pull/923, all of which added exclusions to search presets to filter out Media Direct stories.

## How to test
Go to Cricket Scores preset, change date range to end at 10pm on 25 June and some MD stories should now be visible in the preset. This can be verified by checking the JSON of the top item, in which "guSourceFeed": "PA DATA FORMATTING" is present.