### PR TITLE
 Use last query time instead of most recent result for polling cursor

### DIFF
--- a/newswires/app/db/FingerpostWireEntry.scala
+++ b/newswires/app/db/FingerpostWireEntry.scala
@@ -656,6 +656,16 @@ object FingerpostWireEntry
       countQueryCap: Long = COUNT_QUERY_CAP,
       queryVariant: QueryVariant = PlainNot
   ): QueryResponse = DB readOnly { implicit session =>
+    /** 
+      Capture the database's current time before running the query, so callers
+      can poll for items that appear at or after this point without relying on
+      the client or server clock matching the database clock. Capturing it
+      before the query means any item ingested while the query runs will still
+      be picked up on the next poll (deduplicated client-side).
+     */
+    val queryTimestamp: Instant =
+      sql"SELECT now()".map(_.zonedDateTime(1).toInstant).single().get
+
     val whereClause = buildWhereClause(
       queryParams.searchParams,
       queryParams.queryCursor,
@@ -722,7 +732,8 @@ object FingerpostWireEntry
       results,
       totalCount,
       countQueryCap,
-      queryVariant
+      queryVariant,
+      queryTimestamp
     )
   }
 

--- a/newswires/app/models/QueryResponse.scala
+++ b/newswires/app/models/QueryResponse.scala
@@ -4,11 +4,14 @@ import db.{FingerpostWireEntry, QueryVariant, TimeStampColumn, ToolLink}
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
 import io.circe.{Decoder, Encoder}
 
+import java.time.Instant
+
 case class QueryResponse(
     results: List[FingerpostWireEntry],
     totalCount: Long,
     countQueryCap: Long,
-    queryVariant: QueryVariant
+    queryVariant: QueryVariant,
+    queryTimestamp: Instant
     //      keywordCounts: Map[String, Int]
 )
 

--- a/newswires/client/src/SearchSummary/decideSearchSummaryLabel.test.tsx
+++ b/newswires/client/src/SearchSummary/decideSearchSummaryLabel.test.tsx
@@ -10,6 +10,7 @@ describe('decideSearchSummaryLabel', () => {
 				totalCount: 1,
 				countQueryCap: 100,
 				results: [],
+				queryTimestamp: '2024-01-01T00:00:00.000Z',
 			}),
 		).toContain('1 result');
 	});
@@ -19,6 +20,7 @@ describe('decideSearchSummaryLabel', () => {
 				totalCount: 0,
 				countQueryCap: 100,
 				results: [],
+				queryTimestamp: '2024-01-01T00:00:00.000Z',
 			}),
 		).toContain('No results');
 	});
@@ -28,6 +30,7 @@ describe('decideSearchSummaryLabel', () => {
 				totalCount: 150,
 				countQueryCap: 100,
 				results: [],
+				queryTimestamp: '2024-01-01T00:00:00.000Z',
 			}),
 		).toContain('100+ results');
 	});
@@ -37,6 +40,7 @@ describe('decideSearchSummaryLabel', () => {
 				totalCount: 50,
 				countQueryCap: 100,
 				results: [],
+				queryTimestamp: '2024-01-01T00:00:00.000Z',
 			}),
 		).toContain('50 results');
 	});

--- a/newswires/client/src/SideNav/SideNavListItem.tsx
+++ b/newswires/client/src/SideNav/SideNavListItem.tsx
@@ -80,9 +80,9 @@ export const SideNavListItem = ({
 				margin-bottom: ${euiTheme.size.xs};
 				border-radius: ${euiTheme.size.xs};
 				transition: background-color 0.2s ease;
-				background-color: ${isActive
-					? euiTheme.colors.backgroundBasePrimary
-					: 'transparent'};
+				background-color: ${
+					isActive ? euiTheme.colors.backgroundBasePrimary : 'transparent'
+				};
 
 				&:hover .secondary-action-button,
 				&:focus-within .secondary-action-button {

--- a/newswires/client/src/StageDisplayBanner.tsx
+++ b/newswires/client/src/StageDisplayBanner.tsx
@@ -22,12 +22,14 @@ export const StageDisplayBanner = () => {
 				<EuiHeader
 					position="fixed"
 					css={css`
-						background-color: ${stage === 'DEV'
-							? euiTheme.colors.warning
-							: euiTheme.colors.danger};
-						color: ${stage === 'DEV'
-							? euiTheme.colors.textHeading
-							: euiTheme.colors.textGhost};
+						background-color: ${
+							stage === 'DEV' ? euiTheme.colors.warning : euiTheme.colors.danger
+						};
+						color: ${
+							stage === 'DEV'
+								? euiTheme.colors.textHeading
+								: euiTheme.colors.textGhost
+						};
 						padding: 10px;
 						top: 10px;
 						bottom: 10px;

--- a/newswires/client/src/WireDetail.tsx
+++ b/newswires/client/src/WireDetail.tsx
@@ -786,8 +786,9 @@ export const WireDetail = ({
 											>
 												<span
 													css={css`
-														color: ${theme.euiTheme.colors
-															.backgroundFilledAccent};
+														color: ${
+															theme.euiTheme.colors.backgroundFilledAccent
+														};
 													`}
 												>
 													<EuiIcon type={CollectionsIcon} size="original" />

--- a/newswires/client/src/WireItemLabel.tsx
+++ b/newswires/client/src/WireItemLabel.tsx
@@ -133,9 +133,9 @@ export const WireItemLabel = ({
 			css={[
 				hoverParentStyles,
 				css`
-					border-radius: ${rounded === 'very'
-						? euiTheme.size.m
-						: euiTheme.size.xxs};
+					border-radius: ${
+						rounded === 'very' ? euiTheme.size.m : euiTheme.size.xxs
+					};
 					padding: 0 ${euiTheme.size.s};
 					border: 1px solid ${outlined ? borderColour : 'transparent'};
 					color: ${textColour};

--- a/newswires/client/src/WireItemList.stories.tsx
+++ b/newswires/client/src/WireItemList.stories.tsx
@@ -70,6 +70,7 @@ const mockSearchContext: SearchContextShape = {
 			results: [],
 			totalCount: 0,
 			countQueryCap: 100,
+			queryTimestamp: '2024-01-01T00:00:00.000Z',
 		},
 		successfulQueryHistory: [],
 		autoUpdate: false,

--- a/newswires/client/src/WireItemList.tsx
+++ b/newswires/client/src/WireItemList.tsx
@@ -329,12 +329,14 @@ const WirePreviewCard = ({
 						border-left: 4px solid
 							${selected ? theme.euiTheme.colors.primary : 'transparent'};
 						border-bottom: 1px solid ${theme.euiTheme.colors.mediumShade};
-						${id.toString() === previousItemId
-							? css`
-									animation: ${borderFade(theme.euiTheme.colors.primary)} 0.6s
-										ease-out forwards;
-								`
-							: null}
+						${
+							id.toString() === previousItemId
+								? css`
+										animation: ${borderFade(theme.euiTheme.colors.primary)} 0.6s
+											ease-out forwards;
+									`
+								: null
+						}
 						padding: 0.5rem;
 						box-sizing: content-box;
 						color: ${theme.euiTheme.colors.text};
@@ -351,9 +353,11 @@ const WirePreviewCard = ({
 			>
 				<h3
 					css={css`
-						font-weight: ${hasBeenViewed
-							? theme.euiTheme.font.weight.medium
-							: theme.euiTheme.font.weight.semiBold};
+						font-weight: ${
+							hasBeenViewed
+								? theme.euiTheme.font.weight.medium
+								: theme.euiTheme.font.weight.semiBold
+						};
 						${hasBeenViewed ? 'color:rgba(29, 42, 62,.8)' : ''};
 						font-size: 1.15rem;
 						margin-bottom: ${gapAfterFirstRow};
@@ -370,9 +374,11 @@ const WirePreviewCard = ({
 					css={css`
 						grid-area: time;
 						padding-left: 5px;
-						font-weight: ${hasBeenViewed
-							? theme.euiTheme.font.weight.light
-							: theme.euiTheme.font.weight.regular};
+						font-weight: ${
+							hasBeenViewed
+								? theme.euiTheme.font.weight.light
+								: theme.euiTheme.font.weight.regular
+						};
 						justify-self: end;
 						text-align: right;
 						font-variant-numeric: tabular-nums;
@@ -436,9 +442,11 @@ const WirePreviewCard = ({
 						<div
 							css={css`
 								${hasBeenViewed ? 'color:rgba(29, 42, 62,.8)' : ''};
-								font-weight: ${hasBeenViewed
-									? theme.euiTheme.font.weight.light
-									: theme.euiTheme.font.weight.regular};
+								font-weight: ${
+									hasBeenViewed
+										? theme.euiTheme.font.weight.light
+										: theme.euiTheme.font.weight.regular
+								};
 							`}
 						>
 							<MaybeSecondaryCardContent {...content} highlight={highlight} />

--- a/newswires/client/src/context/SearchContext.test.tsx
+++ b/newswires/client/src/context/SearchContext.test.tsx
@@ -1,6 +1,7 @@
 import { act, render } from '@testing-library/react';
 import type { Mock } from 'vitest';
 import type { Query, WiresQueryResponse } from '../sharedTypes.ts';
+import { sampleWireResponse } from '../tests/fixtures/wireData.ts';
 import { flushPendingPromises } from '../tests/testHelpers.ts';
 import type { SearchContextShape } from './SearchContext.tsx';
 import { SearchContextProvider, useSearch } from './SearchContext.tsx';
@@ -10,6 +11,7 @@ const mockResponseData: WiresQueryResponse = {
 	results: [],
 	totalCount: 0,
 	countQueryCap: 100,
+	queryTimestamp: '2024-01-01T00:00:00.000Z',
 };
 
 global.fetch = vi.fn(() =>
@@ -67,6 +69,7 @@ describe('SearchContext', () => {
 			results: [],
 			totalCount: 0,
 			countQueryCap: 100,
+			queryTimestamp: '2024-01-01T00:00:00.000Z',
 		});
 		expect(contextRef.current.state.successfulQueryHistory).toEqual([]);
 	});
@@ -239,5 +242,88 @@ describe('SearchContext', () => {
 		});
 
 		expect(contextRef.current.viewedItemIds).toEqual(['1', '2']);
+	});
+
+	it('should not let loadMoreResults change the afterTimeStamp used by the next poll', async () => {
+		const initialQueryTimestamp = '2025-06-01T00:00:00.000Z';
+		const loadMoreQueryTimestamp = '2025-06-02T00:00:00.000Z';
+
+		const originalFetch = global.fetch;
+
+		global.fetch = vi.fn((url: string) => {
+			const body: WiresQueryResponse = url.includes('beforeTimeStamp')
+				? {
+						results: [
+							{
+								...sampleWireResponse,
+								id: 2,
+								ingestedAt: '2024-12-31T00:00:00Z',
+							},
+						],
+						totalCount: 2,
+						countQueryCap: 100,
+						queryTimestamp: loadMoreQueryTimestamp,
+					}
+				: {
+						results: [
+							{
+								...sampleWireResponse,
+								id: 1,
+								ingestedAt: '2025-01-01T00:00:00Z',
+							},
+						],
+						totalCount: 1,
+						countQueryCap: 100,
+						queryTimestamp: initialQueryTimestamp,
+					};
+			return Promise.resolve({
+				json: () => Promise.resolve(body),
+				ok: true,
+			});
+		}) as Mock;
+
+		vi.useFakeTimers();
+		try {
+			const contextRef = await renderWithContext();
+			if (!contextRef.current) {
+				throw new Error('Context ref was null after render.');
+			}
+			await flushPendingPromises();
+
+			// the poll cursor is seeded from the initial fetch's queryTimestamp
+			expect(contextRef.current.state.queryData?.queryTimestamp).toBe(
+				initialQueryTimestamp,
+			);
+
+			// load more (older) results in between polls
+			await act(async () => {
+				await contextRef.current?.loadMoreResults();
+			});
+
+			// loading older results must not move the poll cursor forward
+			expect(contextRef.current.state.queryData?.queryTimestamp).toBe(
+				initialQueryTimestamp,
+			);
+
+			// trigger the next poll
+			await act(async () => {
+				await vi.advanceTimersByTimeAsync(6000);
+			});
+
+			const pollAfterTimeStamps = (global.fetch as Mock).mock.calls
+				.map((call: unknown[]) => call[0] as string)
+				.filter((url: string) => url.includes('afterTimeStamp'))
+				.map((url: string) =>
+					new URL(url, 'http://localhost').searchParams.get('afterTimeStamp'),
+				);
+
+			expect(pollAfterTimeStamps.length).toBeGreaterThan(0);
+			pollAfterTimeStamps.forEach((afterTimeStamp: string | null) => {
+				expect(afterTimeStamp).toBe(initialQueryTimestamp);
+			});
+		} finally {
+			vi.useRealTimers();
+			global.fetch = originalFetch;
+		}
 	});
 });

--- a/newswires/client/src/context/SearchContext.tsx
+++ b/newswires/client/src/context/SearchContext.tsx
@@ -29,10 +29,7 @@ import {
 } from './localStorage.tsx';
 import { safeReducer, SearchReducer } from './SearchReducer.ts';
 import { useTelemetry } from './TelemetryContext.tsx';
-import {
-	getEarliestTimeStamp,
-	getLatestTimeStamp,
-} from './timestamp-compare.ts';
+import { getEarliestTimeStamp } from './timestamp-compare.ts';
 
 export type SearchHistory = {
 	query: Query;
@@ -74,11 +71,7 @@ type OfflineState = BaseState & {
 };
 
 export type State =
-	| InitialisedState
-	| LoadingState
-	| SuccessState
-	| ErrorState
-	| OfflineState;
+	InitialisedState | LoadingState | SuccessState | ErrorState | OfflineState;
 
 type Enter = {
 	type: 'ENTER_QUERY';
@@ -298,10 +291,7 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 		if (state.status === 'success' || state.status === 'offline') {
 			pollingInterval = setInterval(() => {
 				if (state.autoUpdate) {
-					const afterTimeStamp = getLatestTimeStamp(
-						state.queryData.results,
-						state.sortBy,
-					);
+					const afterTimeStamp = state.queryData.queryTimestamp;
 					const startedAt = performance.now();
 					fetchResults({
 						query: currentConfig.query,
@@ -353,6 +343,7 @@ export function SearchContextProvider({ children }: PropsWithChildren) {
 		state.autoUpdate,
 		currentConfig.query,
 		state.queryData?.results,
+		state.queryData?.queryTimestamp,
 		sendTelemetryEvent,
 		currentConfig.view,
 		state.sortBy,

--- a/newswires/client/src/context/SearchReducer.test.ts
+++ b/newswires/client/src/context/SearchReducer.test.ts
@@ -14,6 +14,7 @@ const sampleQueryData = {
 	results: [{ ...sampleWireData }],
 	totalCount: 1,
 	countQueryCap: 100,
+	queryTimestamp: '2025-01-01T02:04:00Z',
 };
 
 describe('SearchReducer', () => {
@@ -147,6 +148,7 @@ describe('SearchReducer', () => {
 						],
 						totalCount: 2,
 						countQueryCap: 100,
+						queryTimestamp: '2025-01-01T02:04:00Z',
 					},
 				};
 
@@ -167,6 +169,7 @@ describe('SearchReducer', () => {
 						],
 						totalCount: 2,
 						countQueryCap: 100,
+						queryTimestamp: '2025-01-01T02:04:00Z',
 					},
 					query: {
 						q: 'test',
@@ -224,6 +227,7 @@ describe('SearchReducer', () => {
 						],
 						totalCount: 2,
 						countQueryCap: 100,
+						queryTimestamp: '2025-01-01T02:04:00Z',
 					},
 				};
 
@@ -256,6 +260,7 @@ describe('SearchReducer', () => {
 						],
 						totalCount: 2,
 						countQueryCap: 100,
+						queryTimestamp: '2025-01-01T02:04:00Z',
 					},
 					query: {
 						q: 'test',
@@ -293,6 +298,7 @@ describe('SearchReducer', () => {
 					results: [itemOne],
 					totalCount: 1,
 					countQueryCap: 100,
+					queryTimestamp: '2025-01-01T02:04:00Z',
 				},
 			};
 
@@ -302,6 +308,7 @@ describe('SearchReducer', () => {
 					results: [itemOne, itemTwo],
 					totalCount: 2,
 					countQueryCap: 100,
+					queryTimestamp: '2025-01-01T02:04:00Z',
 				},
 				query: {
 					q: 'test',
@@ -334,6 +341,7 @@ describe('SearchReducer', () => {
 				results: [{ ...sampleWireData, id: 2 }],
 				totalCount: 2,
 				countQueryCap: 100,
+				queryTimestamp: '2025-01-01T02:04:00Z',
 			},
 		};
 
@@ -343,6 +351,7 @@ describe('SearchReducer', () => {
 				results: [{ ...sampleWireData, id: 1 }],
 				totalCount: 1,
 				countQueryCap: 100,
+				queryTimestamp: '2025-01-01T02:04:00Z',
 			},
 		};
 
@@ -368,6 +377,7 @@ describe('SearchReducer', () => {
 				results: [{ ...sampleWireData, id: 2 }],
 				totalCount: 2,
 				countQueryCap: 100,
+				queryTimestamp: '2025-01-01T02:04:00Z',
 			},
 		};
 
@@ -380,6 +390,7 @@ describe('SearchReducer', () => {
 				],
 				totalCount: 2,
 				countQueryCap: 100,
+				queryTimestamp: '2025-01-01T02:04:00Z',
 			},
 		};
 

--- a/newswires/client/src/context/SearchReducer.ts
+++ b/newswires/client/src/context/SearchReducer.ts
@@ -83,6 +83,10 @@ function appendQueryData(
 		return {
 			...newData,
 			totalCount: existing.totalCount,
+			// Keep the existing poll cursor: appended pages are older items, so
+			// advancing to the load-more request's timestamp could skip newer items
+			// that arrived at the top of the list since the last poll.
+			queryTimestamp: existing.queryTimestamp,
 			results: [...existing.results, ...dedupedNewItems],
 		};
 	} else {

--- a/newswires/client/src/context/fetchResults/fetchResults.test.ts
+++ b/newswires/client/src/context/fetchResults/fetchResults.test.ts
@@ -16,6 +16,7 @@ const mockResponseData: WiresQueryResponse = {
 	results: [sampleWireResponse],
 	totalCount: 0,
 	countQueryCap: 100,
+	queryTimestamp: '2024-02-24T16:15:00.000Z',
 };
 
 vi.mock('../../panda-session', () => ({

--- a/newswires/client/src/queryHelpers.ts
+++ b/newswires/client/src/queryHelpers.ts
@@ -16,8 +16,7 @@ type DateRangeKeyValuePair = {
 };
 
 export type DeselectableQueryKeyValue =
-	| QueryKeyValuePair
-	| DateRangeKeyValuePair;
+	QueryKeyValuePair | DateRangeKeyValuePair;
 
 export type DeselectableQueryKey = DeselectableQueryKeyValue['key'];
 

--- a/newswires/client/src/sharedTypes.ts
+++ b/newswires/client/src/sharedTypes.ts
@@ -101,6 +101,9 @@ export const WiresQueryResponseSchema = z.object({
 			description: z.string(),
 		})
 		.optional(),
+	// The database's clock time when this query ran, used as the cursor for the
+	// next poll so that polling doesn't depend on the client/server clock.
+	queryTimestamp: z.string(),
 	// keywordCounts: z.record(z.string(), z.number()),
 });
 
@@ -154,6 +157,7 @@ export type WiresQueryData = {
 		name: string;
 		description: string;
 	};
+	queryTimestamp: string;
 };
 
 export const isValidDateValue = (value: string) =>

--- a/newswires/test/models/QueryResponseSpec.scala
+++ b/newswires/test/models/QueryResponseSpec.scala
@@ -21,7 +21,8 @@ class QueryResponseSpec extends AnyFlatSpec with Matchers with models {
       results = results,
       totalCount = results.length,
       countQueryCap = FingerpostWireEntry.COUNT_QUERY_CAP,
-      queryVariant = PlainNot
+      queryVariant = PlainNot,
+      queryTimestamp = Instant.ofEpochMilli(0)
     )
 
   behavior of "QueryResponse.display"


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Pass a timestamp back from the db for use in subsequent polling, rather than relying on extracting it from results.

Relying on the timestamp of the most recent result means that we can end up polling for a much longer time period than necessary to find updates.

To take the extreme case, imagine that we search across 2 weeks and don't find any results. Because there are no results, subsequent polling requests will cover the whole of the 2 week period even though we already know there's nothing to find.

What we want instead is to look for stories which have arrived since the last poll time. I'm suggesting that we use the timestamp on the db clock just *before* the last query was made. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD