### PR TITLE
restore the guemailidentity which was previosuly held by editorial-wires stack

### DIFF
--- a/cdk/bin/cdk.ts
+++ b/cdk/bin/cdk.ts
@@ -22,6 +22,7 @@ type SharedStackProps = {
 	stack: string;
 	stage: string;
 	domainName: string;
+	emailDomainName: string;
 	enableMonitoring: boolean;
 };
 
@@ -30,6 +31,7 @@ export function createStacks({
 	stack,
 	stage,
 	domainName,
+	emailDomainName,
 	enableMonitoring,
 }: SharedStackProps) {
 	const wiresFeedsStack = new WiresFeeds(app, `WiresFeeds-${stage}`, {
@@ -43,6 +45,7 @@ export function createStacks({
 		stack,
 		stage,
 		domainName,
+		emailDomainName,
 		enableMonitoring,
 		sourceQueue: wiresFeedsStack.sourceQueue,
 		fingerpostQueue: wiresFeedsStack.fingerpostQueue,
@@ -74,6 +77,7 @@ createStacks({
 	stack: STACK,
 	stage: 'CODE',
 	domainName: 'newswires.code.dev-gutools.co.uk',
+	emailDomainName: 'editorial-wires-email.code.dev-gutools.co.uk',
 	enableMonitoring: false,
 });
 createStacks({
@@ -81,6 +85,7 @@ createStacks({
 	stack: STACK,
 	stage: 'PROD',
 	domainName: 'newswires.gutools.co.uk',
+	emailDomainName: 'editorial-wires-email.gutools.co.uk',
 	enableMonitoring: true,
 });
 

--- a/cdk/lib/__snapshots__/newswires.test.ts.snap
+++ b/cdk/lib/__snapshots__/newswires.test.ts.snap
@@ -13,6 +13,10 @@ exports[`The Newswires stack > matches the snapshot 1`] = `
       "GuS3Bucket",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
+      "GuEmailIdentity",
+      "GuCname",
+      "GuCname",
+      "GuCname",
       "GuStringParameter",
       "GuLambdaFunction",
       "GuLambdaFunction",
@@ -726,6 +730,72 @@ exports[`The Newswires stack > matches the snapshot 1`] = `
       },
       "Type": "AWS::IAM::Policy",
     },
+    "EmailIdentityDkimnewswires0": {
+      "Properties": {
+        "Name": {
+          "Fn::GetAtt": [
+            "IncomingCopyEmailIdentityNewswires5C4AE3F8",
+            "DkimDNSTokenName1",
+          ],
+        },
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "IncomingCopyEmailIdentityNewswires5C4AE3F8",
+              "DkimDNSTokenValue1",
+            ],
+          },
+        ],
+        "Stage": "TEST",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+    "EmailIdentityDkimnewswires1": {
+      "Properties": {
+        "Name": {
+          "Fn::GetAtt": [
+            "IncomingCopyEmailIdentityNewswires5C4AE3F8",
+            "DkimDNSTokenName2",
+          ],
+        },
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "IncomingCopyEmailIdentityNewswires5C4AE3F8",
+              "DkimDNSTokenValue2",
+            ],
+          },
+        ],
+        "Stage": "TEST",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+    "EmailIdentityDkimnewswires2": {
+      "Properties": {
+        "Name": {
+          "Fn::GetAtt": [
+            "IncomingCopyEmailIdentityNewswires5C4AE3F8",
+            "DkimDNSTokenName3",
+          ],
+        },
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "IncomingCopyEmailIdentityNewswires5C4AE3F8",
+              "DkimDNSTokenValue3",
+            ],
+          },
+        ],
+        "Stage": "TEST",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
     "FingerpostQueueingLambdaTEST60860D74": {
       "DependsOn": [
         "FingerpostQueueingLambdaTESTServiceRoleDefaultPolicy50D0B801",
@@ -1361,6 +1431,34 @@ exports[`The Newswires stack > matches the snapshot 1`] = `
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "IncomingCopyEmailIdentityNewswires5C4AE3F8": {
+      "Properties": {
+        "EmailIdentity": "emails.newswires.TEST.dev-gutools.co.uk",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newswires",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SES::EmailIdentity",
     },
     "IngestionLambdaTESTAllowSes499F8EFF": {
       "Properties": {

--- a/cdk/lib/__snapshots__/whole-stack.test.ts.snap
+++ b/cdk/lib/__snapshots__/whole-stack.test.ts.snap
@@ -1026,6 +1026,10 @@ exports[`createStacks > should create WiresFeeds and Newswires stacks with corre
       "GuS3Bucket",
       "GuDistributionBucketParameter",
       "GuLambdaFunction",
+      "GuEmailIdentity",
+      "GuCname",
+      "GuCname",
+      "GuCname",
       "GuStringParameter",
       "GuLambdaFunction",
       "GuLambdaFunction",
@@ -1739,6 +1743,72 @@ exports[`createStacks > should create WiresFeeds and Newswires stacks with corre
       },
       "Type": "AWS::IAM::Policy",
     },
+    "EmailIdentityDkimnewswires0": {
+      "Properties": {
+        "Name": {
+          "Fn::GetAtt": [
+            "IncomingCopyEmailIdentityNewswires5C4AE3F8",
+            "DkimDNSTokenName1",
+          ],
+        },
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "IncomingCopyEmailIdentityNewswires5C4AE3F8",
+              "DkimDNSTokenValue1",
+            ],
+          },
+        ],
+        "Stage": "TEST",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+    "EmailIdentityDkimnewswires1": {
+      "Properties": {
+        "Name": {
+          "Fn::GetAtt": [
+            "IncomingCopyEmailIdentityNewswires5C4AE3F8",
+            "DkimDNSTokenName2",
+          ],
+        },
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "IncomingCopyEmailIdentityNewswires5C4AE3F8",
+              "DkimDNSTokenValue2",
+            ],
+          },
+        ],
+        "Stage": "TEST",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
+    "EmailIdentityDkimnewswires2": {
+      "Properties": {
+        "Name": {
+          "Fn::GetAtt": [
+            "IncomingCopyEmailIdentityNewswires5C4AE3F8",
+            "DkimDNSTokenName3",
+          ],
+        },
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "IncomingCopyEmailIdentityNewswires5C4AE3F8",
+              "DkimDNSTokenValue3",
+            ],
+          },
+        ],
+        "Stage": "TEST",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
+    },
     "FingerpostQueueingLambdaTEST60860D74": {
       "DependsOn": [
         "FingerpostQueueingLambdaTESTServiceRoleDefaultPolicy50D0B801",
@@ -2374,6 +2444,34 @@ exports[`createStacks > should create WiresFeeds and Newswires stacks with corre
         "TreatMissingData": "notBreaching",
       },
       "Type": "AWS::CloudWatch::Alarm",
+    },
+    "IncomingCopyEmailIdentityNewswires5C4AE3F8": {
+      "Properties": {
+        "EmailIdentity": "emails.newswires.TEST.dev-gutools.co.uk",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "newswires",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/newswires",
+          },
+          {
+            "Key": "Stack",
+            "Value": "editorial-feeds",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+      },
+      "Type": "AWS::SES::EmailIdentity",
     },
     "IngestionLambdaTESTAllowSes499F8EFF": {
       "Properties": {

--- a/cdk/lib/newswires.test.ts
+++ b/cdk/lib/newswires.test.ts
@@ -34,6 +34,7 @@ describe('The Newswires stack', () => {
 			stack: 'editorial-feeds',
 			stage: 'TEST',
 			domainName: 'newswires.TEST.dev-gutools.co.uk',
+			emailDomainName: 'emails.newswires.TEST.dev-gutools.co.uk',
 			enableMonitoring: true,
 			fingerpostQueue: mockFingerpostQueue,
 			sourceQueue: mockSourceQueue,

--- a/cdk/lib/newswires.ts
+++ b/cdk/lib/newswires.ts
@@ -20,6 +20,7 @@ import {
 } from '@guardian/cdk/lib/constructs/iam';
 import { GuLambdaFunction } from '@guardian/cdk/lib/constructs/lambda';
 import { GuS3Bucket } from '@guardian/cdk/lib/constructs/s3';
+import { GuEmailIdentity } from '@guardian/cdk/lib/constructs/ses';
 import type { App } from 'aws-cdk-lib';
 import { aws_logs, Duration } from 'aws-cdk-lib';
 import { Certificate } from 'aws-cdk-lib/aws-certificatemanager';
@@ -77,6 +78,7 @@ export type NewswiresProps = GuStackProps & {
 	domainName: string;
 	enableMonitoring: boolean;
 	alarmSnsTopic: Topic;
+	emailDomainName: string;
 };
 
 export class Newswires extends GuStack {
@@ -90,7 +92,7 @@ export class Newswires extends GuStack {
 			type: 'String',
 		});
 
-		const { domainName, enableMonitoring } = props;
+		const { domainName, emailDomainName, enableMonitoring } = props;
 
 		const vpc = GuVpc.fromIdParameter(this, 'VPC');
 
@@ -177,6 +179,11 @@ export class Newswires extends GuStack {
 		props.sourceQueue.grantSendMessages(fingerpostQueueingLambda);
 
 		feedsBucket.grantWrite(fingerpostQueueingLambda);
+
+		new GuEmailIdentity(this, 'IncomingCopyEmailIdentity', {
+			domainName: emailDomainName,
+			app: appName,
+		});
 
 		const incomingEmailAddress = new GuStringParameter(
 			this,

--- a/cdk/lib/whole-stack.test.ts
+++ b/cdk/lib/whole-stack.test.ts
@@ -10,6 +10,7 @@ describe('createStacks', () => {
 			stack: 'editorial-feeds',
 			stage: 'TEST',
 			domainName: 'newswires.TEST.dev-gutools.co.uk',
+			emailDomainName: 'emails.newswires.TEST.dev-gutools.co.uk',
 			enableMonitoring: true,
 		};
 


### PR DESCRIPTION


<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

The email receiving requires a GuEmailIdentity to be set up in the account. This was previously held by the editorial-wires stack so deleted by the deletion.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD