### PR TITLE
Fix search empty state layout

### DIFF
--- a/newswires/client/src/Feed.tsx
+++ b/newswires/client/src/Feed.tsx
@@ -147,7 +147,7 @@ export const Feed = ({ containerRef, setSideNavIsOpen }: FeedProps) => {
 			)}
 			{(status == 'success' || status == 'offline') &&
 				queryData.results.length === 0 && (
-					<>
+					<EuiFlexGroup direction="column">
 						<EuiFlexGroup>
 							<EuiFlexItem style={{ flex: 1 }}></EuiFlexItem>
 							<EuiFlexItem grow={false}>
@@ -155,10 +155,22 @@ export const Feed = ({ containerRef, setSideNavIsOpen }: FeedProps) => {
 							</EuiFlexItem>
 						</EuiFlexGroup>
 						<EuiEmptyPrompt
+							css={css`
+								h2 {
+									font-size: 1.5rem;
+									margin-block: 0.5rem !important;
+								}
+							`}
 							body={
 								<>
 									<SearchSummary setSideNavIsOpen={setSideNavIsOpen} />
-									<p>Try another search or reset filters.</p>
+									<p
+										css={css`
+											padding-top: 20px;
+										`}
+									>
+										Try another search or reset filters.
+									</p>
 								</>
 							}
 							color="subdued"
@@ -166,7 +178,7 @@ export const Feed = ({ containerRef, setSideNavIsOpen }: FeedProps) => {
 							title={<h2>No results match your search criteria</h2>}
 							titleSize="s"
 						/>
-					</>
+					</EuiFlexGroup>
 				)}
 			{(status == 'success' || status == 'offline') &&
 				queryData.results.length > 0 && (

--- a/newswires/client/src/Feed.tsx
+++ b/newswires/client/src/Feed.tsx
@@ -4,6 +4,8 @@ import {
 	EuiFlexItem,
 	EuiLoadingLogo,
 	EuiPageTemplate,
+	EuiText,
+	useEuiTheme,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useEffect, useMemo, useState } from 'react';
@@ -66,6 +68,8 @@ function decideSortFunction(sortBy: SortBy): WireSortingFunction {
 }
 
 export const Feed = ({ containerRef, setSideNavIsOpen }: FeedProps) => {
+	const { euiTheme } = useEuiTheme();
+
 	const { state, config } = useSearch();
 	const { status, queryData } = state;
 
@@ -154,30 +158,25 @@ export const Feed = ({ containerRef, setSideNavIsOpen }: FeedProps) => {
 								<DatePicker />
 							</EuiFlexItem>
 						</EuiFlexGroup>
-						<EuiEmptyPrompt
+						<EuiFlexGroup
+							direction="column"
+							justifyContent="center"
 							css={css`
-								h2 {
-									font-size: 1.5rem;
-									margin-block: 0.5rem !important;
-								}
+								background-color: ${euiTheme.colors.backgroundBaseSubdued};
+								border-radius: ${euiTheme.border.radius.medium};
+								padding: ${euiTheme.size.l};
+								max-width: 580px;
+								align-self: center;
 							`}
-							body={
-								<>
-									<SearchSummary setSideNavIsOpen={setSideNavIsOpen} />
-									<p
-										css={css`
-											padding-top: 20px;
-										`}
-									>
-										Try another search or reset filters.
-									</p>
-								</>
-							}
-							color="subdued"
-							layout="horizontal"
-							title={<h2>No results match your search criteria</h2>}
-							titleSize="s"
-						/>
+						>
+							<EuiText size="s">
+								<h2>No results match your search criteria</h2>
+							</EuiText>
+							<SearchSummary setSideNavIsOpen={setSideNavIsOpen} />
+							<EuiText color="subdued" component="p">
+								Try another search or reset filters.
+							</EuiText>
+						</EuiFlexGroup>
 					</EuiFlexGroup>
 				)}
 			{(status == 'success' || status == 'offline') &&


### PR DESCRIPTION
## What does this change?

Search empty state is looking a bit broken at the moment. This PR fixes it (via some brute-force CSS overrides, lol)




## Images

### Before:
<img width="809" height="388" alt="Screenshot 2026-07-23 at 17 36 21" src="https://github.com/user-attachments/assets/bb2f7a69-a36e-4555-a81e-211f03478451" />

### After:
<img width="958" height="385" alt="Screenshot 2026-07-23 at 17 36 31" src="https://github.com/user-attachments/assets/09d2aff2-2f0e-40bd-81f7-24500436062b" />
