### PR TITLE
Add tagging for potential obituary-related phrases

### DIFF
--- a/ingestion-lambda/src/categoryCodes.test.ts
+++ b/ingestion-lambda/src/categoryCodes.test.ts
@@ -1,6 +1,7 @@
 import {
 	inferGBCategoryFromText,
 	inferGeographicalCategoriesFromText,
+	inferObituaryCategoryFromText,
 	processFingerpostAAPCategoryCodes,
 	processFingerpostAFPCategoryCodes,
 	processFingerpostAPCategoryCodes,
@@ -390,6 +391,34 @@ describe('processCategoryCodes', () => {
 				bodyText: content,
 			}),
 		).toEqual([]);
+	});
+});
+
+describe('inferObituaryCategoryFromText', () => {
+	it('should return an empty array when no content is provided', () => {
+		expect(inferObituaryCategoryFromText(undefined)).toEqual([]);
+		expect(inferObituaryCategoryFromText('')).toEqual([]);
+	});
+
+	it.each([
+		'A has died at the age of 82.',
+		'B died at age 95, family confirms.',
+		'C died aged 67 after',
+		'D dies at age 88 in Los Angeles.',
+		'E dies aged 79.',
+	])('should return gu:obits when the text contains "%s"', (content) => {
+		expect(inferObituaryCategoryFromText(content)).toEqual(['gu:obits']);
+	});
+
+	it('should be case-insensitive', () => {
+		expect(inferObituaryCategoryFromText('X HAS DIED SUDDENLY.')).toEqual([
+			'gu:obits',
+		]);
+	});
+
+	it('should return an empty array when no obituary phrase is present', () => {
+		const content = 'The quick brown fox jumped over the lazy dog.';
+		expect(inferObituaryCategoryFromText(content)).toEqual([]);
 	});
 });
 

--- a/ingestion-lambda/src/categoryCodes.ts
+++ b/ingestion-lambda/src/categoryCodes.ts
@@ -243,6 +243,19 @@ export function inferGBCategoryFromText(content: string | undefined): string[] {
 	); /** @todo we should be able to remove the type predicate after we upgrade TS to 5.6 */
 }
 
+export function inferObituaryCategoryFromText(
+	content: string | undefined,
+): string[] {
+	if (!content) {
+		return [];
+	}
+
+	const hasObituaryPhrase =
+		/has died|died at age|died aged|dies at age|dies aged/i.test(content);
+
+	return hasObituaryPhrase ? ['gu:obits'] : [];
+}
+
 export function inferGeographicalCategoriesFromText(
 	content: string | undefined,
 ): string[] {

--- a/ingestion-lambda/src/categoryCodes.ts
+++ b/ingestion-lambda/src/categoryCodes.ts
@@ -243,6 +243,9 @@ export function inferGBCategoryFromText(content: string | undefined): string[] {
 	); /** @todo we should be able to remove the type predicate after we upgrade TS to 5.6 */
 }
 
+const obituaryPhrasesRexExp =
+	/has died|died at age|died aged|dies at age|dies aged/i;
+
 export function inferObituaryCategoryFromText(
 	content: string | undefined,
 ): string[] {
@@ -250,8 +253,7 @@ export function inferObituaryCategoryFromText(
 		return [];
 	}
 
-	const hasObituaryPhrase =
-		/has died|died at age|died aged|dies at age|dies aged/i.test(content);
+	const hasObituaryPhrase = obituaryPhrasesRexExp.test(content);
 
 	return hasObituaryPhrase ? ['gu:obits'] : [];
 }

--- a/ingestion-lambda/src/processContentObject.ts
+++ b/ingestion-lambda/src/processContentObject.ts
@@ -10,6 +10,7 @@ import {
 	dedupeStrings,
 	inferGBCategoryFromText,
 	inferGeographicalCategoriesFromText,
+	inferObituaryCategoryFromText,
 	processFingerpostAAPCategoryCodes,
 	processFingerpostAFPCategoryCodes,
 	processFingerpostAPCategoryCodes,
@@ -81,6 +82,7 @@ export function processCategoryCodes({
 }) {
 	const catCodes: string[] = priority === '1' ? ['HIGH_PRIORITY'] : [];
 	const regionCodes = inferGeographicalCategoriesFromText(bodyText);
+	const obituaryCodes = inferObituaryCategoryFromText(bodyText);
 
 	switch (supplier) {
 		case 'REUTERS': {
@@ -92,6 +94,7 @@ export function processCategoryCodes({
 				...extractedDestinationCodes,
 				...processReutersTopicCodes(subjectCodes, extractedDestinationCodes),
 				...regionCodes,
+				...obituaryCodes,
 				...remapReutersCountryCodes(subjectCodes),
 			];
 		}
@@ -100,29 +103,34 @@ export function processCategoryCodes({
 				...catCodes,
 				...processFingerpostAPCategoryCodes(subjectCodes),
 				...regionCodes,
+				...obituaryCodes,
 			];
 		case 'AAP':
 			return [
 				...catCodes,
 				...processFingerpostAAPCategoryCodes(subjectCodes),
 				...regionCodes,
+				...obituaryCodes,
 			];
 		case 'AFP':
 			return [
 				...catCodes,
 				...processFingerpostAFPCategoryCodes(subjectCodes, maybeHeadline),
 				...regionCodes,
+				...obituaryCodes,
 			];
 		case 'PA':
 			return [
 				...catCodes,
 				...processFingerpostPACategoryCodes(subjectCodes, maybeMediaCatCode),
+				...obituaryCodes,
 			];
 		case 'MINOR_AGENCIES': {
 			const updatedSubjectCodes = [
 				...subjectCodes,
 				...catCodes,
 				...regionCodes,
+				...obituaryCodes,
 				...inferGBCategoryFromText(bodyText),
 			];
 			return updatedSubjectCodes.filter((_) => _.length > 0);
@@ -132,6 +140,7 @@ export function processCategoryCodes({
 				...catCodes,
 				...processUnknownFingerpostCategoryCodes(subjectCodes, supplier),
 				...regionCodes,
+				...obituaryCodes,
 			];
 	}
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds a `gu:obits` category code to stories on ingestion, based on matching against some phrases that are commonly used when announcing obituaries.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

- [x] Deploy to CODE, check that the tag is being applied sensibly
- [x] Leave the branch up for a few days and confirm that it's not making a noticeable difference to ingestion latency:

<img width="1246" height="384" alt="image" src="https://github.com/user-attachments/assets/143e4cf8-d9f9-4a61-bc6b-fa7f66b62964" />


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->


## Introducing DB migrations?

Database migrations need to be applied manually before releasing. The docs can be found in db/README.md 
- [ ] Database migrations have been applied for CODE
- [ ] Database migrations have been applied for PROD