### PR TITLE
Override nodemailer version to remove vuln

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3678,44 +3678,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/@guardian/eslint-config/node_modules/storybook": {
-			"version": "10.3.4",
-			"resolved": "https://registry.npmjs.org/storybook/-/storybook-10.3.4.tgz",
-			"integrity": "sha512-866YXZy9k59tLPl9SN3KZZOFeBC/swxkuBVtW8iQjJIzfCrvk7zXQd8RSQ4ignmCdArVvY4lGMCAT4yNaZSt1g==",
-			"dev": true,
-			"license": "MIT",
-			"peer": true,
-			"dependencies": {
-				"@storybook/global": "^5.0.0",
-				"@storybook/icons": "^2.0.1",
-				"@testing-library/jest-dom": "^6.9.1",
-				"@testing-library/user-event": "^14.6.1",
-				"@vitest/expect": "3.2.4",
-				"@vitest/spy": "3.2.4",
-				"@webcontainer/env": "^1.1.1",
-				"esbuild": "^0.18.0 || ^0.19.0 || ^0.20.0 || ^0.21.0 || ^0.22.0 || ^0.23.0 || ^0.24.0 || ^0.25.0 || ^0.26.0 || ^0.27.0",
-				"open": "^10.2.0",
-				"recast": "^0.23.5",
-				"semver": "^7.7.3",
-				"use-sync-external-store": "^1.5.0",
-				"ws": "^8.18.0"
-			},
-			"bin": {
-				"storybook": "dist/bin/dispatcher.js"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/storybook"
-			},
-			"peerDependencies": {
-				"prettier": "^2 || ^3"
-			},
-			"peerDependenciesMeta": {
-				"prettier": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@guardian/libs": {
 			"version": "27.0.0",
 			"resolved": "https://registry.npmjs.org/@guardian/libs/-/libs-27.0.0.tgz",
@@ -11604,15 +11566,6 @@
 				"node": ">=20.18.1"
 			}
 		},
-		"node_modules/mailauth/node_modules/nodemailer": {
-			"version": "7.0.13",
-			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.13.tgz",
-			"integrity": "sha512-PNDFSJdP+KFgdsG3ZzMXCgquO7I6McjY2vlqILjtJd0hy8wEvtugS9xKRF2NWlPNGxvLCXlTNIae4serI7dinw==",
-			"license": "MIT-0",
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
 		"node_modules/mailparser": {
 			"version": "3.9.12",
 			"resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.12.tgz",
@@ -11906,9 +11859,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nodemailer": {
-			"version": "9.0.1",
-			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
-			"integrity": "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==",
+			"version": "9.0.3",
+			"resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.3.tgz",
+			"integrity": "sha512-n+YP+NKwR5zRWa60k3GiQ6Q3B4KXCoAw40dAKeCtYn020iNN74aWK2liXIC3ZEATeGql7we3tE3t8QwhY0eskw==",
 			"license": "MIT-0",
 			"engines": {
 				"node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
 	"overrides": {
 		"eslint": "9.39.1",
 		"fast-xml-parser": "5.5.8",
-		"undici": "7.28.0"
+		"undici": "7.28.0",
+		"nodemailer": "9.0.3"
 	},
 	"dependencies": {
 		"@aws-sdk/client-s3": "3.995.0",


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Mailauth uses nodemailer, but it hasn't yet upgraded the version it's using to resolve a CVE which was published a few weeks ago.

This PR overrides the nodemailer dependency to a patched version.

>[!WARNING]
> **nb. This involves a major version bump from the one used by mailauth**
> Mailauth uses v8.0.7 at the moment, whereas patches are only available for >=9.0.1, so we're forcing a major version change. This feels risky. I've looked at the changelog and I can't see anything in the breaking changes that *should* affect us, but I'd appreciate additional eyes!


https://github.com/nodemailer/nodemailer/releases/tag/v9.0.0

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Deployed to CODE and tested the happy path by sending a test message and seeing that it shows up as expected. Not sure how to test the unhappy path...

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD