### PR TITLE
Hk/remove md switch

### DIFF
--- a/newswires/app/models/SearchParams.scala
+++ b/newswires/app/models/SearchParams.scala
@@ -57,11 +57,7 @@ object SearchParams {
         preComputedCategoriesExcl = Nil,
         collectionId = baseParams.maybeCollectionId,
         guSourceFeeds = baseParams.guSourceFeeds,
-        guSourceFeedsExcl = computeGuSourceFeedExcl(
-          hideMediaDirectFeeds = featureSwitch.HideMediaDirectFeeds.isOn(req),
-          guSourceFeeds = baseParams.guSourceFeeds,
-          guSourceFeedsExcl = baseParams.guSourceFeedsExcl
-        ),
+        guSourceFeedsExcl = baseParams.guSourceFeedsExcl,
         eventCode = baseParams.eventCode
       ),
       DateRange(
@@ -88,26 +84,5 @@ object SearchParams {
       query.get("supplierExcl").map(_.toList).getOrElse(Nil)
 
     dotCopyExclusion ::: guSuppliersExclusion ::: exclusionFromParams
-  }
-
-  val mediaDirectSourceFeeds = List(
-    "PA",
-    "PA PA RACING DATA",
-    "PA DATA FORMATTING",
-    "PA PA SPORT DATA"
-  )
-
-  def computeGuSourceFeedExcl(
-      hideMediaDirectFeeds: Boolean,
-      guSourceFeeds: List[String],
-      guSourceFeedsExcl: List[String]
-  ): List[String] = {
-    if (guSourceFeeds.nonEmpty || guSourceFeedsExcl.nonEmpty) {
-      guSourceFeedsExcl
-    } else if (hideMediaDirectFeeds) {
-      mediaDirectSourceFeeds
-    } else {
-      Nil
-    }
   }
 }

--- a/newswires/app/service/FeatureSwitchProvider.scala
+++ b/newswires/app/service/FeatureSwitchProvider.scala
@@ -23,19 +23,8 @@ class FeatureSwitchProvider(stage: String) {
       isOn = _ => stage.toUpperCase() != "PROD"
     )
 
-  val HideMediaDirectFeeds: FeatureSwitch =
-    FeatureSwitch(
-      name = "HideMediaDirectFeeds",
-      safeState = Off,
-      description = "Hide media direct source feeds",
-      isOn = _.getQueryString("hideMediaDirectFeeds")
-        .flatMap(_.toBooleanOption)
-        .getOrElse(false)
-    )
-
   private val switches = List(
-    ShowGuSuppliers,
-    HideMediaDirectFeeds
+    ShowGuSuppliers
   )
   def clientSideSwitchStates(request: Request[_]): Map[String, Boolean] =
     switches.filter(_.exposeToClient).map(s => s.name -> s.isOn(request)).toMap

--- a/newswires/client/src/SearchSummary/SearchSummary.tsx
+++ b/newswires/client/src/SearchSummary/SearchSummary.tsx
@@ -29,7 +29,6 @@ const SearchTermBadgeLabelLookup: Record<DeselectableQueryKey, string> = {
 	categoryCode: 'Category',
 	categoryCodeExcl: '(NOT) Category',
 	hasDataFormatting: 'Has data formatting',
-	hideMediaDirectFeeds: 'Hide media direct feeds',
 	keyword: 'Keyword',
 	keywordExcl: '(NOT) Keyword',
 	guSourceFeed: 'Source feed',
@@ -100,7 +99,6 @@ const Summary = ({
 		categoryCode,
 		categoryCodeExcl,
 		hasDataFormatting,
-		hideMediaDirectFeeds,
 		collectionId,
 		eventCode: eventCode,
 	} = query;
@@ -134,7 +132,6 @@ const Summary = ({
 		displayGuSourceFeeds ||
 		displayExcludedGuSourceFeeds ||
 		hasDataFormatting !== undefined ||
-		hideMediaDirectFeeds !== undefined ||
 		collectionId !== undefined ||
 		eventCode !== undefined;
 
@@ -247,14 +244,6 @@ const Summary = ({
 					keyValuePair={{
 						key: 'hasDataFormatting',
 						value: hasDataFormatting ? 'true' : 'false',
-					}}
-				/>
-			)}
-			{hideMediaDirectFeeds !== undefined && (
-				<SummaryBadge
-					keyValuePair={{
-						key: 'hideMediaDirectFeeds',
-						value: hideMediaDirectFeeds ? 'true' : 'false',
 					}}
 				/>
 			)}

--- a/newswires/client/src/SettingsMenu.tsx
+++ b/newswires/client/src/SettingsMenu.tsx
@@ -9,10 +9,7 @@ import {
 } from '@elastic/eui';
 import moment from 'moment-timezone';
 import { useState } from 'react';
-import {
-	HIDE_MEDIA_DIRECT_FEEDS,
-	SHOW_GU_SUPPLIERS,
-} from './app-configuration';
+import { SHOW_GU_SUPPLIERS } from './app-configuration';
 import { StopShortcutPropagationWrapper } from './context/KeyboardShortcutsContext';
 import { useUserSettings } from './context/UserSettingsContext';
 import { useSettingsSwitches } from './SettingsSwitches.tsx';
@@ -99,9 +96,6 @@ export const SettingsMenu = () => {
 			items: [
 				{
 					name: `Show Gu suppliers: ${SHOW_GU_SUPPLIERS ? 'On' : 'Off'}`,
-				},
-				{
-					name: `Hide media direct feeds: ${HIDE_MEDIA_DIRECT_FEEDS ? 'On' : 'Off'}`,
 				},
 			],
 		},

--- a/newswires/client/src/app-configuration.ts
+++ b/newswires/client/src/app-configuration.ts
@@ -13,7 +13,6 @@ const configLookup: AppConfiguration = isTest
 	? {
 			switches: {
 				ShowGuSuppliers: false,
-				HideMediaDirectFeeds: false,
 			},
 			stage: 'test',
 			sendTelemetryAsDev: true,
@@ -22,8 +21,6 @@ const configLookup: AppConfiguration = isTest
 	: window.configuration;
 
 export const SHOW_GU_SUPPLIERS = configLookup.switches.ShowGuSuppliers;
-export const HIDE_MEDIA_DIRECT_FEEDS =
-	configLookup.switches.HideMediaDirectFeeds;
 
 /**
  * The list of suppliers to exclude from the list of 'recognised suppliers' that

--- a/newswires/client/src/queryHelpers.ts
+++ b/newswires/client/src/queryHelpers.ts
@@ -43,13 +43,9 @@ export const queryAfterDeselection = (
 		};
 	}
 	if (
-		[
-			'hasDataFormatting',
-			'start',
-			'end',
-			'collectionId',
-			'eventCode',
-		].includes(key)
+		['hasDataFormatting', 'start', 'end', 'collectionId', 'eventCode'].includes(
+			key,
+		)
 	) {
 		return { ...query, [key]: undefined };
 	}

--- a/newswires/client/src/queryHelpers.ts
+++ b/newswires/client/src/queryHelpers.ts
@@ -45,7 +45,6 @@ export const queryAfterDeselection = (
 	if (
 		[
 			'hasDataFormatting',
-			'hideMediaDirectFeeds',
 			'start',
 			'end',
 			'collectionId',

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -178,7 +178,6 @@ export const BaseQuerySchema = z.object({
 	start: EuiDateStringSchema.optional(),
 	end: EuiDateStringSchema.optional(),
 	hasDataFormatting: z.boolean().optional(),
-	hideMediaDirectFeeds: z.boolean().optional(),
 	eventCode: z.string().optional(),
 });
 export type BaseQuery = z.infer<typeof BaseQuerySchema>;

--- a/newswires/client/src/urlState.ts
+++ b/newswires/client/src/urlState.ts
@@ -18,7 +18,6 @@ export const defaultQuery: Query = {
 	start: DEFAULT_DATE_RANGE.start,
 	end: DEFAULT_DATE_RANGE.end,
 	hasDataFormatting: undefined,
-	hideMediaDirectFeeds: undefined,
 	collectionId: undefined,
 	eventCode: undefined,
 };
@@ -72,9 +71,6 @@ function searchParamsToQuery(params: URLSearchParams): Query {
 	const hasDataFormatting = maybeStringToBooleanOrUndefined(
 		params.get('hasDataFormatting'),
 	);
-	const hideMediaDirectFeeds = maybeStringToBooleanOrUndefined(
-		params.get('hideMediaDirectFeeds'),
-	);
 	const eventCode = params.get('eventCode') ?? undefined;
 	let collectionId: number | undefined = undefined;
 
@@ -107,7 +103,6 @@ function searchParamsToQuery(params: URLSearchParams): Query {
 		start,
 		end,
 		hasDataFormatting,
-		hideMediaDirectFeeds,
 		eventCode,
 	};
 

--- a/newswires/client/src/windowConfigType.ts
+++ b/newswires/client/src/windowConfigType.ts
@@ -1,6 +1,5 @@
 interface FeatureSwitches {
 	ShowGuSuppliers: boolean;
-	HideMediaDirectFeeds: boolean;
 }
 
 export interface AppConfiguration {

--- a/newswires/test/models/SearchParamsSpec.scala
+++ b/newswires/test/models/SearchParamsSpec.scala
@@ -175,60 +175,6 @@ class SearchParamsSpec extends AnyFlatSpec with models {
     )
     result shouldEqual List("UNAUTHED_EMAIL_FEED")
   }
-
-  behavior of "computeGuSourceFeedExcl"
-
-  it should "return empty list when hideMediaDirectFeeds is false and no guSourceFeed is explicitly set" in new searchParamsMocks {
-    val result = SearchParams.computeGuSourceFeedExcl(
-      hideMediaDirectFeeds = false,
-      guSourceFeeds = Nil,
-      guSourceFeedsExcl = Nil
-    )
-    result shouldEqual Nil
-  }
-
-  it should "exclude media direct source feeds when hideMediaDirectFeeds is true and no guSourceFeed is explicitly set" in new searchParamsMocks {
-    val result = SearchParams.computeGuSourceFeedExcl(
-      hideMediaDirectFeeds = true,
-      guSourceFeeds = Nil,
-      guSourceFeedsExcl = Nil
-    )
-    result shouldEqual SearchParams.mediaDirectSourceFeeds
-  }
-
-  it should "pass through guSourceFeedsExcl unchanged when guSourceFeeds is non-empty" in new searchParamsMocks {
-    val result = SearchParams.computeGuSourceFeedExcl(
-      hideMediaDirectFeeds = true,
-      guSourceFeeds = List("some-feed"),
-      guSourceFeedsExcl = List("excluded-feed")
-    )
-    result shouldEqual List("excluded-feed")
-
-    val result2 = SearchParams.computeGuSourceFeedExcl(
-      hideMediaDirectFeeds = true,
-      guSourceFeeds = List("some-feed"),
-      guSourceFeedsExcl = Nil
-    )
-    result2 shouldEqual Nil
-  }
-
-  it should "pass through guSourceFeedsExcl unchanged when guSourceFeedsExcl is non-empty" in new searchParamsMocks {
-    val result = SearchParams.computeGuSourceFeedExcl(
-      hideMediaDirectFeeds = true,
-      guSourceFeeds = Nil,
-      guSourceFeedsExcl = List("excluded-feed")
-    )
-    result shouldEqual List("excluded-feed")
-  }
-
-  it should "apply media direct feed exclusions via SearchParams.build when hideMediaDirectFeeds is on" in new searchParamsMocks {
-    val result = SearchParams.build(
-      emptyQueryString,
-      emptyBaseParams,
-      hideMediaDirectFeedsOn
-    )(FakeRequest())
-    result.filters.guSourceFeedsExcl shouldEqual SearchParams.mediaDirectSourceFeeds
-  }
 }
 
 trait searchParamsMocks {
@@ -236,7 +182,6 @@ trait searchParamsMocks {
   val emptyQueryString = Map[String, Seq[String]]()
   val featureSwitchesOn = mock[FeatureSwitchProvider]
   val showGuSuppliersFeatureOff = mock[FeatureSwitchProvider]
-  val hideMediaDirectFeedsOn = mock[FeatureSwitchProvider]
   val featureSwitch = FeatureSwitch(
     name = "",
     safeState = Off,
@@ -245,15 +190,7 @@ trait searchParamsMocks {
     isOn = _ => true
   )
   when(featureSwitchesOn.ShowGuSuppliers).thenReturn(featureSwitch)
-  when(featureSwitchesOn.HideMediaDirectFeeds).thenReturn(
-    featureSwitch.copy(isOn = _ => false)
-  )
   when(showGuSuppliersFeatureOff.ShowGuSuppliers).thenReturn(
     featureSwitch.copy(isOn = _ => false)
   )
-  when(showGuSuppliersFeatureOff.HideMediaDirectFeeds).thenReturn(
-    featureSwitch.copy(isOn = _ => false)
-  )
-  when(hideMediaDirectFeedsOn.ShowGuSuppliers).thenReturn(featureSwitch)
-  when(hideMediaDirectFeedsOn.HideMediaDirectFeeds).thenReturn(featureSwitch)
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Now that PA have phased out Media Direct and we have stopped receiving stories from this source, we need to clean up source feed logic that is no longer needed.

Remove the switch which was used to hide 'media direct' source feeds, by reverting changes made in PR https://github.com/guardian/newswires/pull/901.