### PR TITLE
add explicit jsdom dependency

### DIFF
--- a/newswires/client/package.json
+++ b/newswires/client/package.json
@@ -44,6 +44,7 @@
 		"eslint-plugin-react-refresh": "^0.5.2",
 		"eslint-plugin-storybook": "10.4.1",
 		"globals": "^16.3.0",
+		"jsdom": "^29.1.1",
 		"prettier": "^3.6.2",
 		"storybook": "10.4.1",
 		"timezone-mock": "^1.3.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2284,6 +2284,7 @@
 				"eslint-plugin-react-refresh": "^0.5.2",
 				"eslint-plugin-storybook": "10.4.1",
 				"globals": "^16.3.0",
+				"jsdom": "^29.1.1",
 				"prettier": "^3.6.2",
 				"storybook": "10.4.1",
 				"timezone-mock": "^1.3.6",
@@ -2900,29 +2901,55 @@
 			}
 		},
 		"node_modules/@asamuzakjp/css-color": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
-			"integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+			"version": "5.1.11",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+			"integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"dependencies": {
-				"@csstools/css-calc": "^2.1.3",
-				"@csstools/css-color-parser": "^3.0.9",
-				"@csstools/css-parser-algorithms": "^3.0.4",
-				"@csstools/css-tokenizer": "^3.0.3",
-				"lru-cache": "^10.4.3"
+				"@asamuzakjp/generational-cache": "^1.0.1",
+				"@csstools/css-calc": "^3.2.0",
+				"@csstools/css-color-parser": "^4.1.0",
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
-		"node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
-			"version": "10.4.3",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
-			"integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+		"node_modules/@asamuzakjp/dom-selector": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.1.1.tgz",
+			"integrity": "sha512-67RZDnYRc8H/8MLDgQCDE//zoqVFwajkepHZgmXrbwybzXOEwOWGPYGmALYl9J2DOLfFPPs6kKCqmbzV895hTQ==",
 			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true
+			"license": "MIT",
+			"dependencies": {
+				"@asamuzakjp/generational-cache": "^1.0.1",
+				"@asamuzakjp/nwsapi": "^2.3.9",
+				"bidi-js": "^1.0.3",
+				"css-tree": "^3.2.1",
+				"is-potential-custom-element-name": "^1.0.1"
+			},
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/generational-cache": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+			"integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			}
+		},
+		"node_modules/@asamuzakjp/nwsapi": {
+			"version": "2.3.9",
+			"resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+			"integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@aws-crypto/crc32": {
 			"version": "5.2.0",
@@ -4690,6 +4717,19 @@
 			"integrity": "sha512-4iri8i1AqYHJE2DstZYkyEprg6Pq6sKx3xn5FpySk9sNhH7qN2LLlHJCfDTZRILNwQNPD7mATWM0TBui7uC1pA==",
 			"license": "BSD-2-Clause"
 		},
+		"node_modules/@bramus/specificity": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+			"integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"css-tree": "^3.0.0"
+			},
+			"bin": {
+				"specificity": "bin/cli.js"
+			}
+		},
 		"node_modules/@cspotcode/source-map-support": {
 			"version": "0.8.1",
 			"resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -4715,9 +4755,9 @@
 			}
 		},
 		"node_modules/@csstools/color-helpers": {
-			"version": "5.0.2",
-			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.0.2.tgz",
-			"integrity": "sha512-JqWH1vsgdGcw2RR6VliXXdA0/59LttzlU8UlRT/iUUsEeWfYq8I+K0yhihEUTTHLRm1EXvpsCx3083EU15ecsA==",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+			"integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
 			"dev": true,
 			"funding": [
 				{
@@ -4730,16 +4770,14 @@
 				}
 			],
 			"license": "MIT-0",
-			"optional": true,
-			"peer": true,
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			}
 		},
 		"node_modules/@csstools/css-calc": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
-			"integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+			"integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
 			"dev": true,
 			"funding": [
 				{
@@ -4752,20 +4790,18 @@
 				}
 			],
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.5",
-				"@csstools/css-tokenizer": "^3.0.4"
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
 			}
 		},
 		"node_modules/@csstools/css-color-parser": {
-			"version": "3.0.10",
-			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.0.10.tgz",
-			"integrity": "sha512-TiJ5Ajr6WRd1r8HSiwJvZBiJOqtH86aHpUjq5aEKWHiII2Qfjqd/HCWKPOW8EP4vcspXbHnXrwIDlu5savQipg==",
+			"version": "4.1.9",
+			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+			"integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
 			"dev": true,
 			"funding": [
 				{
@@ -4778,24 +4814,22 @@
 				}
 			],
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"dependencies": {
-				"@csstools/color-helpers": "^5.0.2",
-				"@csstools/css-calc": "^2.1.4"
+				"@csstools/color-helpers": "^6.1.0",
+				"@csstools/css-calc": "^3.2.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			},
 			"peerDependencies": {
-				"@csstools/css-parser-algorithms": "^3.0.5",
-				"@csstools/css-tokenizer": "^3.0.4"
+				"@csstools/css-parser-algorithms": "^4.0.0",
+				"@csstools/css-tokenizer": "^4.0.0"
 			}
 		},
 		"node_modules/@csstools/css-parser-algorithms": {
-			"version": "3.0.5",
-			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
-			"integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+			"integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
 			"dev": true,
 			"funding": [
 				{
@@ -4808,19 +4842,42 @@
 				}
 			],
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			},
 			"peerDependencies": {
-				"@csstools/css-tokenizer": "^3.0.4"
+				"@csstools/css-tokenizer": "^4.0.0"
+			}
+		},
+		"node_modules/@csstools/css-syntax-patches-for-csstree": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+			"integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"license": "MIT-0",
+			"peerDependencies": {
+				"css-tree": "^3.2.1"
+			},
+			"peerDependenciesMeta": {
+				"css-tree": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@csstools/css-tokenizer": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
-			"integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+			"integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
 			"dev": true,
 			"funding": [
 				{
@@ -4833,10 +4890,8 @@
 				}
 			],
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"engines": {
-				"node": ">=18"
+				"node": ">=20.19.0"
 			}
 		},
 		"node_modules/@elastic/datemath": {
@@ -5699,6 +5754,24 @@
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			}
+		},
+		"node_modules/@exodus/bytes": {
+			"version": "1.15.1",
+			"resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+			"integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+			},
+			"peerDependencies": {
+				"@noble/hashes": "^1.8.0 || ^2.0.0"
+			},
+			"peerDependenciesMeta": {
+				"@noble/hashes": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@guardian/eslint-config": {
@@ -9225,18 +9298,6 @@
 				"node": ">=0.4.0"
 			}
 		},
-		"node_modules/agent-base": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
-			"integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -9582,6 +9643,16 @@
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/bidi-js": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+			"integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"require-from-string": "^2.0.2"
+			}
 		},
 		"node_modules/boolbase": {
 			"version": "1.0.0",
@@ -10081,6 +10152,20 @@
 				"url": "https://github.com/sponsors/fb55"
 			}
 		},
+		"node_modules/css-tree": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+			"integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"mdn-data": "2.27.1",
+				"source-map-js": "^1.2.1"
+			},
+			"engines": {
+				"node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+			}
+		},
 		"node_modules/css-what": {
 			"version": "6.2.2",
 			"resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -10100,22 +10185,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/cssstyle": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
-			"integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"@asamuzakjp/css-color": "^3.2.0",
-				"rrweb-cssom": "^0.8.0"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/csstype": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
@@ -10130,19 +10199,17 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/data-urls": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
-			"integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+			"version": "7.0.0",
+			"resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+			"integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"dependencies": {
-				"whatwg-mimetype": "^4.0.0",
-				"whatwg-url": "^14.0.0"
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/data-view-buffer": {
@@ -10240,9 +10307,7 @@
 			"resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
 			"integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
 			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/deep-eql": {
 			"version": "5.0.2",
@@ -12238,18 +12303,16 @@
 			}
 		},
 		"node_modules/html-encoding-sniffer": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
-			"integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+			"integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"dependencies": {
-				"whatwg-encoding": "^3.1.1"
+				"@exodus/bytes": "^1.6.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/html-to-text": {
@@ -12330,38 +12393,6 @@
 				"domhandler": "^5.0.3",
 				"domutils": "^3.0.1",
 				"entities": "^4.4.0"
-			}
-		},
-		"node_modules/http-proxy-agent": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
-			"integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"agent-base": "^7.1.0",
-				"debug": "^4.3.4"
-			},
-			"engines": {
-				"node": ">= 14"
-			}
-		},
-		"node_modules/https-proxy-agent": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
-			"integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"agent-base": "^7.1.2",
-				"debug": "4"
-			},
-			"engines": {
-				"node": ">= 14"
 			}
 		},
 		"node_modules/husky": {
@@ -12876,9 +12907,7 @@
 			"resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
 			"integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
 			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/is-regex": {
 			"version": "1.2.1",
@@ -13118,37 +13147,36 @@
 			}
 		},
 		"node_modules/jsdom": {
-			"version": "26.1.0",
-			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
-			"integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+			"version": "29.1.1",
+			"resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
+			"integrity": "sha512-ECi4Fi2f7BdJtUKTflYRTiaMxIB0O6zfR1fX0GXpUrf6flp8QIYn1UT20YQqdSOfk2dfkCwS8LAFoJDEppNK5Q==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"dependencies": {
-				"cssstyle": "^4.2.1",
-				"data-urls": "^5.0.0",
-				"decimal.js": "^10.5.0",
-				"html-encoding-sniffer": "^4.0.0",
-				"http-proxy-agent": "^7.0.2",
-				"https-proxy-agent": "^7.0.6",
+				"@asamuzakjp/css-color": "^5.1.11",
+				"@asamuzakjp/dom-selector": "^7.1.1",
+				"@bramus/specificity": "^2.4.2",
+				"@csstools/css-syntax-patches-for-csstree": "^1.1.3",
+				"@exodus/bytes": "^1.15.0",
+				"css-tree": "^3.2.1",
+				"data-urls": "^7.0.0",
+				"decimal.js": "^10.6.0",
+				"html-encoding-sniffer": "^6.0.0",
 				"is-potential-custom-element-name": "^1.0.1",
-				"nwsapi": "^2.2.16",
-				"parse5": "^7.2.1",
-				"rrweb-cssom": "^0.8.0",
+				"lru-cache": "^11.3.5",
+				"parse5": "^8.0.1",
 				"saxes": "^6.0.0",
 				"symbol-tree": "^3.2.4",
-				"tough-cookie": "^5.1.1",
+				"tough-cookie": "^6.0.1",
+				"undici": "^7.25.0",
 				"w3c-xmlserializer": "^5.0.0",
-				"webidl-conversions": "^7.0.0",
-				"whatwg-encoding": "^3.1.1",
-				"whatwg-mimetype": "^4.0.0",
-				"whatwg-url": "^14.1.1",
-				"ws": "^8.18.0",
+				"webidl-conversions": "^8.0.1",
+				"whatwg-mimetype": "^5.0.0",
+				"whatwg-url": "^16.0.1",
 				"xml-name-validator": "^5.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.0 || ^22.13.0 || >=24.0.0"
 			},
 			"peerDependencies": {
 				"canvas": "^3.0.0"
@@ -13157,6 +13185,16 @@
 				"canvas": {
 					"optional": true
 				}
+			}
+		},
+		"node_modules/jsdom/node_modules/lru-cache": {
+			"version": "11.5.2",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+			"integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+			"dev": true,
+			"license": "BlueOak-1.0.0",
+			"engines": {
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/jsesc": {
@@ -13512,12 +13550,6 @@
 				"tldts": "bin/cli.js"
 			}
 		},
-		"node_modules/mailauth/node_modules/tldts-core": {
-			"version": "7.0.23",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
-			"integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
-			"license": "MIT"
-		},
 		"node_modules/mailparser": {
 			"version": "3.9.12",
 			"resolved": "https://registry.npmjs.org/mailparser/-/mailparser-3.9.12.tgz",
@@ -13623,6 +13655,13 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/unified"
 			}
+		},
+		"node_modules/mdn-data": {
+			"version": "2.27.1",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+			"integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+			"dev": true,
+			"license": "CC0-1.0"
 		},
 		"node_modules/mdurl": {
 			"version": "1.0.1",
@@ -13818,15 +13857,6 @@
 			"engines": {
 				"node": "*"
 			}
-		},
-		"node_modules/nwsapi": {
-			"version": "2.2.21",
-			"resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.21.tgz",
-			"integrity": "sha512-o6nIY3qwiSXl7/LuOU0Dmuctd34Yay0yeuZRLFmDPrrdHpXKFndPj3hM+YEPVHYC5fx2otBx4Ilc/gyYSAUaIA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
 		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
@@ -14159,30 +14189,26 @@
 			}
 		},
 		"node_modules/parse5": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
-			"integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+			"integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"dependencies": {
-				"entities": "^6.0.0"
+				"entities": "^8.0.0"
 			},
 			"funding": {
 				"url": "https://github.com/inikulin/parse5?sponsor=1"
 			}
 		},
 		"node_modules/parse5/node_modules/entities": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-			"integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+			"version": "8.0.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+			"integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"optional": true,
-			"peer": true,
 			"engines": {
-				"node": ">=0.12"
+				"node": ">=20.19.0"
 			},
 			"funding": {
 				"url": "https://github.com/fb55/entities?sponsor=1"
@@ -15342,6 +15368,16 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/require-from-string": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+			"integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/requires-port": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -15426,15 +15462,6 @@
 				"@rollup/rollup-win32-x64-msvc": "4.46.2",
 				"fsevents": "~2.3.2"
 			}
-		},
-		"node_modules/rrweb-cssom": {
-			"version": "0.8.0",
-			"resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
-			"integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
 		},
 		"node_modules/run-applescript": {
 			"version": "7.1.0",
@@ -15530,8 +15557,6 @@
 			"integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
 			"dev": true,
 			"license": "ISC",
-			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"xmlchars": "^2.2.0"
 			},
@@ -16096,9 +16121,7 @@
 			"resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
 			"integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
 			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/synckit": {
 			"version": "0.11.12",
@@ -16218,57 +16241,48 @@
 			}
 		},
 		"node_modules/tldts": {
-			"version": "6.1.86",
-			"resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
-			"integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+			"version": "7.4.9",
+			"resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.9.tgz",
+			"integrity": "sha512-3kZ8wQQ/k5DrChD4X4FVvr2D7E5uoRgAqkPyLpSCGUvqOvqu+JEdr3mwMUaVWb+vMHZaKhF5fp2PBigKsui7hA==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"dependencies": {
-				"tldts-core": "^6.1.86"
+				"tldts-core": "^7.4.9"
 			},
 			"bin": {
 				"tldts": "bin/cli.js"
 			}
 		},
 		"node_modules/tldts-core": {
-			"version": "6.1.86",
-			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
-			"integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"version": "7.4.9",
+			"resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.9.tgz",
+			"integrity": "sha512-DxKfPBI52p2msTEu7MPhdpdDTBhhVQg1a/8PjQckeyAvO13eMYElX545grIp6nnTGIMZlRvFZPvFhvI/WIz2Vg==",
+			"license": "MIT"
 		},
 		"node_modules/tough-cookie": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
-			"integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+			"integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
-			"optional": true,
-			"peer": true,
 			"dependencies": {
-				"tldts": "^6.1.32"
+				"tldts": "^7.0.5"
 			},
 			"engines": {
 				"node": ">=16"
 			}
 		},
 		"node_modules/tr46": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
-			"integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+			"integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"punycode": "^2.3.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/trim-trailing-lines": {
@@ -17323,8 +17337,6 @@
 			"integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"dependencies": {
 				"xml-name-validator": "^5.0.0"
 			},
@@ -17343,15 +17355,13 @@
 			}
 		},
 		"node_modules/webidl-conversions": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
-			"integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+			"integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
-			"optional": true,
-			"peer": true,
 			"engines": {
-				"node": ">=12"
+				"node": ">=20"
 			}
 		},
 		"node_modules/webpack-virtual-modules": {
@@ -17361,47 +17371,29 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/whatwg-encoding": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-			"integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"dependencies": {
-				"iconv-lite": "0.6.3"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
 		"node_modules/whatwg-mimetype": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
-			"integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+			"integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"engines": {
-				"node": ">=18"
+				"node": ">=20"
 			}
 		},
 		"node_modules/whatwg-url": {
-			"version": "14.2.0",
-			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
-			"integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+			"version": "16.0.1",
+			"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+			"integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
 			"dev": true,
 			"license": "MIT",
-			"optional": true,
-			"peer": true,
 			"dependencies": {
-				"tr46": "^5.1.0",
-				"webidl-conversions": "^7.0.0"
+				"@exodus/bytes": "^1.11.0",
+				"tr46": "^6.0.0",
+				"webidl-conversions": "^8.0.1"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": "^20.19.0 || ^22.12.0 || >=24.0.0"
 			}
 		},
 		"node_modules/which": {
@@ -17603,8 +17595,6 @@
 			"integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"optional": true,
-			"peer": true,
 			"engines": {
 				"node": ">=18"
 			}
@@ -17629,9 +17619,7 @@
 			"resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
 			"integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
 			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"peer": true
+			"license": "MIT"
 		},
 		"node_modules/xtend": {
 			"version": "4.0.2",
@@ -17657,21 +17645,6 @@
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/yaml": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.1.tgz",
-			"integrity": "sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			}
 		},
 		"node_modules/yargs": {
 			"version": "17.7.2",
@@ -17804,10 +17777,6 @@
 			"dependencies": {
 				"newswires-shared": "*"
 			}
-		},
-		"reingestion-lambda": {
-			"version": "1.0.0",
-			"extraneous": true
 		},
 		"shared": {
 			"name": "newswires-shared",


### PR DESCRIPTION
our vitest config requires jsdom, but its not an explicit dependency so gets lost on an npm i

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD