### PR TITLE
Add strictPort to vite config

### DIFF
--- a/newswires/client/vite.config.ts
+++ b/newswires/client/vite.config.ts
@@ -26,6 +26,7 @@ export default defineConfig(({ mode }) => ({
 	base: '/assets',
 	server: {
 		origin: 'https://newswires.local.dev-gutools.co.uk',
+		strictPort: true,
 		hmr: {
 			protocol: 'wss',
 			host: 'hmr.newswires.local.dev-gutools.co.uk',


### PR DESCRIPTION
## What does this change?

I was running `newswires` locally with port 5173 already occupied in the background, as a result I was served a blank page when going to https://newswires.local.dev-gutools.co.uk.

Port 5173 is required for nginx-mapping.yaml. `strictPort` makes a duplicate/stray instance fail loudly instead of silently binding to a different port.

